### PR TITLE
Center thread stream to match composer width

### DIFF
--- a/desktop/src/renderer/components/ThreadView.tsx
+++ b/desktop/src/renderer/components/ThreadView.tsx
@@ -116,7 +116,7 @@ export function ThreadView(props: ThreadViewProps) {
   } = props;
   return (
     <>
-      <div className="px-6 pb-2 pt-5">
+      <div className="mx-auto max-w-3xl px-6 pb-2 pt-5">
         <h2 className="font-display truncate text-lg font-semibold tracking-tight">{selectedThread.title}</h2>
       </div>
 

--- a/desktop/src/renderer/components/thread-view/thread-transcript.tsx
+++ b/desktop/src/renderer/components/thread-view/thread-transcript.tsx
@@ -205,7 +205,7 @@ export function ThreadTranscript({
           setShowScrollToBottom((current) => current === nextShowScrollToBottom ? current : nextShowScrollToBottom);
         }}
       >
-        <div className="flex w-full flex-col gap-2.5 pb-10">
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-2.5 pb-10">
           {threadInteractionState === "review" || hasReviewArtifacts ? (
             <ThreadReviewCard rightRailChangeGroups={rightRailChangeGroups} selectedThread={selectedThread} threadFolderRoot={threadFolderRoot} />
           ) : null}


### PR DESCRIPTION
## Summary
- Constrain the transcript content column to `max-w-3xl mx-auto`, matching the composer width
- Center the thread title header within the same column
- User messages (right-aligned) and assistant messages (left-aligned) now sit within a focused centered column instead of spanning the full main viewport

## Test plan
- [ ] Open a thread — transcript content should be centered and roughly composer-width
- [ ] User messages should right-align within the centered column
- [ ] Assistant messages should left-align within the centered column
- [ ] Long code blocks should scroll horizontally within the column, not overflow
- [ ] Approval cards, clarification panels, and status footer should render within the column
- [ ] "Jump to latest" button should remain centered and visible
- [ ] Review cards should display correctly within the narrower column