### PR TITLE
[codex] add desktop fast mode controls

### DIFF
--- a/desktop/src/main/runtime/live-thread-runtime-request.js
+++ b/desktop/src/main/runtime/live-thread-runtime-request.js
@@ -60,6 +60,7 @@ export function buildCollaborationMode({
   mode = "default",
   model = null,
   reasoningEffort = null,
+  serviceTier = "flex",
 } = {}) {
   return {
     mode,
@@ -67,6 +68,7 @@ export function buildCollaborationMode({
       developer_instructions: null,
       model: firstString(model) ?? "",
       reasoning_effort: firstString(reasoningEffort),
+      service_tier: firstString(serviceTier),
     },
   };
 }

--- a/desktop/src/main/runtime/live-thread-runtime.d.ts
+++ b/desktop/src/main/runtime/live-thread-runtime.d.ts
@@ -124,6 +124,7 @@ export function ensureDesktopThread(
     executionIntent?: ReturnType<typeof classifyDesktopExecutionIntent> | null;
     model?: string | null;
     personality?: string | null;
+    serviceTier?: "flex" | "fast" | null;
     runContext?: DesktopRunContext | null;
     runtimeInstructions?: string | null;
     settings?: Record<string, unknown> | null;

--- a/desktop/src/main/runtime/live-thread-runtime.js
+++ b/desktop/src/main/runtime/live-thread-runtime.js
@@ -194,6 +194,7 @@ export async function runDesktopTask(
     personality,
     prompt,
     reasoningEffort,
+    serviceTier,
     runContext,
     runtimeInstructions = null,
     settings = null,
@@ -270,6 +271,7 @@ export async function runDesktopTask(
     mode: "default",
     model,
     reasoningEffort,
+    serviceTier,
   });
 
   let turnResult;
@@ -288,6 +290,7 @@ export async function runDesktopTask(
         sense1: {
           executionIntent,
           runContext: productRunContext,
+          serviceTier: firstString(serviceTier) ?? "flex",
         },
       },
     });
@@ -324,6 +327,7 @@ export async function runDesktopTask(
           sense1: {
             executionIntent,
             runContext: productRunContext,
+            serviceTier: firstString(serviceTier) ?? "flex",
           },
         },
       });

--- a/desktop/src/main/runtime/live-thread-runtime.test.js
+++ b/desktop/src/main/runtime/live-thread-runtime.test.js
@@ -528,6 +528,7 @@ test("runDesktopTask starts a new thread then starts a turn with prompt and cwd"
     prompt: "Replace the fake desktop task flow",
     cwd: workspaceRoot,
     model: "gpt-5.4",
+    serviceTier: "fast",
     runContext,
     workspaceRoot,
   });
@@ -588,6 +589,7 @@ test("runDesktopTask starts a new thread then starts a turn with prompt and cwd"
             developer_instructions: null,
             model: "gpt-5.4",
             reasoning_effort: null,
+            service_tier: "fast",
           },
         },
         model: "gpt-5.4",
@@ -608,6 +610,7 @@ test("runDesktopTask starts a new thread then starts a turn with prompt and cwd"
           sense1: {
             executionIntent,
             runContext,
+            serviceTier: "fast",
           },
         },
       },
@@ -934,6 +937,7 @@ test("runDesktopTask does not bind a new chat-only thread to the desktop cwd", a
             developer_instructions: null,
             model: "gpt-5.4",
             reasoning_effort: null,
+            service_tier: "flex",
           },
         },
         model: "gpt-5.4",
@@ -959,6 +963,7 @@ test("runDesktopTask does not bind a new chat-only thread to the desktop cwd", a
               workspaceBound: false,
             },
             runContext,
+            serviceTier: "flex",
           },
         },
       },
@@ -1344,6 +1349,7 @@ test("runDesktopTask keeps the same chat artifact instructions when it has to re
       developer_instructions: null,
       model: "gpt-5.4",
       reasoning_effort: null,
+      service_tier: "flex",
     },
   });
   assert.deepEqual(calls[1].params.sandboxPolicy, {
@@ -1364,6 +1370,7 @@ test("runDesktopTask keeps the same chat artifact instructions when it has to re
       developer_instructions: null,
       model: "gpt-5.4",
       reasoning_effort: null,
+      service_tier: "flex",
     },
   });
   assert.deepEqual(calls[3].params.sandboxPolicy, {
@@ -1498,6 +1505,7 @@ test("runDesktopTask resumes an existing thread before starting a turn", async (
             developer_instructions: null,
             model: "gpt-5.4",
             reasoning_effort: null,
+            service_tier: "flex",
           },
         },
         model: "gpt-5.4",
@@ -1523,6 +1531,7 @@ test("runDesktopTask resumes an existing thread before starting a turn", async (
               workspaceBound: false,
             },
             runContext,
+            serviceTier: "flex",
           },
         },
       },
@@ -1697,6 +1706,7 @@ test("runDesktopTask keeps plainly read-only workspace conversation out of the p
       developer_instructions: null,
       model: "gpt-5.4",
       reasoning_effort: null,
+      service_tier: "flex",
     },
   });
   assert.deepEqual(calls[1].params.sandboxPolicy, {
@@ -2157,6 +2167,7 @@ test("runDesktopTask can start the first real turn on an approval-created thread
       developer_instructions: null,
       model: "",
       reasoning_effort: null,
+      service_tier: "flex",
     },
   });
   assert.deepEqual(calls[1].params.sandboxPolicy, {

--- a/desktop/src/main/session-controller.ts
+++ b/desktop/src/main/session-controller.ts
@@ -143,6 +143,7 @@ export class DesktopSessionController {
   static readonly DEFAULT_SETTINGS: DesktopSettings = {
     model: DEFAULT_DESKTOP_SETTINGS.model,
     reasoningEffort: DEFAULT_DESKTOP_SETTINGS.reasoningEffort,
+    serviceTier: DEFAULT_DESKTOP_SETTINGS.serviceTier,
     personality: DEFAULT_DESKTOP_SETTINGS.personality,
     defaultOperatingMode: DEFAULT_DESKTOP_SETTINGS.defaultOperatingMode,
     runtimeInstructions: DEFAULT_DESKTOP_SETTINGS.runtimeInstructions,

--- a/desktop/src/main/session/desktop-run-start-service.ts
+++ b/desktop/src/main/session/desktop-run-start-service.ts
@@ -316,6 +316,7 @@ export class DesktopRunStartService {
       model: request.model,
       personality: request.personality,
       reasoningEffort: request.reasoningEffort,
+      serviceTier: request.serviceTier,
     });
     const resolvedSettings = resolveDesktopSettings({
       orgPolicy,
@@ -509,6 +510,7 @@ export class DesktopRunStartService {
         model: resolvedModel,
         personality: resolvedPersonality,
         reasoningEffort: resolvedEffort ?? undefined,
+        serviceTier: resolvedSettings.settings.serviceTier === "fast" ? "fast" : "flex",
         runtimeInstructions: resolvedRuntimeInstructions,
         settings: resolvedSettings.settings as unknown as Record<string, unknown>,
         workspaceRoot: effectiveWorkspaceRoot,

--- a/desktop/src/main/settings/desktop-settings-service.ts
+++ b/desktop/src/main/settings/desktop-settings-service.ts
@@ -39,6 +39,7 @@ import type {
 export const DESKTOP_DEFAULT_SETTINGS: DesktopSettings = {
   model: DEFAULT_DESKTOP_SETTINGS.model,
   reasoningEffort: DEFAULT_DESKTOP_SETTINGS.reasoningEffort,
+  serviceTier: DEFAULT_DESKTOP_SETTINGS.serviceTier,
   personality: DEFAULT_DESKTOP_SETTINGS.personality,
   defaultOperatingMode: DEFAULT_DESKTOP_SETTINGS.defaultOperatingMode,
   runtimeInstructions: DEFAULT_DESKTOP_SETTINGS.runtimeInstructions,

--- a/desktop/src/main/settings/desktop-settings.d.ts
+++ b/desktop/src/main/settings/desktop-settings.d.ts
@@ -8,6 +8,7 @@ export type DesktopSettingsPatch = Partial<
     DesktopSettings,
     | "model"
     | "reasoningEffort"
+    | "serviceTier"
     | "personality"
     | "defaultOperatingMode"
     | "runtimeInstructions"
@@ -30,6 +31,7 @@ export type DesktopSettingsPatch = Partial<
 export interface DesktopWorkspaceDefaults {
   readonly model?: string;
   readonly reasoningEffort?: string;
+  readonly serviceTier?: DesktopSettings["serviceTier"];
   readonly personality?: string;
 }
 

--- a/desktop/src/main/settings/desktop-settings.js
+++ b/desktop/src/main/settings/desktop-settings.js
@@ -3,6 +3,7 @@ import { DEFAULT_DESKTOP_RUNTIME_INSTRUCTIONS } from "../runtime/live-thread-run
 export const DEFAULT_DESKTOP_SETTINGS = Object.freeze({
   model: "gpt-5.4-mini",
   reasoningEffort: "xhigh",
+  serviceTier: "flex",
   personality: "friendly",
   defaultOperatingMode: "auto",
   runtimeInstructions: DEFAULT_DESKTOP_RUNTIME_INSTRUCTIONS,
@@ -47,6 +48,15 @@ function normalizePersonality(value) {
 
   if (resolved === "concise" || resolved === "formal" || resolved === "detailed") {
     return "pragmatic";
+  }
+
+  return undefined;
+}
+
+function normalizeServiceTier(value) {
+  const resolved = firstString(value);
+  if (resolved === "flex" || resolved === "fast") {
+    return resolved;
   }
 
   return undefined;
@@ -172,6 +182,7 @@ function normalizeWorkspaceDefaults(value) {
   const workspaceDefaults = {};
   const model = firstString(record.model);
   const reasoningEffort = firstString(record.reasoningEffort);
+  const serviceTier = normalizeServiceTier(record.serviceTier);
   const personality = normalizePersonality(record.personality);
 
   if (model) {
@@ -179,6 +190,9 @@ function normalizeWorkspaceDefaults(value) {
   }
   if (reasoningEffort) {
     workspaceDefaults.reasoningEffort = reasoningEffort;
+  }
+  if (serviceTier) {
+    workspaceDefaults.serviceTier = serviceTier;
   }
   if (personality) {
     workspaceDefaults.personality = personality;
@@ -342,6 +356,7 @@ function buildPatchLayer(patch = {}) {
     workspaceDefaults: {
       ...(patch.model !== undefined ? { model: patch.model } : {}),
       ...(patch.reasoningEffort !== undefined ? { reasoningEffort: patch.reasoningEffort } : {}),
+      ...(patch.serviceTier !== undefined ? { serviceTier: patch.serviceTier } : {}),
       ...(patch.personality !== undefined ? { personality: normalizePersonality(patch.personality) } : {}),
       ...(patch.workspaceDefaults ?? {}),
     },

--- a/desktop/src/main/settings/desktop-settings.test.js
+++ b/desktop/src/main/settings/desktop-settings.test.js
@@ -12,6 +12,7 @@ test("resolveDesktopSettings lifts legacy flat settings into effective desktop d
   const settings = resolveDesktopSettings({
     model: "gpt-5.4",
     reasoningEffort: "high",
+    serviceTier: "fast",
     personality: "formal",
     approvalPosture: "onRequest",
     sandboxPosture: "readOnly",
@@ -21,6 +22,7 @@ test("resolveDesktopSettings lifts legacy flat settings into effective desktop d
     ...resolveDesktopSettings(),
     model: "gpt-5.4",
     reasoningEffort: "high",
+    serviceTier: "fast",
     personality: "pragmatic",
     approvalPosture: "onRequest",
     sandboxPosture: "readOnly",
@@ -43,6 +45,7 @@ test("resolveDesktopSettingsState layers workspace defaults and model restrictio
           workspaceDefaults: {
             model: "gpt-5.4",
             reasoningEffort: "medium",
+            serviceTier: "fast",
             personality: "formal",
           },
           approvalDefaults: {
@@ -67,6 +70,7 @@ test("resolveDesktopSettingsState layers workspace defaults and model restrictio
     ...resolveDesktopSettings(),
     model: "gpt-5.4-mini",
     reasoningEffort: "medium",
+    serviceTier: "fast",
     personality: "pragmatic",
     approvalPosture: "onRequest",
     sandboxPosture: "readOnly",
@@ -162,6 +166,30 @@ test("applyDesktopSettingsPatch persists runtime instructions under general defa
     },
   });
   assert.equal(resolveDesktopSettings(next).runtimeInstructions, "Custom runtime policy text.\nKeep it short.");
+});
+
+test("applyDesktopSettingsPatch persists the default service tier under workspace defaults", () => {
+  const next = applyDesktopSettingsPatch(
+    {
+      version: 2,
+      policy: {
+        system: null,
+        organization: null,
+        profile: null,
+        workspaces: {},
+      },
+    },
+    {
+      serviceTier: "fast",
+    },
+  );
+
+  assert.deepEqual(next.policy.profile, {
+    workspaceDefaults: {
+      serviceTier: "fast",
+    },
+  });
+  assert.equal(resolveDesktopSettings(next).serviceTier, "fast");
 });
 
 test("applyDesktopSettingsPatch persists the default operating mode under general defaults", () => {

--- a/desktop/src/main/settings/policy-settings.js
+++ b/desktop/src/main/settings/policy-settings.js
@@ -21,6 +21,7 @@ const ADMIN_APPROVAL_POSTURE_RANK = Object.freeze({
 const DESKTOP_SETTING_KEYS = Object.freeze([
   "model",
   "reasoningEffort",
+  "serviceTier",
   "personality",
   "runtimeInstructions",
   "approvalPosture",
@@ -133,6 +134,10 @@ export function normalizeDesktopSettingsLayer(settings = {}) {
   const reasoningEffort = firstString(record.reasoningEffort);
   if (reasoningEffort) {
     normalized.reasoningEffort = reasoningEffort;
+  }
+  const serviceTier = firstString(record.serviceTier);
+  if (serviceTier === "flex" || serviceTier === "fast") {
+    normalized.serviceTier = serviceTier;
   }
   const personality = normalizePersonality(record.personality, null);
   if (personality) {

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -21,6 +21,7 @@ import { shouldShowHomeRightRail } from "./features/app/app-view-visibility.js";
 
 const DEFAULT_MODEL = "";
 const DEFAULT_REASONING_EFFORT = "";
+const DEFAULT_SERVICE_TIER = "flex";
 
 // ---------------------------------------------------------------------------
 // App (orchestrator)
@@ -35,17 +36,19 @@ export default function App() {
   const [searchQuery, setSearchQuery] = useState("");
   const [model, setModel] = useState(DEFAULT_MODEL);
   const [reasoning, setReasoning] = useState(DEFAULT_REASONING_EFFORT);
+  const [serviceTier, setServiceTier] = useState<"flex" | "fast">(DEFAULT_SERVICE_TIER);
   const [workInFolder, setWorkInFolder] = useState(false);
   const [folderMenuOpen, setFolderMenuOpen] = useState(false);
   const [workspaceFolder, setWorkspaceFolder] = useState<string | null>(null);
   const [accountMenuOpen, setAccountMenuOpen] = useState(false);
 
-  const sessionState = useDesktopSessionState({ model, reasoningEffort: reasoning });
+  const sessionState = useDesktopSessionState({ model, reasoningEffort: reasoning, serviceTier });
   const settingsController = useSettingsController({
     isSignedIn: sessionState.isSignedIn,
     selectedProfileId: sessionState.selectedProfileId,
     setModel,
     setReasoning,
+    setServiceTier,
   });
   const management = useDesktopManagement({
     enabled: !sessionState.bootstrapLoading && !sessionState.runtimeSetup?.blocked,
@@ -81,11 +84,13 @@ export default function App() {
       model,
       reasoning,
       searchQuery,
+      serviceTier,
       setAccountMenuOpen,
       setFolderMenuOpen,
       setModel,
       setReasoning,
       setSearchQuery,
+      setServiceTier,
       setWorkInFolder,
       setWorkspaceFolder,
       workInFolder,

--- a/desktop/src/renderer/components/SettingsModal.tsx
+++ b/desktop/src/renderer/components/SettingsModal.tsx
@@ -57,6 +57,7 @@ export interface SettingsModalProps {
   settingsModel: string;
   settingsReasoning: string;
   settingsReasoningOptions: string[];
+  settingsServiceTier: "flex" | "fast";
   saveSettingsModelSelection: (nextModel: string) => void;
   availableModels: DesktopModelEntry[];
   currentVersion: string | null;
@@ -82,6 +83,7 @@ export function SettingsModal({
   settingsModel,
   settingsReasoning,
   settingsReasoningOptions,
+  settingsServiceTier,
   saveSettingsModelSelection,
   availableModels,
   currentVersion,
@@ -144,6 +146,7 @@ export function SettingsModal({
                 settingsModel={settingsModel}
                 settingsReasoning={settingsReasoning}
                 settingsReasoningOptions={settingsReasoningOptions}
+                settingsServiceTier={settingsServiceTier}
                 updateState={updateState}
               />
             ) : settingsSection === "team" ? (

--- a/desktop/src/renderer/components/StartSurface.tsx
+++ b/desktop/src/renderer/components/StartSurface.tsx
@@ -22,7 +22,9 @@ export type StartSurfaceProps = {
   setAttachedFiles: Dispatch<SetStateAction<string[]>>;
   pickFiles: () => Promise<string[]>;
   selectedModel: string | null;
+  selectedServiceTier: "flex" | "fast";
   handleModelSelection: (nextModel: string) => void;
+  handleServiceTierSelection: (nextServiceTier: "flex" | "fast") => void;
   modelOptions: string[];
   availableModels: DesktopModelEntry[];
   submitDraftTask: () => void;
@@ -97,7 +99,9 @@ export function StartSurface(props: StartSurfaceProps) {
     setAttachedFiles,
     pickFiles,
     selectedModel,
+    selectedServiceTier,
     handleModelSelection,
+    handleServiceTierSelection,
     modelOptions,
     availableModels,
     submitDraftTask,
@@ -166,6 +170,7 @@ export function StartSurface(props: StartSurfaceProps) {
         recentFolders={recentFolders}
         resumeWorkspaceSession={resumeWorkspaceSession}
         selectedModel={selectedModel}
+        selectedServiceTier={selectedServiceTier}
         setAttachedFiles={setAttachedFiles}
         setDraftPrompt={setDraftPrompt}
         setFolderMenuOpen={setFolderMenuOpen}
@@ -177,6 +182,7 @@ export function StartSurface(props: StartSurfaceProps) {
         tenant={tenant}
         teamSetup={teamSetup}
         threads={threads}
+        handleServiceTierSelection={handleServiceTierSelection}
         refreshBootstrap={refreshBootstrap}
         workspaceSessions={workspaceSessions}
         workspaceSessionsLoading={workspaceSessionsLoading}

--- a/desktop/src/renderer/components/ThreadView.tsx
+++ b/desktop/src/renderer/components/ThreadView.tsx
@@ -35,14 +35,14 @@ export interface ThreadViewProps {
   queueSelectedThreadPrompt: (threadPrompt: string) => Promise<boolean>;
   queuedMessageCount: number;
   submitSelectedThreadPrompt: (threadPrompt: string) => Promise<boolean>;
-  model: string;
-  reasoning: string;
   selectedModel: string;
   selectedReasoning: string;
+  selectedServiceTier: "flex" | "fast";
   setReasoning: Dispatch<SetStateAction<string>>;
   modelOptions: string[];
   reasoningOptions: string[];
   handleModelSelection: (nextModel: string) => void;
+  handleServiceTierSelection: (nextServiceTier: "flex" | "fast") => void;
   REASONING_LABELS: Record<string, string>;
   availableModels: DesktopModelEntry[];
   taskPending: boolean;
@@ -97,9 +97,11 @@ export function ThreadView(props: ThreadViewProps) {
     selectedModel,
     selectedReasoning,
     setReasoning,
+    selectedServiceTier,
     modelOptions,
     reasoningOptions,
     handleModelSelection,
+    handleServiceTierSelection,
     REASONING_LABELS,
     availableModels,
     taskError,
@@ -163,6 +165,7 @@ export function ThreadView(props: ThreadViewProps) {
         selectedThreadId={selectedThreadId}
         selectedModel={selectedModel}
         selectedReasoning={selectedReasoning}
+        selectedServiceTier={selectedServiceTier}
         setAttachedFiles={setAttachedFiles}
         setReasoning={setReasoning}
         submitSelectedThreadPrompt={submitSelectedThreadPrompt}
@@ -170,6 +173,7 @@ export function ThreadView(props: ThreadViewProps) {
         tenant={tenant}
         teamSetup={teamSetup}
         threadPromptOverride={threadPromptOverride}
+        handleServiceTierSelection={handleServiceTierSelection}
         attachedFiles={attachedFiles}
       />
     </>

--- a/desktop/src/renderer/components/composer/fast-mode-suggestion-menu.tsx
+++ b/desktop/src/renderer/components/composer/fast-mode-suggestion-menu.tsx
@@ -1,0 +1,57 @@
+import { Zap } from "lucide-react";
+
+import type { FastModeSuggestion } from "../../features/session/fast-mode-command.js";
+import { cn } from "../../lib/cn.js";
+
+type FastModeSuggestionMenuProps = {
+  activeIndex: number;
+  onSelect: (suggestion: FastModeSuggestion) => void;
+  suggestions: FastModeSuggestion[];
+};
+
+export function FastModeSuggestionMenu({
+  activeIndex,
+  onSelect,
+  suggestions,
+}: FastModeSuggestionMenuProps) {
+  if (suggestions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-2xl border border-line/60 bg-white/96 p-2 shadow-[0_16px_36px_rgba(10,15,20,0.08)] backdrop-blur-sm">
+      <p className="px-2 pb-1 text-[0.625rem] font-semibold uppercase tracking-[0.12em] text-muted">
+        Slash commands
+      </p>
+      <div className="space-y-1">
+        {suggestions.map((suggestion, index) => {
+          const isActive = index === activeIndex;
+          return (
+            <button
+              className={cn(
+                "flex w-full items-center gap-2 rounded-xl px-2 py-1.5 text-left text-[0.6875rem] transition-colors",
+                isActive ? "bg-ink text-white" : "bg-transparent text-ink hover:bg-surface-soft",
+              )}
+              key={suggestion.command}
+              onClick={(event) => event.preventDefault()}
+              onMouseDown={(event) => {
+                event.preventDefault();
+                onSelect(suggestion);
+              }}
+              type="button"
+            >
+              <Zap className={cn("size-3.5 shrink-0", isActive ? "text-white" : "text-ink-muted")} />
+              <span className="min-w-0 flex-1">
+                <span className="block truncate font-semibold">{suggestion.label}</span>
+                <span className={cn("block truncate", isActive ? "text-white/70" : "text-ink-muted")}>
+                  {suggestion.command}
+                  {suggestion.description ? ` · ${suggestion.description}` : ""}
+                </span>
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/renderer/components/settings/GeneralSettingsSection.tsx
+++ b/desktop/src/renderer/components/settings/GeneralSettingsSection.tsx
@@ -28,6 +28,7 @@ export type GeneralSettingsSectionProps = SectionProps & {
   settingsModel: string;
   settingsReasoning: string;
   settingsReasoningOptions: string[];
+  settingsServiceTier: "flex" | "fast";
   updateState: DesktopUpdateState | null;
 };
 
@@ -44,6 +45,7 @@ export function GeneralSettingsSection({
   settingsModel,
   settingsReasoning,
   settingsReasoningOptions,
+  settingsServiceTier,
   updateState,
 }: GeneralSettingsSectionProps) {
   const updateSummary = resolveSettingsUpdateSummary(updateState);
@@ -139,6 +141,23 @@ export function GeneralSettingsSection({
               <p className="mt-[0.2rem] text-[0.8125rem] leading-[1.52] text-[oklch(65%_0.15_25)]">{settingsError.message}</p>
             ) : (
               <p className="mt-[0.2rem] text-[0.8125rem] leading-[1.52] text-ink-muted">Higher reasoning uses more tokens but produces more thorough analysis.</p>
+            )}
+          </label>
+
+          <label className="flex flex-col gap-[0.4rem]">
+            <span className="text-[0.75rem] font-medium uppercase leading-[1.2] tracking-[0.05em] text-ink-faint">Service tier</span>
+            <select
+              className="rounded-md bg-surface-high px-[0.65rem] py-[0.4rem] text-[0.875rem] leading-[1.6] text-ink outline-none focus:ring-1 focus:ring-line"
+              onChange={(e) => void saveSettings({ serviceTier: e.target.value as "flex" | "fast" })}
+              value={settingsServiceTier}
+            >
+              <option value="flex">Flex</option>
+              <option value="fast">Fast</option>
+            </select>
+            {settingsError?.key === "serviceTier" ? (
+              <p className="mt-[0.2rem] text-[0.8125rem] leading-[1.52] text-[oklch(65%_0.15_25)]">{settingsError.message}</p>
+            ) : (
+              <p className="mt-[0.2rem] text-[0.8125rem] leading-[1.52] text-ink-muted">Fast mode prefers the low-latency service tier for new runs.</p>
             )}
           </label>
         </div>

--- a/desktop/src/renderer/components/start-surface/StartSurfaceLaunchPanel.tsx
+++ b/desktop/src/renderer/components/start-surface/StartSurfaceLaunchPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState, type Dispatch, type SetStateActio
 import { ChevronDown, ChevronRight, Clock3, Folder, FolderOpen, Mic, Paperclip, Send } from "lucide-react";
 
 import { Button } from "../ui/button";
+import { FastModeSuggestionMenu } from "../composer/fast-mode-suggestion-menu.js";
 import { ShortcutPillRow } from "../composer/shortcut-pill-row.js";
 import { ShortcutSuggestionMenu } from "../composer/shortcut-suggestion-menu.js";
 import { VoiceRecordingPill } from "../composer/voice-recording-pill.js";
@@ -11,6 +12,7 @@ import type { DesktopBootstrapTeamSetup, DesktopBootstrapTenant, DesktopExtensio
 import type { FolderOption } from "../../state/session/session-types.js";
 import { folderDisplayName } from "../../state/session/session-selectors.js";
 import { buildStartSurfaceIdentity } from "../../state/session/tenant-identity.js";
+import { applyFastModeSuggestion, resolveFastModeSuggestions } from "../../features/session/fast-mode-command.js";
 import { useComposerDictation } from "../../features/session/use-composer-dictation.js";
 import { formatSessionActivity, isResumableProjectedSession, workspaceDisplayName } from "./start-surface-utils.js";
 import { replaceActivePromptShortcut, resolvePromptShortcutSuggestions } from "../../../shared/prompt-shortcuts.ts";
@@ -32,7 +34,9 @@ export type StartSurfaceLaunchPanelProps = {
   setAttachedFiles: Dispatch<SetStateAction<string[]>>;
   pickFiles: () => Promise<string[]>;
   selectedModel: string | null;
+  selectedServiceTier: "flex" | "fast";
   handleModelSelection: (nextModel: string) => void;
+  handleServiceTierSelection: (nextServiceTier: "flex" | "fast") => void;
   modelOptions: string[];
   availableModels: DesktopModelEntry[];
   submitDraftTask: () => void;
@@ -74,7 +78,9 @@ export function StartSurfaceLaunchPanel(props: StartSurfaceLaunchPanelProps) {
     setAttachedFiles,
     pickFiles,
     selectedModel,
+    selectedServiceTier,
     handleModelSelection,
+    handleServiceTierSelection,
     modelOptions,
     availableModels,
     submitDraftTask,
@@ -122,6 +128,10 @@ export function StartSurfaceLaunchPanel(props: StartSurfaceLaunchPanelProps) {
     [draftPrompt, extensionOverview, shortcutCursorIndex],
   );
   const visibleShortcutSuggestions = shortcutSuggestions.slice(0, 8);
+  const fastModeSuggestions = useMemo(
+    () => resolveFastModeSuggestions(draftPrompt, shortcutCursorIndex),
+    [draftPrompt, shortcutCursorIndex],
+  );
 
   useEffect(() => {
     draftPromptRef.current = draftPrompt;
@@ -137,6 +147,17 @@ export function StartSurfaceLaunchPanel(props: StartSurfaceLaunchPanelProps) {
       token,
       promptInputRef.current?.selectionStart ?? shortcutCursorIndex,
     );
+    setDraftPrompt(nextSelection.prompt);
+    setShortcutCursorIndex(nextSelection.cursorIndex);
+    setShortcutSelectionIndex(0);
+    requestAnimationFrame(() => {
+      promptInputRef.current?.focus();
+      promptInputRef.current?.setSelectionRange(nextSelection.cursorIndex, nextSelection.cursorIndex);
+    });
+  }
+
+  function applyFastSuggestion(command: string) {
+    const nextSelection = applyFastModeSuggestion(command);
     setDraftPrompt(nextSelection.prompt);
     setShortcutCursorIndex(nextSelection.cursorIndex);
     setShortcutSelectionIndex(0);
@@ -248,7 +269,16 @@ export function StartSurfaceLaunchPanel(props: StartSurfaceLaunchPanelProps) {
             <Button disabled={!canStartWork} onClick={() => { setWorkInFolder(true); setFolderMenuOpen(true); }} variant={workInFolder ? "default" : "secondary"}>Choose folder</Button>
           </div>
         ) : null}
-        {visibleShortcutSuggestions.length > 0 ? (
+        {fastModeSuggestions.length > 0 ? (
+          <div className="mb-3">
+            <FastModeSuggestionMenu
+              activeIndex={shortcutSelectionIndex}
+              onSelect={(suggestion) => applyFastSuggestion(suggestion.command)}
+              suggestions={fastModeSuggestions}
+            />
+          </div>
+        ) : null}
+        {fastModeSuggestions.length === 0 && visibleShortcutSuggestions.length > 0 ? (
           <div className="mb-3">
             <ShortcutSuggestionMenu
               activeIndex={shortcutSelectionIndex}
@@ -269,6 +299,27 @@ export function StartSurfaceLaunchPanel(props: StartSurfaceLaunchPanelProps) {
             onClick={(event) => setShortcutCursorIndex(event.currentTarget.selectionStart ?? event.currentTarget.value.length)}
             onKeyUp={(event) => setShortcutCursorIndex(event.currentTarget.selectionStart ?? event.currentTarget.value.length)}
             onKeyDown={(event) => {
+              if (fastModeSuggestions.length > 0) {
+                if (event.key === "ArrowDown") {
+                  event.preventDefault();
+                  setShortcutSelectionIndex((current) => (current + 1) % fastModeSuggestions.length);
+                  return;
+                }
+                if (event.key === "ArrowUp") {
+                  event.preventDefault();
+                  setShortcutSelectionIndex((current) => (current - 1 + fastModeSuggestions.length) % fastModeSuggestions.length);
+                  return;
+                }
+                if (event.key === "Enter" || event.key === "Tab") {
+                  event.preventDefault();
+                  applyFastSuggestion(fastModeSuggestions[shortcutSelectionIndex]?.command ?? fastModeSuggestions[0]?.command ?? "");
+                  return;
+                }
+                if (event.key === "Escape") {
+                  setShortcutSelectionIndex(0);
+                  return;
+                }
+              }
               if (visibleShortcutSuggestions.length > 0) {
                 if (event.key === "ArrowDown") {
                   event.preventDefault();
@@ -316,7 +367,18 @@ export function StartSurfaceLaunchPanel(props: StartSurfaceLaunchPanelProps) {
           ) : null}
           <Button aria-label="Send prompt" disabled={!canStartWork || taskPending || !draftPrompt.trim() || (workInFolder && !workspaceFolder)} onClick={submitDraftTask} size="icon" variant="default"><Send /></Button>
         </div>
-        <ShortcutPillRow className="mt-3" overview={extensionOverview} prompt={draftPrompt} />
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          {selectedServiceTier === "fast" ? (
+            <button
+              className="inline-flex items-center gap-1.5 rounded-full bg-[oklch(18%_0.03_55)] px-3 py-1 text-xs font-semibold text-white shadow-[0_8px_20px_rgba(10,15,20,0.12)]"
+              onClick={() => handleServiceTierSelection("flex")}
+              type="button"
+            >
+              Fast mode
+            </button>
+          ) : null}
+          <ShortcutPillRow className="flex-1" overview={extensionOverview} prompt={draftPrompt} />
+        </div>
         {dictation.error ? <p className="mt-2 text-[0.5rem] leading-tight text-black">{dictation.error}</p> : null}
         {dictation.hint ? <p className="mt-2 text-[0.5rem] leading-tight text-black">{dictation.hint}</p> : null}
         {dictation.statusText || dictation.liveTranscript?.assistant ? (
@@ -353,6 +415,14 @@ export function StartSurfaceLaunchPanel(props: StartSurfaceLaunchPanelProps) {
               )) : <option value="">Loading live models...</option>}
             </select>
           </div>
+          <button
+            className={`inline-flex items-center gap-2 rounded-xl border px-2 py-1.5 text-xs ${selectedServiceTier === "fast" ? "border-[oklch(76%_0.17_75)] bg-[oklch(95%_0.04_85)] text-ink" : "border-line/40 text-muted"}`}
+            disabled={!canStartWork}
+            onClick={() => handleServiceTierSelection(selectedServiceTier === "fast" ? "flex" : "fast")}
+            type="button"
+          >
+            Fast
+          </button>
         </div>
 
         {workInFolder ? (

--- a/desktop/src/renderer/components/thread-view/thread-composer.tsx
+++ b/desktop/src/renderer/components/thread-view/thread-composer.tsx
@@ -2,10 +2,15 @@ import { memo, useDeferredValue, useEffect, useMemo, useRef, useState, type Disp
 import { BrainCircuit, Mic, Paperclip, Send, Square } from "lucide-react";
 
 import { Button } from "../ui/button";
+import { FastModeSuggestionMenu } from "../composer/fast-mode-suggestion-menu.js";
 import { ShortcutPillRow } from "../composer/shortcut-pill-row.js";
 import { ShortcutSuggestionMenu } from "../composer/shortcut-suggestion-menu.js";
 import { VoiceRecordingPill } from "../composer/voice-recording-pill.js";
 import { buildThreadComposerIdentity } from "../../state/session/tenant-identity.js";
+import {
+  applyFastModeSuggestion,
+  resolveFastModeSuggestions,
+} from "../../features/session/fast-mode-command.js";
 import { useComposerDictation } from "../../features/session/use-composer-dictation.js";
 import { type DesktopBootstrapTeamSetup, type DesktopBootstrapTenant, type DesktopExtensionOverviewResult, type DesktopModelEntry } from "../../../main/contracts";
 import { replaceActivePromptShortcut, resolvePromptShortcutSuggestions } from "../../../shared/prompt-shortcuts.ts";
@@ -23,7 +28,9 @@ type ThreadComposerProps = {
   modelOptions: string[];
   availableModels: DesktopModelEntry[];
   selectedModel: string;
+  selectedServiceTier: "flex" | "fast";
   handleModelSelection: (nextModel: string) => void;
+  handleServiceTierSelection: (nextServiceTier: "flex" | "fast") => void;
   queueSelectedThreadPrompt: (threadPrompt: string) => Promise<boolean>;
   queuedMessageCount: number;
   reasoningOptions: string[];
@@ -48,7 +55,9 @@ function ThreadComposerInner({
   modelOptions,
   availableModels,
   selectedModel,
+  selectedServiceTier,
   handleModelSelection,
+  handleServiceTierSelection,
   queueSelectedThreadPrompt,
   queuedMessageCount,
   reasoningOptions,
@@ -80,6 +89,10 @@ function ThreadComposerInner({
     [deferredThreadPrompt, extensionOverview, shortcutCursorIndex],
   );
   const visibleShortcutSuggestions = shortcutSuggestions.slice(0, 8);
+  const fastModeSuggestions = useMemo(
+    () => resolveFastModeSuggestions(threadPrompt, shortcutCursorIndex),
+    [threadPrompt, shortcutCursorIndex],
+  );
 
   useEffect(() => {
     setThreadPrompt(threadPromptOverride);
@@ -126,7 +139,40 @@ function ThreadComposerInner({
     });
   }
 
+  function applyFastSuggestion(command: string) {
+    const nextSelection = applyFastModeSuggestion(command);
+    setThreadPrompt(nextSelection.prompt);
+    setShortcutCursorIndex(nextSelection.cursorIndex);
+    setShortcutSelectionIndex(0);
+    requestAnimationFrame(() => {
+      composerRef.current?.focus();
+      composerRef.current?.setSelectionRange(nextSelection.cursorIndex, nextSelection.cursorIndex);
+    });
+  }
+
   function handleComposerKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
+    if (fastModeSuggestions.length > 0) {
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setShortcutSelectionIndex((current) => (current + 1) % fastModeSuggestions.length);
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setShortcutSelectionIndex((current) => (current - 1 + fastModeSuggestions.length) % fastModeSuggestions.length);
+        return;
+      }
+      if ((event.key === "Enter" && !event.shiftKey) || event.key === "Tab") {
+        event.preventDefault();
+        applyFastSuggestion(fastModeSuggestions[shortcutSelectionIndex]?.command ?? fastModeSuggestions[0]?.command ?? "");
+        return;
+      }
+      if (event.key === "Escape") {
+        setShortcutSelectionIndex(0);
+        return;
+      }
+    }
+
     if (visibleShortcutSuggestions.length > 0) {
       if (event.key === "ArrowDown") {
         event.preventDefault();
@@ -213,14 +259,32 @@ function ThreadComposerInner({
             {dictation.liveTranscript?.assistant ? <p>Codex: {dictation.liveTranscript.assistant}</p> : null}
           </div>
         ) : null}
-        {visibleShortcutSuggestions.length > 0 ? (
+        {fastModeSuggestions.length > 0 ? (
+          <FastModeSuggestionMenu
+            activeIndex={shortcutSelectionIndex}
+            onSelect={(suggestion) => applyFastSuggestion(suggestion.command)}
+            suggestions={fastModeSuggestions}
+          />
+        ) : null}
+        {fastModeSuggestions.length === 0 && visibleShortcutSuggestions.length > 0 ? (
           <ShortcutSuggestionMenu
             activeIndex={shortcutSelectionIndex}
             onSelect={(suggestion) => applyShortcutSuggestion(suggestion.token)}
             suggestions={visibleShortcutSuggestions}
           />
         ) : null}
-        <ShortcutPillRow overview={extensionOverview} prompt={deferredThreadPrompt} />
+        <div className="flex flex-wrap items-center gap-2">
+          {selectedServiceTier === "fast" ? (
+            <button
+              className="inline-flex items-center gap-1.5 rounded-full bg-[oklch(18%_0.03_55)] px-3 py-1 text-xs font-semibold text-white shadow-[0_8px_20px_rgba(10,15,20,0.12)]"
+              onClick={() => handleServiceTierSelection("flex")}
+              type="button"
+            >
+              Fast mode
+            </button>
+          ) : null}
+          <ShortcutPillRow overview={extensionOverview} prompt={deferredThreadPrompt} />
+        </div>
         <textarea
           className="min-h-[5.5rem] resize-none rounded-xl border border-line/40 bg-canvas px-3 py-2 text-sm outline-none transition-all placeholder:text-muted focus-visible:ring-[3px] focus-visible:ring-accent/30 disabled:cursor-not-allowed disabled:opacity-70"
           disabled={composerDisabled}
@@ -307,6 +371,14 @@ function ThreadComposerInner({
                 )}
               </select>
             </label>
+            <button
+              className={`inline-flex items-center gap-2 rounded-xl border px-2 py-1 text-xs ${selectedServiceTier === "fast" ? "border-[oklch(76%_0.17_75)] bg-[oklch(95%_0.04_85)] text-ink" : "border-line/40 text-muted"}`}
+              disabled={composerDisabled}
+              onClick={() => handleServiceTierSelection(selectedServiceTier === "fast" ? "flex" : "fast")}
+              type="button"
+            >
+              Fast
+            </button>
           </div>
           <div className="flex items-center gap-2">
             {dictation.recordingIndicator ? (

--- a/desktop/src/renderer/features/app/app-main-content-props.ts
+++ b/desktop/src/renderer/features/app/app-main-content-props.ts
@@ -12,8 +12,6 @@ type BuildThreadViewPropsArgs = {
   sessionState: SessionState;
   extensionOverview: ThreadViewProps["extensionOverview"];
   ui: {
-    model: string;
-    reasoning: string;
     setReasoning: Dispatch<SetStateAction<string>>;
   };
   composer: Pick<
@@ -38,9 +36,11 @@ type BuildThreadViewPropsArgs = {
     ThreadViewProps,
     | "selectedModel"
     | "selectedReasoning"
+    | "selectedServiceTier"
     | "modelOptions"
     | "reasoningOptions"
     | "handleModelSelection"
+    | "handleServiceTierSelection"
   >;
   rightRail: Pick<
     ThreadViewProps,
@@ -80,7 +80,9 @@ type BuildStartSurfacePropsArgs = {
   modelState: Pick<
     StartSurfaceProps,
     | "selectedModel"
+    | "selectedServiceTier"
     | "handleModelSelection"
+    | "handleServiceTierSelection"
     | "modelOptions"
   >;
   workspace: Pick<
@@ -171,14 +173,14 @@ export function buildThreadViewProps({
     queueSelectedThreadPrompt: composer.queueSelectedThreadPrompt,
     queuedMessageCount: selectedThread.threadInputState?.queuedMessages.length ?? 0,
     submitSelectedThreadPrompt: composer.submitSelectedThreadPrompt,
-    model: ui.model,
-    reasoning: ui.reasoning,
     selectedModel: modelState.selectedModel,
     selectedReasoning: modelState.selectedReasoning,
+    selectedServiceTier: modelState.selectedServiceTier,
     setReasoning: ui.setReasoning,
     modelOptions: modelState.modelOptions,
     reasoningOptions: modelState.reasoningOptions,
     handleModelSelection: modelState.handleModelSelection,
+    handleServiceTierSelection: modelState.handleServiceTierSelection,
     REASONING_LABELS,
     availableModels: sessionState.availableModels,
     taskPending: sessionState.taskPending,
@@ -225,7 +227,9 @@ export function buildStartSurfaceProps({
     setAttachedFiles: composer.setAttachedFiles,
     pickFiles: sessionState.pickFiles,
     selectedModel: modelState.selectedModel,
+    selectedServiceTier: modelState.selectedServiceTier,
     handleModelSelection: modelState.handleModelSelection,
+    handleServiceTierSelection: modelState.handleServiceTierSelection,
     modelOptions: modelState.modelOptions,
     availableModels: sessionState.availableModels,
     submitDraftTask: composer.submitDraftTask,

--- a/desktop/src/renderer/features/app/use-app-shell-props.ts
+++ b/desktop/src/renderer/features/app/use-app-shell-props.ts
@@ -47,6 +47,7 @@ type BuildAppShellPropsArgs = {
     settingsOpen: SettingsModalProps["settingsOpen"];
     settingsReasoning: SettingsModalProps["settingsReasoning"];
     settingsReasoningOptions: SettingsModalProps["settingsReasoningOptions"];
+    settingsServiceTier: SettingsModalProps["settingsServiceTier"];
     settingsSaving: SettingsModalProps["settingsSaving"];
     settingsSection: SettingsModalProps["settingsSection"];
     teamSetup: SettingsModalProps["teamSetup"];
@@ -185,6 +186,7 @@ export function useAppShellProps({
     settingsModel: settings.settingsModel,
     settingsReasoning: settings.settingsReasoning,
     settingsReasoningOptions: settings.settingsReasoningOptions,
+    settingsServiceTier: settings.settingsServiceTier,
     saveSettingsModelSelection: settings.saveSettingsModelSelection,
     availableModels: settings.availableModels,
     currentVersion: settings.currentVersion,

--- a/desktop/src/renderer/features/app/use-authenticated-desktop-app.ts
+++ b/desktop/src/renderer/features/app/use-authenticated-desktop-app.ts
@@ -28,11 +28,13 @@ type UseAuthenticatedDesktopAppArgs = {
     model: string;
     reasoning: string;
     searchQuery: string;
+    serviceTier: "flex" | "fast";
     setAccountMenuOpen: Dispatch<SetStateAction<boolean>>;
     setFolderMenuOpen: Dispatch<SetStateAction<boolean>>;
     setModel: Dispatch<SetStateAction<string>>;
     setReasoning: Dispatch<SetStateAction<string>>;
     setSearchQuery: Dispatch<SetStateAction<string>>;
+    setServiceTier: Dispatch<SetStateAction<"flex" | "fast">>;
     setWorkInFolder: Dispatch<SetStateAction<boolean>>;
     setWorkspaceFolder: Dispatch<SetStateAction<string | null>>;
     workInFolder: boolean;
@@ -56,9 +58,11 @@ export function useAuthenticatedDesktopApp({
       model: ui.model,
       reasoning: ui.reasoning,
       searchQuery: ui.searchQuery,
+      serviceTier: ui.serviceTier,
       setFolderMenuOpen: ui.setFolderMenuOpen,
       setModel: ui.setModel,
       setReasoning: ui.setReasoning,
+      setServiceTier: ui.setServiceTier,
       setWorkInFolder: ui.setWorkInFolder,
       setWorkspaceFolder: ui.setWorkspaceFolder,
       workInFolder: ui.workInFolder,
@@ -103,6 +107,7 @@ export function useAuthenticatedDesktopApp({
       settingsOpen: settingsController.settingsOpen,
       settingsReasoning: content.modelSettings.settingsReasoning,
       settingsReasoningOptions: content.modelSettings.settingsReasoningOptions,
+      settingsServiceTier: content.modelSettings.settingsServiceTier,
       settingsSaving: settingsController.settingsSaving,
       settingsSection: settingsController.settingsSection,
       teamSetup: sessionState.teamSetup,
@@ -155,8 +160,6 @@ export function useAuthenticatedDesktopApp({
     extensionOverview,
     sessionState,
     ui: {
-      model: ui.model,
-      reasoning: ui.reasoning,
       setReasoning: ui.setReasoning,
     },
     composer: {
@@ -178,8 +181,10 @@ export function useAuthenticatedDesktopApp({
     },
     modelState: {
       handleModelSelection: content.modelSettings.handleModelSelection,
+      handleServiceTierSelection: content.modelSettings.handleServiceTierSelection,
       selectedModel: content.modelSettings.selectedModel,
       selectedReasoning: content.modelSettings.selectedReasoning,
+      selectedServiceTier: content.modelSettings.selectedServiceTier,
       modelOptions: content.modelSettings.modelOptions,
       reasoningOptions: content.modelSettings.reasoningOptions,
     },
@@ -220,7 +225,9 @@ export function useAuthenticatedDesktopApp({
     },
     modelState: {
       selectedModel: content.modelSettings.selectedModel,
+      selectedServiceTier: content.modelSettings.selectedServiceTier,
       handleModelSelection: content.modelSettings.handleModelSelection,
+      handleServiceTierSelection: content.modelSettings.handleServiceTierSelection,
       modelOptions: content.modelSettings.modelOptions,
     },
     workspace: {

--- a/desktop/src/renderer/features/app/use-authenticated-desktop-content.ts
+++ b/desktop/src/renderer/features/app/use-authenticated-desktop-content.ts
@@ -5,6 +5,7 @@ import type { useDesktopSessionState } from "../../use-desktop-session-state.js"
 import type { useSettingsController } from "../settings/use-settings-controller.js";
 import { REASONING_LABELS, useAppModelSettings } from "../settings/use-app-model-settings.js";
 import { useAppComposer } from "../session/use-app-composer.js";
+import { parseFastModeCommand } from "../session/fast-mode-command.js";
 import { useThreadShell } from "../threads/use-thread-shell.js";
 import { useWorkspaceActivity } from "../workspace/use-workspace-activity.js";
 import { useWorkspaceCollections } from "../workspace/use-workspace-collections.js";
@@ -23,9 +24,11 @@ type UseAuthenticatedDesktopContentArgs = {
     model: string;
     reasoning: string;
     searchQuery: string;
+    serviceTier: "flex" | "fast";
     setFolderMenuOpen: Dispatch<SetStateAction<boolean>>;
     setModel: Dispatch<SetStateAction<string>>;
     setReasoning: Dispatch<SetStateAction<string>>;
+    setServiceTier: Dispatch<SetStateAction<"flex" | "fast">>;
     setWorkInFolder: Dispatch<SetStateAction<boolean>>;
     setWorkspaceFolder: Dispatch<SetStateAction<string | null>>;
     workInFolder: boolean;
@@ -42,12 +45,47 @@ export function useAuthenticatedDesktopContent({
   const transcriptEndRef = useRef<HTMLDivElement>(null);
   const transcriptContainerRef = useRef<HTMLDivElement>(null);
   const currentRequestId = sessionState.threadInputRequest?.requestId ?? null;
+  const modelSettings = useAppModelSettings({
+    availableModels: sessionState.availableModels,
+    model: ui.model,
+    reasoning: ui.reasoning,
+    serviceTier: ui.serviceTier,
+    selectedThreadId: sessionState.selectedThreadId,
+    setModel: ui.setModel,
+    setReasoning: ui.setReasoning,
+    setServiceTier: ui.setServiceTier,
+    settingsData: settingsController.settingsData,
+    saveSettings: settingsController.saveSettings,
+  });
 
   const composer = useAppComposer({
     canSteerSelectedThread: Boolean(sessionState.activeTurnId),
     currentRequestId,
     clearSelectedThread: sessionState.clearSelectedThread,
     effectiveThreadBusy: sessionState.selectedThread?.state === "running",
+    handleFastModeCommand: async (prompt) => {
+      const action = parseFastModeCommand(prompt);
+      if (!action) {
+        return false;
+      }
+      if (action === "on") {
+        modelSettings.handleServiceTierSelection("fast");
+        return true;
+      }
+      if (action === "off") {
+        modelSettings.handleServiceTierSelection("flex");
+        return true;
+      }
+      if (action === "status") {
+        modelSettings.pushConfigNotice(
+          modelSettings.selectedServiceTier === "fast"
+            ? "Fast mode is on"
+            : "Fast mode is off",
+        );
+        return true;
+      }
+      return false;
+    },
     queueTurnInput: sessionState.queueTurnInput,
     runTask: sessionState.runTask,
     selectedThread: sessionState.selectedThread,
@@ -128,17 +166,6 @@ export function useAuthenticatedDesktopContent({
       composer.resetComposerState();
       workspaceShell.resetWorkspaceShell();
     },
-  });
-
-  const modelSettings = useAppModelSettings({
-    availableModels: sessionState.availableModels,
-    model: ui.model,
-    reasoning: ui.reasoning,
-    selectedThreadId: sessionState.selectedThreadId,
-    setModel: ui.setModel,
-    setReasoning: ui.setReasoning,
-    settingsData: settingsController.settingsData,
-    saveSettings: settingsController.saveSettings,
   });
 
   const rightRail = useAppRightRail({

--- a/desktop/src/renderer/features/session/actions/session-run-actions.test.js
+++ b/desktop/src/renderer/features/session/actions/session-run-actions.test.js
@@ -5,14 +5,17 @@ import { createSessionRunActions } from "./session-run-actions.ts";
 
 function createDeps({ runResult }) {
   let pendingPermission = null;
+  const turnRunCalls = [];
 
   return {
     getPendingPermission: () => pendingPermission,
+    getTurnRunCalls: () => turnRunCalls,
     getRunContext: () => null,
     getSelectedThreadId: () => null,
     getActiveTurnIdsByThread: () => ({}),
     model: "",
     reasoningEffort: "",
+    serviceTier: "fast",
     flushPendingThreadDeltas: () => {},
     rememberKnownThreadIds: () => {},
     refreshBootstrap: async () => null,
@@ -22,7 +25,10 @@ function createDeps({ runResult }) {
       turns: {
         interrupt: async () => {},
         queue: async () => {},
-        run: async () => runResult,
+        run: async (request) => {
+          turnRunCalls.push(request);
+          return runResult;
+        },
         steer: async () => {},
       },
       workspace: { rememberThreadRoot: async () => {} },
@@ -74,4 +80,5 @@ test("runTask rewrites permission retry requests to the granted workspace root",
       workspaceRoot: "/tmp",
     },
   });
+  assert.equal(deps.getTurnRunCalls()[0]?.serviceTier, "fast");
 });

--- a/desktop/src/renderer/features/session/actions/session-run-actions.ts
+++ b/desktop/src/renderer/features/session/actions/session-run-actions.ts
@@ -84,6 +84,7 @@ export function createSessionRunActions(
         workspaceRoot: request.workspaceRoot ?? undefined,
         model: deps.model || undefined,
         reasoningEffort: deps.reasoningEffort || undefined,
+        serviceTier: deps.serviceTier,
         attachments: request.attachments?.length ? request.attachments : undefined,
         runContext: deps.getRunContext() ?? undefined,
       });

--- a/desktop/src/renderer/features/session/actions/session-thread-actions.ts
+++ b/desktop/src/renderer/features/session/actions/session-thread-actions.ts
@@ -162,6 +162,7 @@ export function createSessionThreadActions(
         workspaceRoot: request.workspaceRoot ?? undefined,
         model: deps.model || undefined,
         reasoningEffort: deps.reasoningEffort || undefined,
+        serviceTier: deps.serviceTier,
         attachments: request.attachments?.length ? request.attachments : undefined,
         runContext: deps.getRunContext() ?? undefined,
       });

--- a/desktop/src/renderer/features/session/fast-mode-command.test.js
+++ b/desktop/src/renderer/features/session/fast-mode-command.test.js
@@ -24,6 +24,10 @@ test("resolveFastModeSuggestions offers matching slash completions", () => {
     resolveFastModeSuggestions("/fast o", 7).map((suggestion) => suggestion.command),
     ["/fast on", "/fast off"],
   );
+  assert.deepEqual(resolveFastModeSuggestions("/fast", 5), []);
+  assert.deepEqual(resolveFastModeSuggestions("/fast on", 8), []);
+  assert.deepEqual(resolveFastModeSuggestions("/fast off", 9), []);
+  assert.deepEqual(resolveFastModeSuggestions("/fast status", 12), []);
   assert.deepEqual(resolveFastModeSuggestions("ship it", 7), []);
 });
 

--- a/desktop/src/renderer/features/session/fast-mode-command.test.js
+++ b/desktop/src/renderer/features/session/fast-mode-command.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  applyFastModeSuggestion,
+  parseFastModeCommand,
+  resolveFastModeSuggestions,
+} from "./fast-mode-command.ts";
+
+test("parseFastModeCommand resolves fast slash commands", () => {
+  assert.equal(parseFastModeCommand("/fast"), "status");
+  assert.equal(parseFastModeCommand("/fast on"), "on");
+  assert.equal(parseFastModeCommand("/fast off"), "off");
+  assert.equal(parseFastModeCommand("/fast status"), "status");
+  assert.equal(parseFastModeCommand("/fast later"), null);
+});
+
+test("resolveFastModeSuggestions offers matching slash completions", () => {
+  assert.deepEqual(
+    resolveFastModeSuggestions("/fa", 3).map((suggestion) => suggestion.command),
+    ["/fast on", "/fast off", "/fast status"],
+  );
+  assert.deepEqual(
+    resolveFastModeSuggestions("/fast o", 7).map((suggestion) => suggestion.command),
+    ["/fast on", "/fast off"],
+  );
+  assert.deepEqual(resolveFastModeSuggestions("ship it", 7), []);
+});
+
+test("applyFastModeSuggestion replaces the composer prompt with the selected command", () => {
+  assert.deepEqual(applyFastModeSuggestion("/fast on"), {
+    cursorIndex: 8,
+    prompt: "/fast on",
+  });
+});

--- a/desktop/src/renderer/features/session/fast-mode-command.ts
+++ b/desktop/src/renderer/features/session/fast-mode-command.ts
@@ -1,0 +1,74 @@
+export type FastModeAction = "on" | "off" | "status";
+
+export type FastModeSuggestion = {
+  command: string;
+  description: string;
+  label: string;
+};
+
+const FAST_MODE_SUGGESTIONS = Object.freeze([
+  {
+    command: "/fast on",
+    description: "Enable fast service tier for new runs.",
+    label: "Enable Fast mode",
+  },
+  {
+    command: "/fast off",
+    description: "Return to the default flex tier.",
+    label: "Disable Fast mode",
+  },
+  {
+    command: "/fast status",
+    description: "Show whether Fast mode is active.",
+    label: "Show Fast mode status",
+  },
+]);
+
+export function parseFastModeCommand(prompt: string): FastModeAction | null {
+  const match = prompt.trim().match(/^\/fast(?:\s+(on|off|status))?$/iu);
+  if (!match) {
+    return null;
+  }
+
+  const action = match[1]?.toLowerCase() ?? "status";
+  if (action === "on" || action === "off" || action === "status") {
+    return action;
+  }
+
+  return null;
+}
+
+export function resolveFastModeSuggestions(prompt: string, cursorIndex: number): FastModeSuggestion[] {
+  const beforeCursor = prompt.slice(0, cursorIndex);
+  const afterCursor = prompt.slice(cursorIndex);
+  if (afterCursor.trim().length > 0) {
+    return [];
+  }
+
+  const trimmed = beforeCursor.trim();
+  if (!trimmed.startsWith("/")) {
+    return [];
+  }
+
+  if ("/fast".startsWith(trimmed.toLowerCase())) {
+    return [...FAST_MODE_SUGGESTIONS];
+  }
+
+  const match = trimmed.match(/^\/fast(?:\s+(\S*))?$/iu);
+  if (!match) {
+    return [];
+  }
+
+  const actionFragment = match[1]?.toLowerCase() ?? "";
+  return FAST_MODE_SUGGESTIONS.filter((suggestion) => {
+    const action = suggestion.command.split(/\s+/u)[1] ?? "";
+    return action.startsWith(actionFragment);
+  });
+}
+
+export function applyFastModeSuggestion(command: string) {
+  return {
+    cursorIndex: command.length,
+    prompt: command,
+  };
+}

--- a/desktop/src/renderer/features/session/fast-mode-command.ts
+++ b/desktop/src/renderer/features/session/fast-mode-command.ts
@@ -50,6 +50,10 @@ export function resolveFastModeSuggestions(prompt: string, cursorIndex: number):
     return [];
   }
 
+  if (parseFastModeCommand(trimmed) !== null) {
+    return [];
+  }
+
   if ("/fast".startsWith(trimmed.toLowerCase())) {
     return [...FAST_MODE_SUGGESTIONS];
   }

--- a/desktop/src/renderer/features/session/session-action-types.ts
+++ b/desktop/src/renderer/features/session/session-action-types.ts
@@ -56,6 +56,7 @@ export type DesktopSessionActionDependencies = {
   rememberKnownThreadIds: (threadIds: Iterable<string>, options?: { replace?: boolean }) => void;
   requireDesktopBridge: () => DesktopBridge;
   reasoningEffort: string;
+  serviceTier: "flex" | "fast";
   removeThreadFromLocalState: (threadId: string) => Promise<void>;
   removeWorkspaceFromLocalState: (workspaceRoot: string) => Promise<void>;
   selectedThreadIdRef: MutableRefObject<string | null>;

--- a/desktop/src/renderer/features/session/use-app-composer.ts
+++ b/desktop/src/renderer/features/session/use-app-composer.ts
@@ -11,6 +11,7 @@ type UseAppComposerParams = {
   currentRequestId: number | string | null;
   clearSelectedThread: () => Promise<void>;
   effectiveThreadBusy: boolean;
+  handleFastModeCommand: (prompt: string) => Promise<boolean>;
   queueTurnInput: (input: string) => Promise<void>;
   runTask: (request: {
     prompt: string;
@@ -34,6 +35,7 @@ export function useAppComposer({
   currentRequestId,
   clearSelectedThread,
   effectiveThreadBusy,
+  handleFastModeCommand,
   queueTurnInput,
   runTask,
   selectedThread,
@@ -69,6 +71,13 @@ export function useAppComposer({
   }
 
   async function submitSelectedThreadPrompt(threadPrompt: string) {
+    if (await handleFastModeCommand(threadPrompt)) {
+      setThreadPromptOverride("");
+      setAttachedFiles([]);
+      setTaskError(null);
+      return true;
+    }
+
     const request = buildSelectedThreadRunRequest({
       attachedFiles,
       selectedThread,
@@ -100,6 +109,13 @@ export function useAppComposer({
   }
 
   async function queueSelectedThreadPrompt(threadPrompt: string) {
+    if (await handleFastModeCommand(threadPrompt)) {
+      setThreadPromptOverride("");
+      setAttachedFiles([]);
+      setTaskError(null);
+      return true;
+    }
+
     const request = buildSelectedThreadRunRequest({
       attachedFiles,
       selectedThread,
@@ -130,7 +146,14 @@ export function useAppComposer({
     return true;
   }
 
-  function submitDraftTask() {
+  async function submitDraftTask() {
+    if (await handleFastModeCommand(draftPrompt)) {
+      setDraftPrompt("");
+      setAttachedFiles([]);
+      setTaskError(null);
+      return;
+    }
+
     const request = buildDraftRunRequest({
       attachedFiles,
       draftPrompt,
@@ -149,7 +172,7 @@ export function useAppComposer({
     requestAnimationFrame(() => {
       transcriptEndRef.current?.scrollIntoView({ behavior: "smooth" });
     });
-    void runTask(request);
+    await runTask(request);
   }
 
   return {

--- a/desktop/src/renderer/features/settings/use-app-model-settings.ts
+++ b/desktop/src/renderer/features/settings/use-app-model-settings.ts
@@ -21,15 +21,18 @@ export const REASONING_LABELS: Record<string, string> = {
 type SaveSettings = (patch: {
   model?: string;
   reasoningEffort?: string;
+  serviceTier?: "flex" | "fast";
 }) => Promise<unknown>;
 
 type UseAppModelSettingsParams = {
   availableModels: DesktopModelEntry[];
   model: string;
   reasoning: string;
+  serviceTier: "flex" | "fast";
   selectedThreadId: string | null;
   setModel: Dispatch<SetStateAction<string>>;
   setReasoning: Dispatch<SetStateAction<string>>;
+  setServiceTier: Dispatch<SetStateAction<"flex" | "fast">>;
   settingsData: DesktopSettings | null;
   saveSettings: SaveSettings;
 };
@@ -38,9 +41,11 @@ export function useAppModelSettings({
   availableModels,
   model,
   reasoning,
+  serviceTier,
   selectedThreadId,
   setModel,
   setReasoning,
+  setServiceTier,
   settingsData,
   saveSettings,
 }: UseAppModelSettingsParams) {
@@ -83,11 +88,22 @@ export function useAppModelSettings({
         modelId: settingsModel,
         requestedReasoning: settingsData?.reasoningEffort ?? selectedReasoning,
       });
+  const selectedServiceTier: "flex" | "fast" = serviceTier === "fast" ? "fast" : "flex";
+  const settingsServiceTier: "flex" | "fast" = settingsData?.serviceTier === "fast" ? "fast" : "flex";
 
   const prevModelRef = useRef(selectedModel);
   const prevReasoningRef = useRef(selectedReasoning);
+  const prevServiceTierRef = useRef(selectedServiceTier);
   const [configNotices, setConfigNotices] = useState<Array<{ id: number; text: string }>>([]);
   const configNoticeIdRef = useRef(0);
+
+  function pushConfigNotice(text: string) {
+    const id = ++configNoticeIdRef.current;
+    setConfigNotices((current) => [...current, { id, text }]);
+    setTimeout(() => {
+      setConfigNotices((current) => current.filter((notice) => notice.id !== id));
+    }, 3000);
+  }
 
   useEffect(() => {
     if (availableModels.length === 0) {
@@ -115,11 +131,7 @@ export function useAppModelSettings({
     prevModelRef.current = selectedModel;
     if (prev && prev !== selectedModel) {
       const toLabel = availableModels.find((entry) => entry.id === selectedModel)?.name ?? selectedModel;
-      const id = ++configNoticeIdRef.current;
-      setConfigNotices((current) => [...current, { id, text: `Model changed to ${toLabel}` }]);
-      setTimeout(() => {
-        setConfigNotices((current) => current.filter((notice) => notice.id !== id));
-      }, 3000);
+      pushConfigNotice(`Model changed to ${toLabel}`);
     }
   }, [selectedModel, availableModels]);
 
@@ -128,13 +140,23 @@ export function useAppModelSettings({
     prevReasoningRef.current = selectedReasoning;
     if (prev && prev !== selectedReasoning) {
       const toLabel = REASONING_LABELS[selectedReasoning] ?? selectedReasoning;
-      const id = ++configNoticeIdRef.current;
-      setConfigNotices((current) => [...current, { id, text: `Reasoning effort changed to ${toLabel}` }]);
-      setTimeout(() => {
-        setConfigNotices((current) => current.filter((notice) => notice.id !== id));
-      }, 3000);
+      pushConfigNotice(`Reasoning effort changed to ${toLabel}`);
     }
   }, [selectedReasoning]);
+
+  useEffect(() => {
+    const prev = prevServiceTierRef.current;
+    prevServiceTierRef.current = selectedServiceTier;
+    if (!prev || prev === selectedServiceTier) {
+      return;
+    }
+
+    pushConfigNotice(
+      selectedServiceTier === "fast"
+        ? "Fast mode enabled"
+        : "Fast mode disabled",
+    );
+  }, [selectedServiceTier]);
 
   useEffect(() => {
     setConfigNotices([]);
@@ -166,17 +188,28 @@ export function useAppModelSettings({
     });
   }
 
+  function handleServiceTierSelection(nextServiceTier: "flex" | "fast") {
+    setServiceTier(nextServiceTier);
+    void saveSettings({
+      serviceTier: nextServiceTier,
+    });
+  }
+
   return {
     REASONING_LABELS,
     configNotices,
     handleModelSelection,
+    handleServiceTierSelection,
     modelOptions,
+    pushConfigNotice,
     reasoningOptions,
     saveSettingsModelSelection,
     selectedModel,
     selectedReasoning,
+    selectedServiceTier,
     settingsModel,
     settingsReasoning,
     settingsReasoningOptions,
+    settingsServiceTier,
   };
 }

--- a/desktop/src/renderer/features/settings/use-settings-controller.ts
+++ b/desktop/src/renderer/features/settings/use-settings-controller.ts
@@ -4,6 +4,7 @@ import type { DesktopSettings } from "../../../main/contracts";
 
 const DEFAULT_MODEL = "";
 const DEFAULT_REASONING_EFFORT = "";
+const DEFAULT_SERVICE_TIER = "flex";
 
 function sanitizeSettingsErrorMessage(message: string): string {
   return message
@@ -17,11 +18,13 @@ export function useSettingsController({
   selectedProfileId,
   setModel,
   setReasoning,
+  setServiceTier,
 }: {
   isSignedIn: boolean;
   selectedProfileId: string;
   setModel: (value: string) => void;
   setReasoning: (value: string) => void;
+  setServiceTier: (value: "flex" | "fast") => void;
 }) {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsData, setSettingsData] = useState<DesktopSettings | null>(null);
@@ -45,6 +48,7 @@ export function useSettingsController({
       setSettingsData(result.settings);
       setModel(result.settings.model);
       setReasoning(result.settings.reasoningEffort);
+      setServiceTier(result.settings.serviceTier);
     } catch {
       // Use the current visible state as a fallback.
     }
@@ -59,11 +63,12 @@ export function useSettingsController({
       setSettingsSection("general");
       setModel(DEFAULT_MODEL);
       setReasoning(DEFAULT_REASONING_EFFORT);
+      setServiceTier(DEFAULT_SERVICE_TIER);
       return;
     }
 
     void loadSettings();
-  }, [isSignedIn, selectedProfileId, setModel, setReasoning]);
+  }, [isSignedIn, selectedProfileId, setModel, setReasoning, setServiceTier]);
 
   useEffect(() => {
     if (!settingsError) {
@@ -95,6 +100,7 @@ export function useSettingsController({
         setSettingsData(result.settings);
         setModel(result.settings.model);
         setReasoning(result.settings.reasoningEffort);
+        setServiceTier(result.settings.serviceTier);
       }
     } catch (error) {
       const message = sanitizeSettingsErrorMessage(
@@ -108,6 +114,7 @@ export function useSettingsController({
           setSettingsData(result.settings);
           setModel(result.settings.model);
           setReasoning(result.settings.reasoningEffort);
+          setServiceTier(result.settings.serviceTier);
         }
       } catch {
         // Leave the current values visible if reload also fails.

--- a/desktop/src/renderer/use-desktop-session-state.ts
+++ b/desktop/src/renderer/use-desktop-session-state.ts
@@ -71,7 +71,15 @@ export {
   upsertThread,
 } from "./state/threads/thread-summary-state.js";
 
-export function useDesktopSessionState({ model, reasoningEffort }: { model: string; reasoningEffort: string }) {
+export function useDesktopSessionState({
+  model,
+  reasoningEffort,
+  serviceTier,
+}: {
+  model: string;
+  reasoningEffort: string;
+  serviceTier: "flex" | "fast";
+}) {
   const [threads, setThreads] = useState<ThreadRecord[]>([]);
   const [activeTurnIdsByThread, setActiveTurnIdsByThread] = useState<Record<string, string>>({});
   const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
@@ -330,6 +338,7 @@ export function useDesktopSessionState({ model, reasoningEffort }: { model: stri
     rememberKnownThreadIds,
     requireDesktopBridge,
     reasoningEffort,
+    serviceTier,
     removeThreadFromLocalState,
     removeWorkspaceFromLocalState,
     selectedThreadIdRef,

--- a/desktop/src/shared/contracts/events.ts
+++ b/desktop/src/shared/contracts/events.ts
@@ -45,6 +45,7 @@ export interface DesktopTaskRunRequest {
   readonly model?: string;
   readonly personality?: string;
   readonly reasoningEffort?: string;
+  readonly serviceTier?: "flex" | "fast";
   readonly attachments?: string[];
   readonly inputItems?: DesktopAppServerInputItem[];
   readonly runContext?: DesktopRunContext | null;

--- a/desktop/src/shared/contracts/settings.ts
+++ b/desktop/src/shared/contracts/settings.ts
@@ -1,6 +1,7 @@
 export interface DesktopSettings {
   readonly model: string;
   readonly reasoningEffort: string;
+  readonly serviceTier: "flex" | "fast";
   readonly personality: "none" | "friendly" | "pragmatic";
   readonly defaultOperatingMode: "preview" | "auto" | "apply";
   readonly runtimeInstructions: string;


### PR DESCRIPTION
## Summary

This adds a desktop equivalent of Codex fast mode so people can opt into the fast service tier before they launch a run. The setting is persistent, visible from both the start surface and the active thread composer, and forwarded through the runtime request contract as `service_tier`.

## What changed

- persist a desktop `serviceTier` setting and expose it through the shared settings contracts
- add `/fast on`, `/fast off`, and `/fast status` parsing plus a suggestion row in the composer
- show fast-mode controls in the start surface, thread view, and general settings so the current tier is obvious
- pass the selected tier through live runtime request construction and session actions
- add unit coverage around command parsing, settings persistence, runtime request shaping, and session actions

## Validation

- `node scripts/check-public-boundary.mjs`
- `pnpm --dir desktop typecheck`
- `pnpm --dir desktop test:unit`
- `pnpm --dir desktop check:structure`
- `pnpm --dir desktop build`
- Electron Playwright smoke covering `/fast` suggestions and visible fast-mode UI state

## Issues

Fixes #18
