### PR TITLE
Polish composer layout and sidebar density

### DIFF
--- a/desktop/src/renderer/components/thread-view/thread-composer.tsx
+++ b/desktop/src/renderer/components/thread-view/thread-composer.tsx
@@ -68,6 +68,8 @@ function ThreadComposerInner({
     setValue: setThreadPrompt,
   });
   const composerRef = useRef<HTMLTextAreaElement | null>(null);
+  const floatingRef = useRef<HTMLDivElement | null>(null);
+  const [spacerHeight, setSpacerHeight] = useState(192);
   const [shortcutCursorIndex, setShortcutCursorIndex] = useState(threadPrompt.length);
   const [shortcutSelectionIndex, setShortcutSelectionIndex] = useState(0);
   const deferredThreadPrompt = useDeferredValue(threadPrompt);
@@ -85,6 +87,16 @@ function ThreadComposerInner({
   useEffect(() => {
     setShortcutSelectionIndex(0);
   }, [deferredThreadPrompt, shortcutCursorIndex, shortcutSuggestions.length]);
+
+  useEffect(() => {
+    const el = floatingRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver(([entry]) => {
+      if (entry) setSpacerHeight(entry.borderBoxSize[0]?.blockSize ?? el.offsetHeight);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
 
   function applyShortcutSuggestion(token: string) {
     const selectionIndex =
@@ -170,8 +182,8 @@ function ThreadComposerInner({
   }
 
   return (
-    <div className="sticky bottom-0 z-10 py-3">
-      <div className="fixed bottom-3 left-1/2 z-50 flex w-full max-w-3xl -translate-x-1/2 flex-col gap-3 rounded-[1.7rem] bg-white p-3 shadow-[0_-12px_28px_rgba(10,15,20,0.04)]">
+    <div className="shrink-0" style={{ height: spacerHeight + 24 }}>
+      <div ref={floatingRef} className="fixed bottom-3 left-1/2 z-50 flex w-full max-w-3xl -translate-x-1/2 flex-col gap-3 rounded-[1.7rem] bg-white p-3 shadow-[0_-12px_28px_rgba(10,15,20,0.04)]">
         {taskError ? (
           <p className="rounded-xl bg-surface-soft px-3 py-2 text-sm text-ink-soft" role="alert">
             {taskError}

--- a/desktop/src/renderer/components/thread-view/thread-transcript.tsx
+++ b/desktop/src/renderer/components/thread-view/thread-transcript.tsx
@@ -205,7 +205,7 @@ export function ThreadTranscript({
           setShowScrollToBottom((current) => current === nextShowScrollToBottom ? current : nextShowScrollToBottom);
         }}
       >
-        <div className="flex w-full flex-col gap-2.5 pb-48">
+        <div className="flex w-full flex-col gap-2.5 pb-10">
           {threadInteractionState === "review" || hasReviewArtifacts ? (
             <ThreadReviewCard rightRailChangeGroups={rightRailChangeGroups} selectedThread={selectedThread} threadFolderRoot={threadFolderRoot} />
           ) : null}
@@ -256,7 +256,7 @@ export function ThreadTranscript({
       </div>
 
       {showScrollToBottom ? (
-        <div className="pointer-events-none sticky bottom-16 z-10 flex justify-center">
+        <div className="pointer-events-none sticky bottom-52 z-50 flex justify-center">
           <button
             className="pointer-events-auto flex items-center gap-1.5 rounded-full bg-ink px-3 py-1.5 text-xs font-medium text-white shadow-[0_4px_12px_rgba(10,15,20,0.2)] transition-opacity hover:opacity-90"
             onClick={() => transcriptEndRef.current?.scrollIntoView({ behavior: "smooth" })}


### PR DESCRIPTION
## Summary
- Center the thread composer at the viewport midpoint (`fixed bottom, left-1/2, max-w-3xl`) so it stays centered regardless of sidebar state
- Dynamic spacer via ResizeObserver tracks composer height so transcript content always clears it
- "Jump to latest" button repositioned above the fixed composer
- Switch attach/dictate to icon-only buttons on both start surface and thread composers
- Remove session folder label from thread title header
- Reclaim horizontal space in sidebar workspace rows (tighter padding, gaps, removed grip spacer on non-draggable items)
- Add thin 6px black scrollbar styling globally
- Sidebar scrollbar flush to edge, no right-padding gap

## Test plan
- [ ] Open a thread with both sidebars open — composer should be viewport-centered
- [ ] Close/open sidebars — composer position should not shift
- [ ] Scroll a long thread — last entries should not hide behind the composer
- [ ] "Jump to latest" button should appear above the composer, not behind it
- [ ] Attach files or trigger notices — spacer should grow with composer
- [ ] Check sidebar workspace rows — action buttons should be clickable without scrollbar overlap
- [ ] Verify start surface composer attach button is icon-only