### PR TITLE
Fix busy-thread routing and transcript auto-follow regressions

### DIFF
--- a/desktop/src/renderer/features/app/transcript-scroll.ts
+++ b/desktop/src/renderer/features/app/transcript-scroll.ts
@@ -7,16 +7,21 @@ export function shouldAutoFollowTranscript(distanceFromBottom: number): boolean 
   return distanceFromBottom <= TRANSCRIPT_AUTO_FOLLOW_DISTANCE_PX;
 }
 
-export function buildTranscriptScrollAnchor(entry: DesktopThreadSnapshot["entries"][number] | null | undefined): string {
+export function buildTranscriptScrollAnchor(
+  entry: DesktopThreadSnapshot["entries"][number] | null | undefined,
+  liveStreamingBody: string | null = null,
+): string {
   if (!entry) {
     return "";
   }
 
-  const entryBodyLength =
-    "body" in entry && typeof entry.body === "string"
-      ? entry.body.length
-      : 0;
   const entryStatus = "status" in entry ? entry.status : "";
+  const entryBodyLength =
+    entryStatus === "streaming" && typeof liveStreamingBody === "string"
+      ? liveStreamingBody.length
+      : "body" in entry && typeof entry.body === "string"
+        ? entry.body.length
+      : 0;
   const entryScrollBucket = entryStatus === "streaming"
     ? Math.floor(entryBodyLength / TRANSCRIPT_STREAM_SCROLL_BUCKET_CHARS)
     : 0;

--- a/desktop/src/renderer/features/app/use-app-right-rail.test.js
+++ b/desktop/src/renderer/features/app/use-app-right-rail.test.js
@@ -52,3 +52,32 @@ test("buildTranscriptScrollAnchor coalesces streaming body growth into larger bu
     "entry-1:completed:0",
   );
 });
+
+test("buildTranscriptScrollAnchor can follow live streaming body overlays", () => {
+  assert.equal(
+    buildTranscriptScrollAnchor(
+      {
+        id: "entry-1",
+        kind: "assistant",
+        title: "Sense-1 activity",
+        body: "stale",
+        status: "streaming",
+      },
+      "x".repeat(2048),
+    ),
+    "entry-1:streaming:2",
+  );
+  assert.equal(
+    buildTranscriptScrollAnchor(
+      {
+        id: "entry-1",
+        kind: "assistant",
+        title: "Sense-1 activity",
+        body: "done",
+        status: "completed",
+      },
+      "x".repeat(2048),
+    ),
+    "entry-1:completed:0",
+  );
+});

--- a/desktop/src/renderer/features/app/use-app-right-rail.ts
+++ b/desktop/src/renderer/features/app/use-app-right-rail.ts
@@ -12,6 +12,7 @@ import type {
 import type { RightRailProps } from "../../components/RightRail";
 import { buildTranscriptScrollAnchor, shouldAutoFollowTranscript } from "./transcript-scroll.js";
 import { perfCount, perfMeasure } from "../../lib/perf-debug.ts";
+import { useStreamingEntryBody } from "../../state/session/session-stream-live-bodies.ts";
 
 const PRE_EXECUTION_STATES = new Set<DesktopInteractionState>(["conversation", "clarification"]);
 
@@ -147,7 +148,11 @@ export function useAppRightRail({
 
   const entryCount = selectedThread?.entries.length ?? 0;
   const lastEntry = selectedThread?.entries[entryCount - 1];
-  const lastEntryAnchor = perfMeasure("right-rail.build-scroll-anchor", () => buildTranscriptScrollAnchor(lastEntry));
+  const lastEntryLiveBody = useStreamingEntryBody(selectedThread?.id ?? "", lastEntry?.id ?? "");
+  const lastEntryAnchor = perfMeasure(
+    "right-rail.build-scroll-anchor",
+    () => buildTranscriptScrollAnchor(lastEntry, lastEntryLiveBody),
+  );
   useEffect(() => {
     if (!entryCount) {
       return;

--- a/desktop/src/renderer/features/session/app-composer-utils.test.js
+++ b/desktop/src/renderer/features/session/app-composer-utils.test.js
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   buildDraftRunRequest,
   buildSelectedThreadRunRequest,
+  shouldUseSelectedThreadBusyActions,
 } from "./app-composer-utils.ts";
 
 test("buildSelectedThreadRunRequest trims prompt and forwards thread context", () => {
@@ -60,6 +61,30 @@ test("buildSelectedThreadRunRequest returns null for empty prompts", () => {
       threadPrompt: "   ",
     }),
     null,
+  );
+});
+
+test("shouldUseSelectedThreadBusyActions keeps restored running threads on the steer/queue path", () => {
+  assert.equal(
+    shouldUseSelectedThreadBusyActions({
+      canSteerSelectedThread: false,
+      effectiveThreadBusy: true,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldUseSelectedThreadBusyActions({
+      canSteerSelectedThread: true,
+      effectiveThreadBusy: false,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldUseSelectedThreadBusyActions({
+      canSteerSelectedThread: false,
+      effectiveThreadBusy: false,
+    }),
+    false,
   );
 });
 

--- a/desktop/src/renderer/features/session/app-composer-utils.ts
+++ b/desktop/src/renderer/features/session/app-composer-utils.ts
@@ -13,6 +13,11 @@ type SelectedThreadRunRequestParams = {
   threadPrompt: string;
 };
 
+type SelectedThreadBusyActionParams = {
+  canSteerSelectedThread: boolean;
+  effectiveThreadBusy: boolean;
+};
+
 export function buildSelectedThreadRunRequest({
   attachedFiles,
   selectedThread,
@@ -30,6 +35,13 @@ export function buildSelectedThreadRunRequest({
     threadId: selectedThread.id,
     workspaceRoot: selectedThread.workspaceRoot,
   };
+}
+
+export function shouldUseSelectedThreadBusyActions({
+  canSteerSelectedThread,
+  effectiveThreadBusy,
+}: SelectedThreadBusyActionParams): boolean {
+  return canSteerSelectedThread || effectiveThreadBusy;
 }
 
 export function buildDraftRunRequest({

--- a/desktop/src/renderer/features/session/use-app-composer.ts
+++ b/desktop/src/renderer/features/session/use-app-composer.ts
@@ -3,6 +3,7 @@ import type { DesktopThreadSnapshot } from "../../../main/contracts";
 import {
   buildDraftRunRequest,
   buildSelectedThreadRunRequest,
+  shouldUseSelectedThreadBusyActions,
 } from "./app-composer-utils.js";
 
 type UseAppComposerParams = {
@@ -76,7 +77,11 @@ export function useAppComposer({
     if (!request) {
       return false;
     }
-    if (canSteerSelectedThread && attachedFiles.length > 0) {
+    const useBusyThreadActions = shouldUseSelectedThreadBusyActions({
+      canSteerSelectedThread,
+      effectiveThreadBusy,
+    });
+    if (useBusyThreadActions && attachedFiles.length > 0) {
       setTaskError("Finish the current run before sending attachments.");
       return false;
     }
@@ -86,7 +91,7 @@ export function useAppComposer({
     requestAnimationFrame(() => {
       transcriptEndRef.current?.scrollIntoView({ behavior: "smooth" });
     });
-    if (canSteerSelectedThread) {
+    if (useBusyThreadActions) {
       await steerTurn(request.prompt);
       return true;
     }
@@ -103,7 +108,11 @@ export function useAppComposer({
     if (!request) {
       return false;
     }
-    if (canSteerSelectedThread && attachedFiles.length > 0) {
+    const useBusyThreadActions = shouldUseSelectedThreadBusyActions({
+      canSteerSelectedThread,
+      effectiveThreadBusy,
+    });
+    if (useBusyThreadActions && attachedFiles.length > 0) {
       setTaskError("Finish the current run before sending attachments.");
       return false;
     }
@@ -113,7 +122,7 @@ export function useAppComposer({
     requestAnimationFrame(() => {
       transcriptEndRef.current?.scrollIntoView({ behavior: "smooth" });
     });
-    if (canSteerSelectedThread) {
+    if (useBusyThreadActions) {
       await queueTurnInput(request.prompt);
       return true;
     }


### PR DESCRIPTION
## Summary
- restore selected-thread submit and queue routing to the busy-thread paths when bootstrap restore has not repopulated `activeTurnId` yet
- keep attachment blocking aligned with busy-thread state so restored live threads cannot start a new run accidentally
- feed transcript auto-follow anchors from the live streaming body overlay store and lock both regressions down with tests

## Why
Downstream review on [georgestander/sense-1#95](https://github.com/georgestander/sense-1/pull/95) found two bugs in the upstream responsiveness sync:
1. restored running threads could fall back to `runTask` instead of `steerTurn` / `queueTurnInput`
2. transcript auto-follow could stop during streaming because live body updates no longer mutated thread snapshots

This PR fixes those upstream so the downstream private sync does not need to carry a divergence.

## Verification
- `node --test desktop/src/renderer/features/session/app-composer-utils.test.js desktop/src/renderer/features/app/use-app-right-rail.test.js`
- `pnpm -C desktop typecheck`
- `pnpm -C desktop test:renderer`
- `pnpm -C desktop build`

## Not run
- `pnpm -C desktop qa:electron:smoke`
