### PR TITLE
Polish composer layout and sidebar density

### DIFF
--- a/desktop/src/renderer/components/LeftSidebar.tsx
+++ b/desktop/src/renderer/components/LeftSidebar.tsx
@@ -123,10 +123,10 @@ export function LeftSidebar({
 
   return (
     <aside
-      className={cn("z-20 min-h-0 bg-surface-soft transition-all duration-250 ease-[cubic-bezier(0.22,1,0.36,1)] max-lg:absolute max-lg:inset-y-0 max-lg:left-0", leftRailOpen ? "w-72 p-3 max-lg:shadow-2xl" : "w-0 overflow-hidden p-0 max-lg:hidden")}
+      className={cn("z-20 min-h-0 bg-surface-soft transition-all duration-250 ease-[cubic-bezier(0.22,1,0.36,1)] max-lg:absolute max-lg:inset-y-0 max-lg:left-0", leftRailOpen ? "w-72 pb-3 pl-3 pt-3 max-lg:shadow-2xl" : "w-0 overflow-hidden p-0 max-lg:hidden")}
     >
       <div className="flex h-full min-h-0 flex-col overflow-hidden">
-        <div className="sticky top-0 z-10 shrink-0 bg-surface-soft pb-4">
+        <div className="sticky top-0 z-10 shrink-0 bg-surface-soft pb-4 pr-3">
           <Button className="w-full justify-start" onClick={resetToStartSurface} variant="default">
             <Plus />
             New chat
@@ -247,7 +247,7 @@ export function LeftSidebar({
           </div>
         </div>
 
-        <div className="mt-4 shrink-0 rounded-2xl bg-surface-strong p-3">
+        <div className="mr-3 mt-4 shrink-0 rounded-2xl bg-surface-strong p-3">
           <button className="flex w-full items-center gap-2 text-left" onClick={() => setAccountMenuOpen((value) => !value)} type="button">
             <UserCircle2 className="text-muted" />
             <div className="min-w-0 flex-1">

--- a/desktop/src/renderer/components/ThreadView.tsx
+++ b/desktop/src/renderer/components/ThreadView.tsx
@@ -1,7 +1,4 @@
 import type { Dispatch, RefObject, SetStateAction } from "react";
-import { Folder } from "lucide-react";
-
-import { folderDisplayName } from "../state/session/session-selectors.js";
 import { type DesktopApprovalDecision, type DesktopApprovalEvent, type DesktopBootstrapTeamSetup, type DesktopBootstrapTenant, type DesktopExtensionOverviewResult, type DesktopInputQuestion, type DesktopInputRequestState, type DesktopModelEntry, type DesktopThreadChangeGroup, type DesktopThreadSnapshot } from "../../main/contracts";
 import { ThreadComposer } from "./thread-view/thread-composer.js";
 import { ThreadTranscript } from "./thread-view/thread-transcript.js";
@@ -117,18 +114,10 @@ export function ThreadView(props: ThreadViewProps) {
     configNotices,
     footerStatusText,
   } = props;
-  const threadFolderRoot = selectedThread.workspaceRoot ?? selectedThread.cwd ?? null;
-
   return (
     <>
       <div className="px-6 pb-2 pt-5">
         <h2 className="font-display truncate text-lg font-semibold tracking-tight">{selectedThread.title}</h2>
-        {threadFolderRoot ? (
-          <div className="mt-[0.2rem] flex items-center gap-[0.2rem] text-[0.8125rem] leading-[1.52] text-ink-muted">
-            <Folder className="size-3.5 shrink-0" />
-            <span className="truncate">{folderDisplayName(threadFolderRoot)}</span>
-          </div>
-        ) : null}
       </div>
 
       <ThreadTranscript

--- a/desktop/src/renderer/components/left-sidebar/workspace-sidebar-group.tsx
+++ b/desktop/src/renderer/components/left-sidebar/workspace-sidebar-group.tsx
@@ -99,16 +99,14 @@ export function WorkspaceSidebarGroup({
       onDragStart={(event) => handleWorkspaceDragStart(event, root)}
       onDrop={(event) => void handleWorkspaceDrop(event, root)}
     >
-      <div className="flex items-center gap-1">
+      <div className="flex items-center gap-0.5">
         {isDraggable ? (
           <GripVertical className="size-3 shrink-0 cursor-grab text-muted opacity-0 transition-opacity group-hover:opacity-100 active:cursor-grabbing" />
-        ) : (
-          <span className="w-3 shrink-0" />
-        )}
+        ) : null}
         <button
           aria-label={`${isExpanded ? "Collapse" : "Expand"} workspace ${folderName}`}
           className={cn(
-            "flex min-w-0 flex-1 items-center gap-1.5 rounded-lg px-2 py-1.5 text-left text-xs transition-colors",
+            "flex min-w-0 flex-1 items-center gap-1 rounded-lg px-1 py-1.5 text-left text-xs transition-colors",
             group.isActive ? "bg-surface-strong text-ink" : "text-ink-faint hover:bg-surface-soft",
           )}
           onClick={() => toggleWorkspaceExpanded(root)}
@@ -182,7 +180,7 @@ export function WorkspaceSidebarGroup({
         ) : null}
       </div>
       {isExpanded ? (
-        <div className="ml-4 space-y-0.5 pl-2">
+        <div className="space-y-0.5 pl-3">
           {wsThreads.map((thread) => (
             <ThreadSidebarItem
               archivePending={threadArchivePendingId === thread.id}

--- a/desktop/src/renderer/components/start-surface/StartSurfaceLaunchPanel.tsx
+++ b/desktop/src/renderer/components/start-surface/StartSurfaceLaunchPanel.tsx
@@ -317,7 +317,7 @@ export function StartSurfaceLaunchPanel(props: StartSurfaceLaunchPanelProps) {
           </div>
         ) : null}
         <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
-          <Button disabled={!canStartWork} onClick={async () => { const paths = await pickFiles(); if (paths.length > 0) setAttachedFiles((current) => [...new Set([...current, ...paths])]); }} size="sm" variant="secondary"><Paperclip />Add local files</Button>
+          <Button aria-label="Add local files" disabled={!canStartWork} onClick={async () => { const paths = await pickFiles(); if (paths.length > 0) setAttachedFiles((current) => [...new Set([...current, ...paths])]); }} size="icon" variant="secondary"><Paperclip /></Button>
           <label className="inline-flex items-center gap-2 rounded-xl border border-line/40 px-2.5 py-1.5 text-xs text-muted">
             <input checked={workInFolder} className="size-3.5 accent-ink" disabled={!canStartWork} onChange={(event) => { const checked = event.target.checked; setWorkInFolder(checked); setFolderMenuOpen(checked); }} type="checkbox" />
             Keep this task bound to a folder

--- a/desktop/src/renderer/components/thread-view/thread-composer.tsx
+++ b/desktop/src/renderer/components/thread-view/thread-composer.tsx
@@ -170,8 +170,8 @@ function ThreadComposerInner({
   }
 
   return (
-    <div className="sticky bottom-0 z-10 bg-white/94 px-6 py-3 backdrop-blur-sm">
-      <div className="flex w-full flex-col gap-3 rounded-[1.7rem] bg-white p-3 shadow-[0_-12px_28px_rgba(10,15,20,0.04)]">
+    <div className="sticky bottom-0 z-10 py-3">
+      <div className="fixed bottom-3 left-1/2 z-50 flex w-full max-w-3xl -translate-x-1/2 flex-col gap-3 rounded-[1.7rem] bg-white p-3 shadow-[0_-12px_28px_rgba(10,15,20,0.04)]">
         {taskError ? (
           <p className="rounded-xl bg-surface-soft px-3 py-2 text-sm text-ink-soft" role="alert">
             {taskError}
@@ -231,9 +231,10 @@ function ThreadComposerInner({
             ))}
           </div>
         ) : null}
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <div className="flex items-center gap-2">
+        <div className="flex items-center justify-between gap-1.5">
+          <div className="flex items-center gap-1.5">
             <Button
+              aria-label="Add local files"
               disabled={composerDisabled || effectiveThreadBusy}
               onClick={async () => {
                 const paths = await pickFiles();
@@ -241,20 +242,19 @@ function ThreadComposerInner({
                   setAttachedFiles((current) => [...new Set([...current, ...paths])]);
                 }
               }}
-              size="sm"
+              size="icon"
               variant="secondary"
             >
               <Paperclip />
-              Add local files
             </Button>
             <Button
+              aria-label={dictation.active ? "Stop dictation" : "Dictate"}
               disabled={composerDisabled || !dictation.supported}
               onClick={() => dictation.toggle()}
-              size="sm"
+              size="icon"
               variant="secondary"
             >
               {dictation.active ? <MicOff /> : <Mic />}
-              {dictation.active ? "Stop dictation" : "Dictate"}
             </Button>
             <label className="inline-flex items-center gap-2 rounded-xl border border-line/40 px-2 py-1 text-xs text-muted">
               <select

--- a/desktop/src/renderer/components/thread-view/thread-transcript.tsx
+++ b/desktop/src/renderer/components/thread-view/thread-transcript.tsx
@@ -205,7 +205,7 @@ export function ThreadTranscript({
           setShowScrollToBottom((current) => current === nextShowScrollToBottom ? current : nextShowScrollToBottom);
         }}
       >
-        <div className="flex w-full flex-col gap-2.5 pb-10">
+        <div className="flex w-full flex-col gap-2.5 pb-48">
           {threadInteractionState === "review" || hasReviewArtifacts ? (
             <ThreadReviewCard rightRailChangeGroups={rightRailChangeGroups} selectedThread={selectedThread} threadFolderRoot={threadFolderRoot} />
           ) : null}

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -49,6 +49,24 @@ body {
   color: var(--color-ink);
 }
 
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: oklch(0.25 0.01 200);
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: oklch(0.15 0.01 200);
+}
+
 .fade-up {
   animation: fade-up 200ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }


### PR DESCRIPTION
## Summary
- Center the thread composer at the viewport midpoint (`fixed bottom, left-1/2, max-w-3xl`) so it stays centered regardless of sidebar state
- Switch attach/dictate to icon-only buttons on both start surface and thread composers
- Remove session folder label from thread title header
- Reclaim horizontal space in sidebar workspace rows (tighter padding, gaps, removed grip spacer on non-draggable items)
- Add thin 6px black scrollbar styling globally
- Add transcript bottom padding so last content clears the fixed composer

## Test plan
- [x] Open a thread with both sidebars open — composer should be viewport-centered
- [x] Close/open sidebars — composer position should not shift
- [x] Scroll a long thread — last entries should not hide behind the composer
- [x] Check sidebar workspace rows — `+` and `...` buttons should be clickable without scrollbar overlap
- [x] Verify start surface composer attach button is icon-only