### PR TITLE
[codex] Restore durable workspace and thread continuity

### DIFF
--- a/desktop/src/main/session/desktop-run-start-service.ts
+++ b/desktop/src/main/session/desktop-run-start-service.ts
@@ -41,6 +41,7 @@ import {
 import {
   writeSessionRecord,
 } from "./session-record.ts";
+import { buildRuntimeContinuityInstruction } from "./workspace-thread-continuity.ts";
 import {
   getSession as querySession,
 } from "../substrate/substrate-reader.js";
@@ -482,7 +483,16 @@ export class DesktopRunStartService {
         await fs.mkdir(effectiveCwd, { recursive: true });
       }
       const resolvedRuntimeInstructions = mergeRuntimeInstructions(
-        baseRuntimeInstructions,
+        mergeRuntimeInstructions(
+          baseRuntimeInstructions,
+          await buildRuntimeContinuityInstruction({
+            artifactRoot: profileArtifactRoot,
+            currentSessionId: existingSession?.id ?? pendingSessionId,
+            dbPath: substrateDbPath,
+            profileId: profile.id,
+            workspaceRoot: effectiveWorkspaceRoot,
+          }),
+        ),
         buildProfileExtensionRuntimeInstruction({
           inputItems,
           profileCodexHome: resolveProfileCodexHome(profile.id, this.#env),

--- a/desktop/src/main/session/session-controller.test.js
+++ b/desktop/src/main/session/session-controller.test.js
@@ -6,7 +6,7 @@ import fs from "node:fs/promises";
 import { DatabaseSync } from "node:sqlite";
 
 import { DesktopSessionController } from "../session-controller.ts";
-import { readSessionRecord } from "./session-record.ts";
+import { readSessionRecord, writeSessionRecord } from "./session-record.ts";
 import {
   DEFAULT_PROFILE_ID,
   ensureProfileDirectories,
@@ -36,6 +36,7 @@ import {
   getSubstrateSessionByThreadId,
   loadWorkspacePolicy,
   resolveDefaultScopeId,
+  resolvePrimaryActorId,
   upsertWorkspacePolicy,
   upsertSubstrateActor,
 } from "../substrate/substrate.js";
@@ -1527,6 +1528,121 @@ test("runDesktopTask applies persisted workspace policy defaults to the runtime 
     networkAccess: true,
     writableRoots: [await fs.realpath(workspaceRoot)],
   });
+});
+
+test("runDesktopTask adds durable workspace continuity instructions from prior session records", async () => {
+  const root = await makeTempRoot();
+  const env = createTestEnv(root);
+  const managerCalls = [];
+  const manager = {
+    request: async (method, params) => {
+      managerCalls.push({ method, params });
+      if (method === "account/read") {
+        return {
+          account: {
+            email: "george@example.com",
+          },
+        };
+      }
+
+      if (method === "thread/start") {
+        return {
+          thread: {
+            id: "thread-continuity-1",
+            name: "Continuity thread",
+            preview: "Continuity thread",
+            updatedAt: Math.floor(Date.now() / 1000),
+            status: {
+              type: "active",
+              activeFlags: ["running"],
+            },
+          },
+        };
+      }
+
+      if (method === "turn/start") {
+        return {
+          turn: {
+            id: "turn-continuity-1",
+          },
+        };
+      }
+
+      throw new Error(`Unexpected method: ${method}`);
+    },
+    handleProfileChange: async () => {},
+    off: () => {},
+    on: () => {},
+    respond: () => {},
+  };
+
+  const controller = new DesktopSessionController(manager, {
+    appStartedAt: "2026-03-24T10:00:00.000Z",
+    env,
+    openExternal: async () => {},
+    runtimeInfo: {
+      appVersion: "0.1.0",
+      electronVersion: "35.2.1",
+      platform: "darwin",
+      startedAt: "2026-03-24T10:00:00.000Z",
+    },
+  });
+
+  const workspaceRoot = path.join(root, "workspace-continuity");
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  await grantWorkspaceReadPermission(env, workspaceRoot);
+
+  const dbPath = resolveProfileSubstrateDbPath(CANONICAL_PROFILE_ID, env);
+  const artifactRoot = await resolveProfileArtifactRoot(CANONICAL_PROFILE_ID, env);
+  const scopeId = resolveDefaultScopeId(CANONICAL_PROFILE_ID);
+  const actorId = resolvePrimaryActorId(CANONICAL_PROFILE_ID);
+  const previousSession = await createSubstrateSessionShell({
+    actorId,
+    dbPath,
+    model: "gpt-5.4-mini",
+    now: "2026-04-11T09:00:00Z",
+    profileId: CANONICAL_PROFILE_ID,
+    scopeId,
+    title: "Review workspace continuity",
+    workspaceRoot,
+  });
+  await finalizeSubstrateSessionStart({
+    actorId,
+    codexThreadId: "thread-previous-continuity",
+    dbPath,
+    effort: "medium",
+    model: "gpt-5.4-mini",
+    now: "2026-04-11T09:10:00Z",
+    profileId: CANONICAL_PROFILE_ID,
+    scopeId,
+    sessionId: previousSession.sessionId,
+    threadTitle: "Review workspace continuity",
+    workspaceRoot,
+  });
+  await writeSessionRecord({
+    artifactRoot,
+    intent: "Review workspace continuity",
+    outcomes: ["Recovered context from substrate history"],
+    pathsWritten: [path.join(workspaceRoot, "docs", "continuity.md")],
+    sessionId: previousSession.sessionId,
+    startedAt: "2026-04-11T09:00:00Z",
+    workspaceRoot,
+  });
+
+  const result = await controller.runDesktopTask({
+    prompt: "What were we working on in this workspace?",
+    workspaceRoot,
+  });
+
+  assert.equal(result.threadId, "thread-continuity-1");
+  const threadStart = managerCalls.find((entry) => entry.method === "thread/start");
+  const developerInstructions =
+    threadStart?.params.developerInstructions
+    ?? threadStart?.params.config?.developer_instructions
+    ?? "";
+  assert.match(developerInstructions, /Workspace continuity is available from 1 recent durable session record for this folder\./);
+  assert.match(developerInstructions, /Recovered context from substrate history/);
+  assert.match(developerInstructions, /docs\/continuity\.md/);
 });
 
 test("runDesktopTask forwards selected attachment paths through the session controller", async () => {

--- a/desktop/src/main/session/session-record.ts
+++ b/desktop/src/main/session/session-record.ts
@@ -61,6 +61,11 @@ interface ReadSessionRecordOptions {
   sessionId: string;
 }
 
+interface ReadSessionSummaryOptions {
+  artifactRoot: string;
+  sessionId: string;
+}
+
 interface UpdateSessionRecordPathsWrittenOptions {
   artifactRoot: string;
   path: string;
@@ -163,6 +168,21 @@ export async function readSessionRecord({
     const raw = await fs.readFile(sessionRecordPath, "utf8");
     const parsed = JSON.parse(raw) as SessionRecordInput;
     return buildSessionRecord(parsed);
+  } catch {
+    return null;
+  }
+}
+
+export async function readSessionSummary({
+  artifactRoot,
+  sessionId,
+}: ReadSessionSummaryOptions): Promise<string | null> {
+  const { summaryPath } = resolveSessionRecordPaths(artifactRoot, sessionId);
+
+  try {
+    const raw = await fs.readFile(summaryPath, "utf8");
+    const trimmed = raw.trim();
+    return trimmed || null;
   } catch {
     return null;
   }

--- a/desktop/src/main/session/workspace-thread-continuity.test.js
+++ b/desktop/src/main/session/workspace-thread-continuity.test.js
@@ -1,0 +1,111 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs/promises";
+import { DatabaseSync } from "node:sqlite";
+
+import { ensureProfileDirectories, resolveProfileArtifactRoot, resolveProfileSubstrateDbPath } from "../profile/profile-state.js";
+import { ensureProfileSubstrate, resolveDefaultScopeId, resolvePrimaryActorId } from "../substrate/substrate.js";
+import { writeSessionRecord } from "./session-record.ts";
+import { buildRuntimeContinuityInstruction } from "./workspace-thread-continuity.ts";
+
+function createTestEnv(runtimeRoot) {
+  return {
+    ...process.env,
+    SENSE1_ARTIFACT_ROOT: path.join(runtimeRoot, "visible-artifacts"),
+    SENSE1_RUNTIME_STATE_ROOT: runtimeRoot,
+  };
+}
+
+test("buildRuntimeContinuityInstruction includes thread and workspace continuity from durable records", async () => {
+  const runtimeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-runtime-continuity-test-"));
+  const env = createTestEnv(runtimeRoot);
+  const { profileId } = await ensureProfileDirectories("ops-team", env);
+  const dbPath = resolveProfileSubstrateDbPath(profileId, env);
+  const scopeId = resolveDefaultScopeId(profileId);
+  const actorId = resolvePrimaryActorId(profileId);
+  const artifactRoot = await resolveProfileArtifactRoot(profileId, env);
+  const workspaceRoot = path.join(runtimeRoot, "workspace-alpha");
+
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  await ensureProfileSubstrate({
+    actorEmail: "george@example.com",
+    dbPath,
+    profileId,
+  });
+
+  const db = new DatabaseSync(dbPath);
+  db.prepare(
+    `INSERT INTO sessions (id, profile_id, scope_id, actor_id, codex_thread_id, workspace_id, title, model, effort, status, started_at, ended_at, summary, metadata)
+     VALUES (?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    "sess_current",
+    profileId,
+    scopeId,
+    actorId,
+    "thread-current",
+    "Current thread",
+    "gpt-5.4",
+    "high",
+    "active",
+    "2026-04-12T10:00:00Z",
+    null,
+    null,
+    JSON.stringify({ workspaceRoot }),
+  );
+  db.prepare(
+    `INSERT INTO sessions (id, profile_id, scope_id, actor_id, codex_thread_id, workspace_id, title, model, effort, status, started_at, ended_at, summary, metadata)
+     VALUES (?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    "sess_previous",
+    profileId,
+    scopeId,
+    actorId,
+    "thread-previous",
+    "Workspace follow-up",
+    "gpt-5.4-mini",
+    "medium",
+    "completed",
+    "2026-04-11T09:00:00Z",
+    "2026-04-11T09:30:00Z",
+    "Summarized workspace continuity.",
+    JSON.stringify({ workspaceRoot }),
+  );
+  db.close();
+
+  await writeSessionRecord({
+    artifactRoot,
+    intent: "Continue the current thread",
+    outcomes: ["Thread state restored", "Audit trail still intact"],
+    pathsWritten: [path.join(workspaceRoot, "notes", "current.txt")],
+    sessionId: "sess_current",
+    startedAt: "2026-04-12T10:00:00Z",
+    workspaceRoot,
+  });
+  await writeSessionRecord({
+    artifactRoot,
+    intent: "Review workspace history",
+    outcomes: ["Recovered context from substrate history"],
+    pathsWritten: [path.join(workspaceRoot, "docs", "continuity.md")],
+    sessionId: "sess_previous",
+    startedAt: "2026-04-11T09:00:00Z",
+    workspaceRoot,
+  });
+
+  const instruction = await buildRuntimeContinuityInstruction({
+    artifactRoot,
+    currentSessionId: "sess_current",
+    dbPath,
+    profileId,
+    workspaceRoot,
+  });
+
+  assert.ok(instruction);
+  assert.match(instruction ?? "", /Thread continuity is available from the durable session record for this thread\./);
+  assert.match(instruction ?? "", /Thread state restored; Audit trail still intact/);
+  assert.match(instruction ?? "", /Workspace continuity is available from 1 recent durable session record for this folder\./);
+  assert.match(instruction ?? "", /Recovered context from substrate history/);
+  assert.match(instruction ?? "", /docs\/continuity\.md/);
+  assert.doesNotMatch(instruction ?? "", /Current thread/);
+});

--- a/desktop/src/main/session/workspace-thread-continuity.ts
+++ b/desktop/src/main/session/workspace-thread-continuity.ts
@@ -1,0 +1,305 @@
+import path from "node:path";
+
+import { listRecentSessions } from "../substrate/substrate-reader.js";
+import { readSessionRecord, readSessionSummary } from "./session-record.ts";
+
+type ContinuitySession = {
+  id: string;
+  codex_thread_id: string | null;
+  title: string | null;
+  summary: string | null;
+  started_at: string;
+  metadata: Record<string, unknown>;
+};
+
+interface BuildRuntimeContinuityInstructionOptions {
+  artifactRoot: string;
+  currentSessionId?: string | null;
+  dbPath: string;
+  profileId: string;
+  workspaceRoot?: string | null;
+}
+
+interface SessionContinuityDetails {
+  displayTitle: string | null;
+  summary: string | null;
+  timestamp: string | null;
+  writtenPaths: string[];
+}
+
+function firstString(...values: Array<unknown>): string | null {
+  for (const value of values) {
+    if (typeof value !== "string") {
+      continue;
+    }
+
+    const trimmed = value.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  return null;
+}
+
+function normalizeWorkspaceRoot(rootPath: string | null | undefined): string | null {
+  const resolvedRootPath = firstString(rootPath);
+  if (!resolvedRootPath) {
+    return null;
+  }
+
+  return path.resolve(resolvedRootPath);
+}
+
+function formatTimestamp(value: string | null): string | null {
+  const resolvedValue = firstString(value);
+  if (!resolvedValue) {
+    return null;
+  }
+
+  const parsed = Date.parse(resolvedValue);
+  if (Number.isNaN(parsed)) {
+    return resolvedValue;
+  }
+
+  return new Date(parsed).toISOString().slice(0, 10);
+}
+
+function collapseWhitespace(value: string | null | undefined): string | null {
+  const resolvedValue = firstString(value);
+  if (!resolvedValue) {
+    return null;
+  }
+
+  return resolvedValue.replace(/\s+/g, " ").trim() || null;
+}
+
+function truncateText(value: string | null, maxLength = 180): string | null {
+  const resolvedValue = collapseWhitespace(value);
+  if (!resolvedValue) {
+    return null;
+  }
+
+  if (resolvedValue.length <= maxLength) {
+    return resolvedValue;
+  }
+
+  return `${resolvedValue.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function extractMarkdownOutcomes(summary: string | null): string[] {
+  const resolvedSummary = firstString(summary);
+  if (!resolvedSummary) {
+    return [];
+  }
+
+  const match = resolvedSummary.match(/## Outcomes\s+([\s\S]*?)(?:\n## |\s*$)/i);
+  if (!match?.[1]) {
+    return [];
+  }
+
+  return match[1]
+    .split("\n")
+    .map((line) => line.replace(/^\s*-\s*/, "").trim())
+    .filter(Boolean);
+}
+
+function summarizeWrittenPaths(paths: string[], workspaceRoot: string | null): string[] {
+  const resolvedWorkspaceRoot = normalizeWorkspaceRoot(workspaceRoot);
+  return paths
+    .slice(0, 3)
+    .map((entry) => {
+      const resolvedEntry = firstString(entry);
+      if (!resolvedEntry) {
+        return null;
+      }
+      if (!resolvedWorkspaceRoot) {
+        return path.basename(resolvedEntry);
+      }
+
+      const relativePath = path.relative(resolvedWorkspaceRoot, path.resolve(resolvedEntry)).replace(/\\/g, "/");
+      if (!relativePath || relativePath.startsWith("..")) {
+        return path.basename(resolvedEntry);
+      }
+
+      return relativePath;
+    })
+    .filter((entry): entry is string => Boolean(entry));
+}
+
+function sessionMatchesWorkspace(session: ContinuitySession, workspaceRoot: string | null): boolean {
+  const resolvedWorkspaceRoot = normalizeWorkspaceRoot(workspaceRoot);
+  if (!resolvedWorkspaceRoot) {
+    return false;
+  }
+
+  const metadataWorkspaceRoot = normalizeWorkspaceRoot(firstString(session.metadata?.workspaceRoot));
+  return metadataWorkspaceRoot === resolvedWorkspaceRoot;
+}
+
+async function buildSessionContinuityDetails({
+  artifactRoot,
+  session,
+  workspaceRoot = null,
+}: {
+  artifactRoot: string;
+  session: ContinuitySession;
+  workspaceRoot?: string | null;
+}): Promise<SessionContinuityDetails> {
+  const sessionRecord = await readSessionRecord({
+    artifactRoot,
+    sessionId: session.id,
+  });
+  const summaryMarkdown = await readSessionSummary({
+    artifactRoot,
+    sessionId: session.id,
+  });
+  const outcomesFromRecord = Array.isArray(sessionRecord?.outcomes)
+    ? sessionRecord.outcomes.filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    : [];
+  const outcomesFromSummary = extractMarkdownOutcomes(summaryMarkdown);
+  const summary = truncateText(
+    outcomesFromRecord.slice(0, 2).join("; ")
+    || outcomesFromSummary.slice(0, 2).join("; ")
+    || firstString(session.summary, summaryMarkdown, sessionRecord?.intent),
+  );
+
+  return {
+    displayTitle: truncateText(firstString(session.title, sessionRecord?.intent), 80),
+    summary,
+    timestamp: formatTimestamp(firstString(session.started_at, sessionRecord?.started_at)),
+    writtenPaths: summarizeWrittenPaths(sessionRecord?.paths_written ?? [], workspaceRoot),
+  };
+}
+
+function formatContinuityLine(details: SessionContinuityDetails): string | null {
+  const parts = [
+    firstString(details.timestamp),
+    firstString(details.displayTitle),
+    firstString(details.summary),
+    details.writtenPaths.length > 0 ? `Files: ${details.writtenPaths.join(", ")}` : null,
+  ].filter((value): value is string => Boolean(value));
+
+  if (parts.length === 0) {
+    return null;
+  }
+
+  return `- ${parts.join(" · ")}`;
+}
+
+async function buildThreadContinuitySection({
+  artifactRoot,
+  sessionId,
+}: {
+  artifactRoot: string;
+  sessionId: string | null | undefined;
+}): Promise<string | null> {
+  const resolvedSessionId = firstString(sessionId);
+  if (!resolvedSessionId) {
+    return null;
+  }
+
+  const details = await buildSessionContinuityDetails({
+    artifactRoot,
+    session: {
+      id: resolvedSessionId,
+      codex_thread_id: null,
+      title: null,
+      summary: null,
+      started_at: "",
+      metadata: {},
+    },
+  });
+  const line = formatContinuityLine(details);
+  if (!line) {
+    return null;
+  }
+
+  return [
+    "Thread continuity is available from the durable session record for this thread.",
+    line,
+  ].join("\n");
+}
+
+async function buildWorkspaceContinuitySection({
+  artifactRoot,
+  dbPath,
+  profileId,
+  workspaceRoot,
+  currentSessionId = null,
+}: {
+  artifactRoot: string;
+  currentSessionId?: string | null;
+  dbPath: string;
+  profileId: string;
+  workspaceRoot: string | null | undefined;
+}): Promise<string | null> {
+  const resolvedWorkspaceRoot = normalizeWorkspaceRoot(workspaceRoot);
+  if (!resolvedWorkspaceRoot) {
+    return null;
+  }
+
+  const recentSessions = await listRecentSessions({
+    dbPath,
+    profileId,
+    limit: 50,
+  });
+  const matchingSessions = recentSessions
+    .filter((session) => Boolean(session?.id))
+    .filter((session) => session.id !== firstString(currentSessionId))
+    .filter((session) => sessionMatchesWorkspace(session, resolvedWorkspaceRoot))
+    .slice(0, 3);
+
+  if (matchingSessions.length === 0) {
+    return null;
+  }
+
+  const lines = await Promise.all(
+    matchingSessions.map(async (session) => formatContinuityLine(
+      await buildSessionContinuityDetails({
+        artifactRoot,
+        session,
+        workspaceRoot: resolvedWorkspaceRoot,
+      }),
+    )),
+  );
+  const visibleLines = lines.filter((line): line is string => Boolean(line));
+  if (visibleLines.length === 0) {
+    return null;
+  }
+
+  return [
+    `Workspace continuity is available from ${matchingSessions.length} recent durable session record${matchingSessions.length === 1 ? "" : "s"} for this folder. Use this history when the user asks what has been happening here or starts a new thread in the workspace.`,
+    ...visibleLines,
+  ].join("\n");
+}
+
+export async function buildRuntimeContinuityInstruction({
+  artifactRoot,
+  currentSessionId = null,
+  dbPath,
+  profileId,
+  workspaceRoot = null,
+}: BuildRuntimeContinuityInstructionOptions): Promise<string | null> {
+  const sections = (
+    await Promise.all([
+      buildThreadContinuitySection({
+        artifactRoot,
+        sessionId: currentSessionId,
+      }),
+      buildWorkspaceContinuitySection({
+        artifactRoot,
+        currentSessionId,
+        dbPath,
+        profileId,
+        workspaceRoot,
+      }),
+    ])
+  ).filter((section): section is string => Boolean(section));
+
+  if (sections.length === 0) {
+    return null;
+  }
+
+  return sections.join("\n\n");
+}

--- a/desktop/src/renderer/features/workspace/use-workspace-collections.ts
+++ b/desktop/src/renderer/features/workspace/use-workspace-collections.ts
@@ -7,6 +7,14 @@ import type {
   SubstrateWorkspaceRecord,
 } from "../../../main/contracts";
 import { perfCount } from "../../lib/perf-debug.ts";
+import {
+  findSubstrateWorkspaceByRoot,
+  matchesWorkspaceSession,
+  projectSubstrateSessionToProjectedSession,
+  projectSubstrateWorkspaceToProjectedWorkspace,
+  sortProjectedSessionsByContinuity,
+  synthesizeProjectedWorkspaceFromSessions,
+} from "./workspace-continuity.js";
 
 type WorkspaceCollectionsResult = {
   activeWorkspaceProjection: ProjectedWorkspaceRecord | null;
@@ -101,7 +109,8 @@ export function useWorkspaceCollections({
     }
 
     const bridge = window.sense1Desktop;
-    if (!bridge?.projections?.workspaceByRoot || !bridge?.projections?.sessions) {
+    if ((!bridge?.projections?.workspaceByRoot || !bridge?.projections?.sessions)
+      && (!bridge?.substrate?.recentSessions || !bridge?.substrate?.recentWorkspaces)) {
       activeWorkspaceRequestIdRef.current += 1;
       setActiveWorkspaceProjection(null);
       setWorkspaceSessions([]);
@@ -115,14 +124,30 @@ export function useWorkspaceCollections({
     perfCount("workspace-collections.load-active-workspace");
     void (async () => {
       try {
-        const wsResult = await bridge.projections.workspaceByRoot({ rootPath: activeWorkspaceRoot });
+        const [wsResult, recentSessionResult, recentWorkspaceResult] = await Promise.all([
+          bridge?.projections?.workspaceByRoot
+            ? bridge.projections.workspaceByRoot({ rootPath: activeWorkspaceRoot })
+            : Promise.resolve({ workspace: null }),
+          bridge?.substrate?.recentSessions
+            ? bridge.substrate.recentSessions({ limit: 200 }) as Promise<{ sessions: SubstrateSessionRecord[] }>
+            : Promise.resolve({ sessions: [] }),
+          bridge?.substrate?.recentWorkspaces
+            ? bridge.substrate.recentWorkspaces({ limit: 200 }) as Promise<{ workspaces: SubstrateWorkspaceRecord[] }>
+            : Promise.resolve({ workspaces: [] }),
+        ]);
         if (!isActive || requestId !== activeWorkspaceRequestIdRef.current) {
           return;
         }
 
-        const workspace = wsResult.workspace ?? null;
-        setActiveWorkspaceProjection(workspace);
-        if (workspace) {
+        const fallbackWorkspaceRecord = findSubstrateWorkspaceByRoot(recentWorkspaceResult.workspaces, activeWorkspaceRoot);
+        let workspace = wsResult.workspace ?? (
+          fallbackWorkspaceRecord
+            ? projectSubstrateWorkspaceToProjectedWorkspace(fallbackWorkspaceRecord)
+            : null
+        );
+
+        let sessions: ProjectedSessionRecord[] = [];
+        if (workspace && bridge?.projections?.sessions) {
           const sessResult = await bridge.projections.sessions({
             workspaceId: workspace.workspace_id,
             limit: WORKSPACE_SESSION_HISTORY_LIMIT,
@@ -130,10 +155,30 @@ export function useWorkspaceCollections({
           if (!isActive || requestId !== activeWorkspaceRequestIdRef.current) {
             return;
           }
-          setWorkspaceSessions(sessResult.sessions);
-        } else {
-          setWorkspaceSessions([]);
+          sessions = Array.isArray(sessResult.sessions) ? sessResult.sessions : [];
         }
+
+        if (sessions.length === 0) {
+          const fallbackSessions = (Array.isArray(recentSessionResult.sessions) ? recentSessionResult.sessions : [])
+            .filter((session) => matchesWorkspaceSession(session, {
+              workspaceId: workspace?.workspace_id ?? fallbackWorkspaceRecord?.id ?? null,
+              workspaceRoot: activeWorkspaceRoot,
+            }))
+            .map((session) => projectSubstrateSessionToProjectedSession(
+              session,
+              workspace?.workspace_id ?? fallbackWorkspaceRecord?.id ?? null,
+            ));
+          sessions = sortProjectedSessionsByContinuity(fallbackSessions).slice(0, WORKSPACE_SESSION_HISTORY_LIMIT);
+        }
+        if (!workspace && sessions.length > 0) {
+          workspace = synthesizeProjectedWorkspaceFromSessions({
+            profileId: sessions[0]?.profile_id ?? selectedProfileId,
+            rootPath: activeWorkspaceRoot,
+            sessions,
+          });
+        }
+        setActiveWorkspaceProjection(workspace);
+        setWorkspaceSessions(sessions);
       } catch {
         if (!isActive || requestId !== activeWorkspaceRequestIdRef.current) {
           return;

--- a/desktop/src/renderer/features/workspace/workspace-continuity.d.ts
+++ b/desktop/src/renderer/features/workspace/workspace-continuity.d.ts
@@ -1,9 +1,23 @@
-import type { ProjectedSessionRecord, ProjectedWorkspaceRecord } from "../main/contracts";
+import type {
+  ProjectedSessionRecord,
+  ProjectedWorkspaceRecord,
+  SubstrateSessionRecord,
+  SubstrateWorkspaceRecord,
+} from "../../../main/contracts";
+
+export function normalizeWorkspaceRoot(
+  workspaceRoot: string | null | undefined,
+): string | null;
 
 export function findProjectedWorkspaceByRoot(
   workspaces: ProjectedWorkspaceRecord[],
   workspaceRoot: string | null | undefined,
 ): ProjectedWorkspaceRecord | null;
+
+export function findSubstrateWorkspaceByRoot(
+  workspaces: SubstrateWorkspaceRecord[],
+  workspaceRoot: string | null | undefined,
+): SubstrateWorkspaceRecord | null;
 
 export function sortProjectedSessionsByContinuity(
   sessions: ProjectedSessionRecord[],
@@ -22,3 +36,27 @@ export function buildWorkspaceContinuityState(options?: {
   hasResumableHistory: boolean;
   historyOnlySessionCount: number;
 };
+
+export function matchesWorkspaceSession(
+  session: Pick<SubstrateSessionRecord, "workspace_id" | "metadata">,
+  options?: {
+    workspaceId?: string | null;
+    workspaceRoot?: string | null;
+  },
+): boolean;
+
+export function projectSubstrateSessionToProjectedSession(
+  session: SubstrateSessionRecord,
+  workspaceId?: string | null,
+): ProjectedSessionRecord;
+
+export function projectSubstrateWorkspaceToProjectedWorkspace(
+  workspace: SubstrateWorkspaceRecord,
+): ProjectedWorkspaceRecord;
+
+export function synthesizeProjectedWorkspaceFromSessions(options: {
+  profileId?: string;
+  rootPath: string;
+  sessions?: ProjectedSessionRecord[];
+  workspaceId?: string | null;
+}): ProjectedWorkspaceRecord;

--- a/desktop/src/renderer/features/workspace/workspace-continuity.js
+++ b/desktop/src/renderer/features/workspace/workspace-continuity.js
@@ -13,6 +13,15 @@ function firstString(...values) {
   return null;
 }
 
+export function normalizeWorkspaceRoot(workspaceRoot) {
+  const resolvedWorkspaceRoot = firstString(workspaceRoot);
+  if (!resolvedWorkspaceRoot) {
+    return null;
+  }
+
+  return resolvedWorkspaceRoot.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
 function toTimestamp(value) {
   const resolvedValue = firstString(value);
   if (!resolvedValue) {
@@ -24,13 +33,24 @@ function toTimestamp(value) {
 }
 
 export function findProjectedWorkspaceByRoot(workspaces, workspaceRoot) {
-  const resolvedWorkspaceRoot = firstString(workspaceRoot);
+  const resolvedWorkspaceRoot = normalizeWorkspaceRoot(workspaceRoot);
   if (!resolvedWorkspaceRoot) {
     return null;
   }
 
   return (Array.isArray(workspaces) ? workspaces : []).find(
-    (workspace) => firstString(workspace?.root_path) === resolvedWorkspaceRoot,
+    (workspace) => normalizeWorkspaceRoot(workspace?.root_path) === resolvedWorkspaceRoot,
+  ) ?? null;
+}
+
+export function findSubstrateWorkspaceByRoot(workspaces, workspaceRoot) {
+  const resolvedWorkspaceRoot = normalizeWorkspaceRoot(workspaceRoot);
+  if (!resolvedWorkspaceRoot) {
+    return null;
+  }
+
+  return (Array.isArray(workspaces) ? workspaces : []).find(
+    (workspace) => normalizeWorkspaceRoot(workspace?.root_path) === resolvedWorkspaceRoot,
   ) ?? null;
 }
 
@@ -60,5 +80,87 @@ export function buildWorkspaceContinuityState({ sessions = [], workspaceRoot = n
     hasHistory: orderedSessions.length > 0,
     hasResumableHistory: resumableSessions.length > 0,
     historyOnlySessionCount: orderedSessions.length - resumableSessions.length,
+  };
+}
+
+export function matchesWorkspaceSession(session, { workspaceId = null, workspaceRoot = null } = {}) {
+  const resolvedWorkspaceId = firstString(workspaceId);
+  if (resolvedWorkspaceId && firstString(session?.workspace_id) === resolvedWorkspaceId) {
+    return true;
+  }
+
+  const resolvedWorkspaceRoot = normalizeWorkspaceRoot(workspaceRoot);
+  if (!resolvedWorkspaceRoot) {
+    return false;
+  }
+
+  return normalizeWorkspaceRoot(session?.metadata?.workspaceRoot) === resolvedWorkspaceRoot;
+}
+
+export function projectSubstrateSessionToProjectedSession(session, workspaceId = null) {
+  return {
+    session_id: session.id,
+    profile_id: session.profile_id,
+    workspace_id: firstString(session.workspace_id, workspaceId),
+    actor_id: session.actor_id,
+    codex_thread_id: firstString(session.codex_thread_id),
+    title: firstString(session.title),
+    model: firstString(session.model),
+    status: firstString(session.status) ?? "active",
+    started_at: firstString(session.started_at) ?? "",
+    ended_at: firstString(session.ended_at),
+    last_activity_at: firstString(session.ended_at, session.started_at),
+    event_count: 0,
+    file_change_count: 0,
+    metadata: session?.metadata && typeof session.metadata === "object" ? session.metadata : {},
+  };
+}
+
+export function projectSubstrateWorkspaceToProjectedWorkspace(workspace) {
+  return {
+    workspace_id: workspace.id,
+    profile_id: workspace.profile_id,
+    scope_id: workspace.scope_id,
+    root_path: workspace.root_path,
+    display_name: firstString(workspace.display_name),
+    status: workspace.status === "archived" ? "archived" : "active",
+    archived_at: firstString(workspace.archived_at),
+    registered_at: firstString(workspace.registered_at) ?? "",
+    last_activity_at: firstString(workspace.last_active_at, workspace.registered_at),
+    session_count: Number.isFinite(workspace?.session_count) ? workspace.session_count : 0,
+    event_count: 0,
+    file_change_count: 0,
+    last_session_id: null,
+    last_thread_id: null,
+    recent_file_paths: [],
+    metadata: workspace?.metadata && typeof workspace.metadata === "object" ? workspace.metadata : {},
+  };
+}
+
+export function synthesizeProjectedWorkspaceFromSessions({
+  profileId = "",
+  rootPath,
+  sessions = [],
+  workspaceId = null,
+}) {
+  const orderedSessions = sortProjectedSessionsByContinuity(sessions);
+  const latestSession = orderedSessions[0] ?? null;
+  return {
+    workspace_id: firstString(workspaceId) ?? `workspace:${normalizeWorkspaceRoot(rootPath) ?? "unknown"}`,
+    profile_id: firstString(profileId, latestSession?.profile_id) ?? "",
+    scope_id: "",
+    root_path: firstString(rootPath) ?? "",
+    display_name: null,
+    status: "active",
+    archived_at: null,
+    registered_at: firstString(latestSession?.started_at) ?? "",
+    last_activity_at: firstString(latestSession?.last_activity_at, latestSession?.started_at),
+    session_count: orderedSessions.length,
+    event_count: 0,
+    file_change_count: 0,
+    last_session_id: firstString(latestSession?.session_id) ?? null,
+    last_thread_id: firstString(latestSession?.codex_thread_id) ?? null,
+    recent_file_paths: [],
+    metadata: {},
   };
 }

--- a/desktop/src/renderer/features/workspace/workspace-continuity.test.js
+++ b/desktop/src/renderer/features/workspace/workspace-continuity.test.js
@@ -4,6 +4,9 @@ import assert from "node:assert/strict";
 import {
   buildWorkspaceContinuityState,
   findProjectedWorkspaceByRoot,
+  matchesWorkspaceSession,
+  projectSubstrateSessionToProjectedSession,
+  synthesizeProjectedWorkspaceFromSessions,
   sortProjectedSessionsByContinuity,
 } from "./workspace-continuity.js";
 
@@ -89,4 +92,85 @@ test("buildWorkspaceContinuityState surfaces resumable and history-only sessions
     continuity.resumableSessions.map((session) => session.session_id),
     ["sess_resume_latest", "sess_resume_older"],
   );
+});
+
+test("matchesWorkspaceSession falls back to metadata.workspaceRoot when projections are incomplete", () => {
+  assert.equal(
+    matchesWorkspaceSession(
+      {
+        workspace_id: null,
+        metadata: {
+          workspaceRoot: "/tmp/workspace-alpha",
+        },
+      },
+      {
+        workspaceId: "ws_alpha",
+        workspaceRoot: "/tmp/workspace-alpha",
+      },
+    ),
+    true,
+  );
+  assert.equal(
+    matchesWorkspaceSession(
+      {
+        workspace_id: null,
+        metadata: {
+          workspaceRoot: "/tmp/workspace-beta",
+        },
+      },
+      {
+        workspaceId: "ws_alpha",
+        workspaceRoot: "/tmp/workspace-alpha",
+      },
+    ),
+    false,
+  );
+});
+
+test("projectSubstrateSessionToProjectedSession produces a resumable session shape for fallback UI history", () => {
+  const projected = projectSubstrateSessionToProjectedSession(
+    {
+      id: "sess_alpha",
+      profile_id: "ops-team",
+      actor_id: "actor_1",
+      workspace_id: null,
+      codex_thread_id: "thread_alpha",
+      title: "Recovered thread",
+      model: "gpt-5.4-mini",
+      status: "completed",
+      started_at: "2026-03-24T08:00:00Z",
+      ended_at: "2026-03-24T08:05:00Z",
+      metadata: {
+        workspaceRoot: "/tmp/workspace-alpha",
+      },
+    },
+    "ws_alpha",
+  );
+
+  assert.equal(projected.session_id, "sess_alpha");
+  assert.equal(projected.workspace_id, "ws_alpha");
+  assert.equal(projected.codex_thread_id, "thread_alpha");
+  assert.equal(projected.last_activity_at, "2026-03-24T08:05:00Z");
+});
+
+test("synthesizeProjectedWorkspaceFromSessions creates an active workspace shell from fallback session history", () => {
+  const workspace = synthesizeProjectedWorkspaceFromSessions({
+    profileId: "ops-team",
+    rootPath: "/tmp/workspace-alpha",
+    sessions: [
+      {
+        session_id: "sess_alpha",
+        profile_id: "ops-team",
+        codex_thread_id: "thread_alpha",
+        started_at: "2026-03-24T08:00:00Z",
+        last_activity_at: "2026-03-24T08:05:00Z",
+      },
+    ],
+  });
+
+  assert.equal(workspace.root_path, "/tmp/workspace-alpha");
+  assert.equal(workspace.session_count, 1);
+  assert.equal(workspace.last_session_id, "sess_alpha");
+  assert.equal(workspace.last_thread_id, "thread_alpha");
+  assert.equal(workspace.status, "active");
 });


### PR DESCRIPTION
## Summary

This restores the workspace/thread continuity path so Sense-1 can answer "what were we doing here?" from durable local history instead of falling back to folder archaeology.

## Problem

Issue #5 described a regression where Sense-1 could behave as if a workspace had no prior history unless that history was visible through the current workspace folder structure. In practice, we already had durable session and substrate records under the app-owned storage root, but new runs were not feeding that continuity back into runtime instructions, and the workspace UI could miss legacy sessions when projection linkage was incomplete.

## Root cause

There were two separate gaps:

1. Runtime startup only passed workspace structure hints (`contextPaths`) into new turns. It did not assemble bounded continuity from durable session/session-summary records.
2. The workspace session UI trusted projections too much. If older sessions were only linked by `metadata.workspaceRoot`, history could disappear from the workspace surface even though the substrate records still existed.

## Fix

The change keeps one canonical source of truth and derives continuity from it:

- Add a bounded continuity assembler that reads substrate recent sessions plus durable session artifacts (`session.json` / `summary.md`) and turns them into runtime instructions.
- Inject that continuity into `runDesktopTask` startup so fresh workspace threads and resumed app sessions have durable context before the assistant answers.
- Add a renderer fallback that reconstructs workspace sessions from substrate history when projections are incomplete, and synthesize a lightweight workspace shell when needed so the existing UI can still render continuity.
- Add regression coverage for the runtime continuity builder, the session-controller integration point, and the workspace fallback helpers.

## Validation

- `node --test desktop/src/main/session/workspace-thread-continuity.test.js`
- `node --test desktop/src/renderer/features/workspace/workspace-continuity.test.js`
- `node --test --test-name-pattern "durable workspace continuity|workspace policy defaults" desktop/src/main/session/session-controller.test.js`
- `pnpm test:unit`
- `pnpm typecheck`
- `pnpm build`
- Interactive Electron QA on the signed-in `default` profile: a fresh workspace-bound thread answered from recent workspace context instead of acting blank

## Notes

`pnpm check` is still blocked by existing repository structure warnings unrelated to this diff.
