### PR TITLE
[codex] Fix desktop composer dictation on macOS

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -76,6 +76,10 @@
     ],
     "mac": {
       "icon": "resources/icon.icns",
+      "extendInfo": {
+        "NSMicrophoneUsageDescription": "Sense-1 Workspace needs microphone access when voice input is enabled.",
+        "NSSpeechRecognitionUsageDescription": "Sense-1 Workspace needs speech recognition access for voice input features."
+      },
       "target": [
         {
           "target": "zip",

--- a/desktop/src/renderer/components/start-surface/StartSurfaceLaunchPanel.tsx
+++ b/desktop/src/renderer/components/start-surface/StartSurfaceLaunchPanel.tsx
@@ -289,19 +289,22 @@ export function StartSurfaceLaunchPanel(props: StartSurfaceLaunchPanelProps) {
             ref={promptInputRef}
             value={draftPrompt}
           />
-          <Button
-            aria-label={dictation.active ? "Stop voice dictation" : "Start voice dictation"}
-            disabled={!dictation.supported || !canStartWork}
-            onClick={() => dictation.toggle()}
-            size="icon"
-            variant="secondary"
-          >
-            {dictation.active ? <MicOff /> : <Mic />}
-          </Button>
+          {dictation.supported ? (
+            <Button
+              aria-label={dictation.active ? "Stop voice dictation" : "Start voice dictation"}
+              disabled={!canStartWork}
+              onClick={() => dictation.toggle()}
+              size="icon"
+              variant="secondary"
+            >
+              {dictation.active ? <MicOff /> : <Mic />}
+            </Button>
+          ) : null}
           <Button aria-label="Send prompt" disabled={!canStartWork || taskPending || !draftPrompt.trim() || (workInFolder && !workspaceFolder)} onClick={submitDraftTask} size="icon" variant="default"><Send /></Button>
         </div>
         <ShortcutPillRow className="mt-3" overview={extensionOverview} prompt={draftPrompt} />
         {dictation.error ? <p className="mt-2 text-xs text-ink-muted">{dictation.error}</p> : null}
+        {dictation.hint ? <p className="mt-2 text-xs text-ink-muted">{dictation.hint}</p> : null}
         {attachedFiles.length > 0 ? (
           <div className="mt-2 flex flex-wrap gap-1.5">
             {attachedFiles.map((filePath) => {

--- a/desktop/src/renderer/components/thread-view/thread-composer.tsx
+++ b/desktop/src/renderer/components/thread-view/thread-composer.tsx
@@ -202,6 +202,9 @@ function ThreadComposerInner({
         {dictation.error ? (
           <p className="rounded-xl bg-surface-soft px-3 py-2 text-sm text-ink-soft">{dictation.error}</p>
         ) : null}
+        {dictation.hint ? (
+          <p className="rounded-xl bg-surface-soft px-3 py-2 text-sm text-ink-soft" role="note">{dictation.hint}</p>
+        ) : null}
         {visibleShortcutSuggestions.length > 0 ? (
           <ShortcutSuggestionMenu
             activeIndex={shortcutSelectionIndex}
@@ -259,15 +262,17 @@ function ThreadComposerInner({
             >
               <Paperclip />
             </Button>
-            <Button
-              aria-label={dictation.active ? "Stop dictation" : "Dictate"}
-              disabled={composerDisabled || !dictation.supported}
-              onClick={() => dictation.toggle()}
-              size="icon"
-              variant="secondary"
-            >
-              {dictation.active ? <MicOff /> : <Mic />}
-            </Button>
+            {dictation.supported ? (
+              <Button
+                aria-label={dictation.active ? "Stop dictation" : "Dictate"}
+                disabled={composerDisabled}
+                onClick={() => dictation.toggle()}
+                size="icon"
+                variant="secondary"
+              >
+                {dictation.active ? <MicOff /> : <Mic />}
+              </Button>
+            ) : null}
             <label className="inline-flex items-center gap-2 rounded-xl border border-line/40 px-2 py-1 text-xs text-muted">
               <select
                 className="bg-transparent text-ink outline-none"

--- a/desktop/src/renderer/features/session/composer-dictation-support.test.js
+++ b/desktop/src/renderer/features/session/composer-dictation-support.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  appendDictationTranscript,
+  resolveComposerDictationHint,
+  resolveComposerDictationMode,
+  resolveComposerDictationUnavailableMessage,
+} from "./composer-dictation-support.ts";
+
+test("resolveComposerDictationMode prefers native macOS dictation for Electron desktop", () => {
+  assert.equal(
+    resolveComposerDictationMode({
+      hasDesktopBridge: true,
+      hasSpeechRecognition: true,
+      platform: "MacIntel",
+    }),
+    "nativeMacos",
+  );
+});
+
+test("resolveComposerDictationMode preserves web speech support in supported browser contexts", () => {
+  assert.equal(
+    resolveComposerDictationMode({
+      hasDesktopBridge: false,
+      hasSpeechRecognition: true,
+      platform: "Win32",
+    }),
+    "webSpeech",
+  );
+});
+
+test("resolveComposerDictationHint and unavailable message explain the native macOS fallback", () => {
+  assert.match(resolveComposerDictationHint("nativeMacos") ?? "", /macOS Dictation/u);
+  assert.equal(
+    resolveComposerDictationUnavailableMessage("nativeMacos"),
+    "Use macOS Dictation while the composer is focused.",
+  );
+});
+
+test("appendDictationTranscript trims and appends speech fragments cleanly", () => {
+  assert.equal(appendDictationTranscript("", "  hello world  "), "hello world");
+  assert.equal(appendDictationTranscript("Existing note", "  and more  "), "Existing note and more");
+  assert.equal(appendDictationTranscript("Existing note", "   "), "Existing note");
+});

--- a/desktop/src/renderer/features/session/composer-dictation-support.ts
+++ b/desktop/src/renderer/features/session/composer-dictation-support.ts
@@ -1,0 +1,48 @@
+export type ComposerDictationMode = "webSpeech" | "nativeMacos" | "unsupported";
+
+export function appendDictationTranscript(currentValue: string, transcript: string): string {
+  const normalizedTranscript = transcript.trim();
+  if (!normalizedTranscript) {
+    return currentValue;
+  }
+
+  const normalizedCurrentValue = currentValue.trim();
+  return normalizedCurrentValue ? `${normalizedCurrentValue} ${normalizedTranscript}` : normalizedTranscript;
+}
+
+export function resolveComposerDictationMode({
+  hasDesktopBridge,
+  hasSpeechRecognition,
+  platform,
+}: {
+  hasDesktopBridge: boolean;
+  hasSpeechRecognition: boolean;
+  platform: string | null;
+}): ComposerDictationMode {
+  const normalizedPlatform = platform?.trim().toLowerCase() ?? "";
+  if (hasDesktopBridge && (normalizedPlatform === "macintel" || normalizedPlatform === "darwin" || normalizedPlatform === "macos")) {
+    return "nativeMacos";
+  }
+
+  if (hasSpeechRecognition) {
+    return "webSpeech";
+  }
+
+  return "unsupported";
+}
+
+export function resolveComposerDictationHint(mode: ComposerDictationMode): string | null {
+  if (mode !== "nativeMacos") {
+    return null;
+  }
+
+  return "Use macOS Dictation while the composer is focused. The built-in mic button is hidden on desktop because Electron's speech-recognition path is unreliable on macOS.";
+}
+
+export function resolveComposerDictationUnavailableMessage(mode: ComposerDictationMode): string {
+  if (mode === "nativeMacos") {
+    return "Use macOS Dictation while the composer is focused.";
+  }
+
+  return "Voice dictation is not available in this desktop runtime.";
+}

--- a/desktop/src/renderer/features/session/use-composer-dictation.ts
+++ b/desktop/src/renderer/features/session/use-composer-dictation.ts
@@ -1,5 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import {
+  appendDictationTranscript,
+  resolveComposerDictationHint,
+  resolveComposerDictationMode,
+  resolveComposerDictationUnavailableMessage,
+} from "./composer-dictation-support.js";
+
 type SpeechRecognitionLike = {
   continuous: boolean;
   interimResults: boolean;
@@ -36,10 +43,19 @@ export function useComposerDictation({
   const [active, setActive] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
-  const supported = useMemo(() => typeof window !== "undefined" && Boolean(resolveSpeechRecognition()), []);
+  const dictationMode = useMemo(
+    () => resolveComposerDictationMode({
+      hasDesktopBridge: typeof window !== "undefined" && Boolean(window.sense1Desktop),
+      hasSpeechRecognition: typeof window !== "undefined" && Boolean(resolveSpeechRecognition()),
+      platform: typeof navigator !== "undefined" ? navigator.platform : null,
+    }),
+    [],
+  );
+  const supported = dictationMode === "webSpeech";
+  const hint = enabled ? resolveComposerDictationHint(dictationMode) : null;
 
   useEffect(() => {
-    if (!supported || !enabled) {
+    if (dictationMode !== "webSpeech" || !enabled) {
       return;
     }
     const SpeechRecognition = resolveSpeechRecognition();
@@ -61,7 +77,7 @@ export function useComposerDictation({
       if (!transcript) {
         return;
       }
-      setValue((current) => current.trim() ? `${current.trim()} ${transcript}` : transcript);
+      setValue((current) => appendDictationTranscript(current, transcript));
     };
     recognition.onend = () => {
       setActive(false);
@@ -76,10 +92,10 @@ export function useComposerDictation({
       recognition.stop();
       recognitionRef.current = null;
     };
-  }, [enabled, setValue, supported]);
+  }, [dictationMode, enabled, setValue]);
 
   useEffect(() => {
-    if (!enabled || !supported) {
+    if (!enabled || dictationMode !== "webSpeech") {
       setActive(false);
       return;
     }
@@ -98,11 +114,11 @@ export function useComposerDictation({
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [active, enabled, supported]);
+  }, [active, dictationMode, enabled]);
 
   function toggle() {
-    if (!supported || !enabled) {
-      setError("Voice dictation is not available in this desktop runtime.");
+    if (dictationMode !== "webSpeech" || !enabled) {
+      setError(resolveComposerDictationUnavailableMessage(dictationMode));
       return;
     }
     if (active) {
@@ -118,6 +134,7 @@ export function useComposerDictation({
   return {
     active,
     error,
+    hint,
     supported,
     toggle,
     value,


### PR DESCRIPTION
Fixes #7.

The desktop composer's dictation affordance was wired to Chromium's in-app `SpeechRecognition` path. In packaged macOS Electron builds that path is unreliable, so trying to dictate from the composer surfaced Chromium upload-stream failures instead of turning speech into text. For users, that meant the voice-input control looked available but failed at the moment they tried to use it.

The root cause is twofold. First, Electron has a long-standing macOS reliability gap around the Chromium speech-recognition path we were calling from the renderer. Second, our packaged desktop build did not declare the macOS speech and microphone privacy usage strings that voice features should ship with. Keeping the existing mic button in place would have continued routing users into the brittle Electron path.

This change fixes the user experience by treating macOS desktop as a native-dictation fallback environment instead of a Chromium speech-recognition environment. The shared composer dictation hook now resolves support mode explicitly, both composer surfaces hide the broken in-app mic button on macOS desktop, and both surfaces render guidance telling users to use native macOS Dictation while the composer is focused. The desktop build config now also declares `NSMicrophoneUsageDescription` and `NSSpeechRecognitionUsageDescription` so packaged builds are no longer missing the platform privacy metadata.

Validation:

- `pnpm test:renderer`
- `pnpm typecheck`
- `pnpm build`

I also ran the repo's local code-review pass on the diff; it found no blocking bug, regression, or security issues.

Known gap:

- I did not run a packaged macOS arm64 dictation session end-to-end, so the remaining risk is acceptance-level verification of native macOS Dictation in the packaged app.
