### PR TITLE
[codex] Keep desktop thread titles in sync after auto-rename

### DIFF
--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -467,6 +467,15 @@ const desktopSessionController = new DesktopSessionController(appServerManager, 
       return;
     }
   },
+  onThreadTitleChanged: async (threadId, title) => {
+    enqueueAccumulatorNotification({
+      method: "thread/name/updated",
+      params: {
+        threadId,
+        name: title,
+      },
+    });
+  },
   runtimeInfo,
 });
 let runtimeStartInFlight: Promise<void> | null = null;

--- a/desktop/src/main/session-controller.ts
+++ b/desktop/src/main/session-controller.ts
@@ -102,6 +102,7 @@ export type DesktopSessionControllerOptions = {
   readonly openExternal: (url: string) => Promise<void>;
   readonly onDesktopRunStarted?: (result: DesktopTaskRunResult) => void | Promise<void>;
   readonly onDesktopTaskResult?: (result: DesktopTaskRunResult) => void | Promise<void>;
+  readonly onThreadTitleChanged?: (threadId: string, title: string) => void | Promise<void>;
   readonly runtimeInfo: RuntimeInfo;
 };
 
@@ -128,6 +129,7 @@ export class DesktopSessionController {
   readonly #openExternal: (url: string) => Promise<void>;
   readonly #onDesktopRunStarted: ((result: DesktopTaskRunResult) => void | Promise<void>) | null;
   readonly #onDesktopTaskResult: ((result: DesktopTaskRunResult) => void | Promise<void>) | null;
+  readonly #onThreadTitleChanged: ((threadId: string, title: string) => void | Promise<void>) | null;
   readonly #runtimeInfo: RuntimeInfo;
   readonly #workspaceState: DesktopWorkspaceStateService;
   readonly #workspaceService: DesktopWorkspaceService;
@@ -159,6 +161,7 @@ export class DesktopSessionController {
     this.#resolveProfile = async () => await this.#resolveCurrentProfile();
     this.#onDesktopRunStarted = options.onDesktopRunStarted ?? null;
     this.#onDesktopTaskResult = options.onDesktopTaskResult ?? null;
+    this.#onThreadTitleChanged = options.onThreadTitleChanged ?? null;
     this.#runtimeInfo = options.runtimeInfo;
     this.#workspaceState = new DesktopWorkspaceStateService({
       env: this.#env,
@@ -345,6 +348,9 @@ export class DesktopSessionController {
       threadId: resolvedThreadId,
       name: resolvedTitle,
     });
+    if (this.#onThreadTitleChanged) {
+      await this.#onThreadTitleChanged(resolvedThreadId, resolvedTitle);
+    }
   }
 
   ingestRuntimeEvent(event: DesktopRuntimeEvent): void {

--- a/desktop/src/main/session/session-controller.test.js
+++ b/desktop/src/main/session/session-controller.test.js
@@ -2296,6 +2296,7 @@ test("ingestRuntimeMessage auto-renames a generic thread after the first assista
   const root = await makeTempRoot();
   const env = createTestEnv(root);
   const managerCalls = [];
+  const titleChangeCalls = [];
   const manager = {
     request: async (method, params) => {
       managerCalls.push({ method, params });
@@ -2346,6 +2347,9 @@ test("ingestRuntimeMessage auto-renames a generic thread after the first assista
     appStartedAt: "2026-03-24T10:00:00.000Z",
     env,
     openExternal: async () => {},
+    onThreadTitleChanged: async (threadId, title) => {
+      titleChangeCalls.push({ threadId, title });
+    },
     runtimeInfo: {
       appVersion: "0.1.0",
       electronVersion: "35.2.1",
@@ -2399,6 +2403,12 @@ test("ingestRuntimeMessage auto-renames a generic thread after the first assista
         threadId: "thread-auto-title-1",
         name: "Inspect the login crash and patch the auth handler",
       },
+    },
+  ]);
+  assert.deepEqual(titleChangeCalls, [
+    {
+      threadId: "thread-auto-title-1",
+      title: "Inspect the login crash and patch the auth handler",
     },
   ]);
 


### PR DESCRIPTION
This is a follow-up fix for the desktop thread-title summarization work.

The issue was not the summarizer itself. The controller could successfully ask the runtime to rename a thread after the early assistant response, but the desktop shell never replayed that title change through its live thread-state accumulator. From the user's perspective, the thread stayed named after the first prompt even though the auto-rename logic had already produced a better title.

The root cause was a propagation gap between the main-process title suggestion path and the renderer's live thread summary state. Manual renames already end up on the shell's existing `thread/name/updated` delta path, but suggested renames from the controller only called `thread/name/set` against the runtime and stopped there.

This change fixes that by emitting the same `thread/name/updated` notification path immediately after the controller applies a suggested title. That keeps the desktop shell's live thread state aligned with the runtime rename behavior without forcing a full bootstrap refresh. I also added a regression assertion to the session-controller test that covers the generic-first-prompt auto-rename flow.

Validation:

- `node --test --test-name-pattern="auto-renames a generic thread after the first assistant answer" src/main/session/session-controller.test.js`
- `pnpm typecheck`
- `pnpm build`

Known gap:

- `pnpm test:main` still has an unrelated existing timeout in `src/main/runtime/app-server-process-manager.test.js`, so I did not use the full suite as the acceptance gate for this focused follow-up.
