### PR TITLE
[codex] restore desktop responsiveness during live thread streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # Local editor and tool state
 .claude/
+CLAUDE.md
 .omx/
 .env*.local
 

--- a/desktop/src/renderer/components/thread-view/thread-entry-list.tsx
+++ b/desktop/src/renderer/components/thread-view/thread-entry-list.tsx
@@ -130,7 +130,11 @@ function renderThreadEntry(entry: DesktopThreadEntry, workspaceRoot: string | nu
   if (entry.kind === "assistant") {
     return (
       <article className="mr-auto w-full px-4 py-2" key={entry.id}>
-        <ThreadMarkdown workspaceRoot={workspaceRoot}>{entryBody}</ThreadMarkdown>
+        {"status" in entry && entry.status === "streaming" ? (
+          <div className="text-sm leading-[1.6] whitespace-pre-wrap text-ink">{entryBody}</div>
+        ) : (
+          <ThreadMarkdown workspaceRoot={workspaceRoot}>{entryBody}</ThreadMarkdown>
+        )}
         {entryBody.trim() ? (
           <div className="mt-1 flex items-center justify-start">
             <EntryCopyButton text={entryBody} />

--- a/desktop/src/renderer/features/app/use-authenticated-desktop-content.ts
+++ b/desktop/src/renderer/features/app/use-authenticated-desktop-content.ts
@@ -62,7 +62,6 @@ export function useAuthenticatedDesktopContent({
     activeWorkspaceRoot,
     isSignedIn: sessionState.isSignedIn,
     selectedProfileId: sessionState.selectedProfileId,
-    selectedThreadId: sessionState.selectedThreadId,
   });
 
   const trimmedSearchQuery = ui.searchQuery.trim();

--- a/desktop/src/renderer/features/workspace/use-workspace-activity.ts
+++ b/desktop/src/renderer/features/workspace/use-workspace-activity.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import type {
   DesktopWorkspaceHydrateResult,
@@ -32,6 +32,14 @@ export function useWorkspaceActivity({
   const [persistedSessionActivityLoading, setPersistedSessionActivityLoading] = useState(false);
   const [workspaceStructureRefreshing, setWorkspaceStructureRefreshing] = useState(false);
   const activityRequestIdRef = useRef(0);
+  const selectedWorkspaceSession = useMemo(
+    () => (
+      selectedThreadId
+        ? workspaceSessions.find((session) => session.codex_thread_id === selectedThreadId) ?? null
+        : null
+    ),
+    [selectedThreadId, workspaceSessions],
+  );
 
   function extractWrittenPath(event: SubstrateEventRecord): string | null {
     if (event.verb !== "file.write") {
@@ -72,14 +80,13 @@ export function useWorkspaceActivity({
 
     void (async () => {
       try {
-        const projectedSession = workspaceSessions.find((session) => session.codex_thread_id === selectedThreadId) ?? null;
-        const recentSessionsResult = projectedSession
+        const recentSessionsResult = selectedWorkspaceSession
           ? null
           : await bridge.substrate.recentSessions({ limit: 200 });
         const fallbackSession = Array.isArray(recentSessionsResult?.sessions)
           ? recentSessionsResult.sessions.find((session: { codex_thread_id?: string | null }) => session.codex_thread_id === selectedThreadId) ?? null
           : null;
-        const session = projectedSession ?? fallbackSession;
+        const session = selectedWorkspaceSession ?? fallbackSession;
         const sessionId = resolveSessionId(session);
         if (!sessionId || requestId !== activityRequestIdRef.current || !isActive) {
           if (isActive) {
@@ -144,7 +151,7 @@ export function useWorkspaceActivity({
     return () => {
       isActive = false;
     };
-  }, [selectedThreadId, workspaceSessions]);
+  }, [selectedThreadId, selectedWorkspaceSession]);
 
   useEffect(() => {
     const rootPath = selectedThreadWorkspaceRoot;

--- a/desktop/src/renderer/features/workspace/use-workspace-collections.ts
+++ b/desktop/src/renderer/features/workspace/use-workspace-collections.ts
@@ -25,12 +25,10 @@ export function useWorkspaceCollections({
   activeWorkspaceRoot,
   isSignedIn,
   selectedProfileId,
-  selectedThreadId,
 }: {
   activeWorkspaceRoot: string | null;
   isSignedIn: boolean;
   selectedProfileId: string;
-  selectedThreadId: string | null;
 }): WorkspaceCollectionsResult {
   const [projectedWorkspaces, setProjectedWorkspaces] = useState<ProjectedWorkspaceRecord[]>([]);
   const [knownWorkspaces, setKnownWorkspaces] = useState<SubstrateWorkspaceRecord[]>([]);
@@ -148,7 +146,7 @@ export function useWorkspaceCollections({
     return () => {
       isActive = false;
     };
-  }, [activeWorkspaceRoot, isSignedIn, selectedProfileId, selectedThreadId]);
+  }, [activeWorkspaceRoot, isSignedIn, selectedProfileId]);
 
   return {
     activeWorkspaceProjection,

--- a/desktop/src/renderer/state/session/session-stream-delta.test.js
+++ b/desktop/src/renderer/state/session/session-stream-delta.test.js
@@ -153,3 +153,41 @@ test("applyThreadDelta appends streaming entry text without bumping recency meta
   assert.equal(thread.updatedAt, "2026-04-08T10:00:00.000Z");
   assert.equal(thread.updatedLabel, "10 min ago");
 });
+
+test("applyThreadDelta keeps thread ordering stable for streaming entry appends", () => {
+  const harness = createDeps([
+    createThread({
+      id: "thread-1",
+      title: "Older running thread",
+      updatedAt: "2026-04-08T10:00:00.000Z",
+      entries: [
+        {
+          id: "entry-1",
+          kind: "assistant",
+          title: "Sense-1 activity",
+          body: "Hello",
+          status: "streaming",
+        },
+      ],
+    }),
+    createThread({
+      id: "thread-2",
+      title: "Newer idle thread",
+      updatedAt: "2026-04-08T11:00:00.000Z",
+    }),
+  ]);
+
+  applyThreadDelta(
+    {
+      kind: "entryDelta",
+      threadId: "thread-1",
+      entryId: "entry-1",
+      append: " world",
+    },
+    harness.deps,
+  );
+
+  const { threads } = harness.getState();
+  assert.deepEqual(threads.map((thread) => thread.id), ["thread-1", "thread-2"]);
+  assert.equal(threads[0].entries[0]?.body, "Hello world");
+});

--- a/desktop/src/renderer/state/session/session-stream-delta.ts
+++ b/desktop/src/renderer/state/session/session-stream-delta.ts
@@ -16,6 +16,26 @@ type ApplyThreadDeltaDeps = {
   threadDeltaBufferRef: MutableRefObject<ThreadDeltaBuffer>;
 };
 
+function replaceThreadWithoutReordering(
+  threads: ThreadRecord[],
+  threadId: string,
+  buildNextThread: (thread: ThreadRecord) => ThreadRecord,
+): ThreadRecord[] {
+  const threadIndex = threads.findIndex((thread) => thread.id === threadId);
+  if (threadIndex === -1) {
+    return threads;
+  }
+
+  const nextThread = buildNextThread(threads[threadIndex]);
+  if (nextThread === threads[threadIndex]) {
+    return threads;
+  }
+
+  const nextThreads = [...threads];
+  nextThreads[threadIndex] = nextThread;
+  return nextThreads;
+}
+
 export function applyThreadDelta(
   delta: DesktopThreadDelta,
   deps: ApplyThreadDeltaDeps,
@@ -73,31 +93,29 @@ export function applyThreadDelta(
 
   if (delta.kind === "entryDelta") {
     deps.setThreads((current) => {
-      const thread = current.find((t) => t.id === delta.threadId);
-      if (!thread) {
-        return current;
-      }
-      const entries = thread.entries.map((entry) => {
-        if (entry.id !== delta.entryId) {
+      return replaceThreadWithoutReordering(current, delta.threadId, (thread) => {
+        const entries = thread.entries.map((entry) => {
+          if (entry.id !== delta.entryId) {
+            return entry;
+          }
+          if ("body" in entry) {
+            return { ...entry, body: entry.body + delta.append };
+          }
           return entry;
-        }
-        if ("body" in entry) {
-          return { ...entry, body: entry.body + delta.append };
-        }
-        return entry;
-      });
-      if (!entries.some((e) => e.id === delta.entryId)) {
-        entries.push({
-          id: delta.entryId,
-          kind: "assistant" as const,
-          title: "Sense-1 activity",
-          body: delta.append,
-          status: "streaming",
         });
-      }
-      return upsertThread(current, {
-        ...thread,
-        entries,
+        if (!entries.some((entry) => entry.id === delta.entryId)) {
+          entries.push({
+            id: delta.entryId,
+            kind: "assistant" as const,
+            title: "Sense-1 activity",
+            body: delta.append,
+            status: "streaming",
+          });
+        }
+        return {
+          ...thread,
+          entries,
+        };
       });
     });
     return;


### PR DESCRIPTION
## Summary

This fixes a desktop responsiveness regression that showed up once a thread started streaming. After the first live response, the app could become visibly laggy: scrolling stuttered, button clicks felt delayed, and the composer stopped feeling immediate.

The main issue was renderer churn during live streaming. Each `entryDelta` append was rebuilding thread state through the normal upsert path, which re-sorted the thread list and propagated extra work back through shell-level surfaces. At the same time, the actively streaming assistant row was repeatedly re-running full markdown parsing and syntax highlighting as the response body grew.

## What changed

The fix keeps append-only stream updates local and cheap:

- stream appends now update the existing thread in place instead of reordering the thread list on every chunk
- streaming assistant entries render as lightweight plain text until completion, then fall back to normal markdown rendering once the final entry arrives
- workspace collection fetches no longer refire on every selected-thread change when the actual workspace context has not changed
- workspace activity lookup now reuses the selected projected session instead of re-scanning and re-fetching more often than needed
- a regression test now locks in stable thread ordering for streaming entry appends

## Tradeoffs

Streaming assistant content is intentionally rendered without rich markdown treatment while the response is still in progress. That keeps the live path fast and avoids reparsing a growing markdown document on every token/chunk. Once the message completes, the normal markdown renderer is used again.

I did not bundle a runtime-root migration into this patch. The macOS profile-root chooser still prefers the root that currently owns the active profile, and changing that in the same fix would have mixed a data-migration concern into a responsiveness regression patch.

## Validation

I verified the patch with:

- `pnpm typecheck`
- `pnpm test:unit`
- `pnpm build`
- `pnpm qa:electron:smoke`

`pnpm check` still reports pre-existing strict structure warnings in unrelated oversized files and was not made worse by this change.
