### PR TITLE
[codex] stop shortcut tokens leaking into transcript UI

### DIFF
--- a/desktop/src/main/session/desktop-prompt-shortcuts.test.js
+++ b/desktop/src/main/session/desktop-prompt-shortcuts.test.js
@@ -352,6 +352,29 @@ test("resolvePromptShortcutSuggestions prefers fully qualified names when local 
   );
 });
 
+test("resolvePromptShortcutSuggestions prefers human app aliases over connector ids when they stay unique", () => {
+  const overview = {
+    apps: [
+      {
+        id: "connector_outlook_email",
+        name: "Outlook Email",
+        description: "Mailbox access",
+        installUrl: null,
+        isAccessible: true,
+        isEnabled: true,
+        pluginDisplayNames: [],
+      },
+    ],
+    plugins: [],
+    skills: [],
+  };
+
+  assert.deepEqual(
+    resolvePromptShortcutSuggestions("$out", overview).map((entry) => `${entry.kind}:${entry.token}`),
+    ["app:outlook-email"],
+  );
+});
+
 test("replaceActivePromptShortcut inserts the chosen token at the active cursor position", () => {
   assert.deepEqual(
     resolveActivePromptShortcutQuery("Use $exc for this", 8),

--- a/desktop/src/main/substrate/thread-title-summarizer.js
+++ b/desktop/src/main/substrate/thread-title-summarizer.js
@@ -40,8 +40,8 @@ function trimStoredText(value, maxLength = 400) {
 
 function stripSkillMentions(value) {
   return normalizeWhitespace(value)
-    .replace(/\[[^\]]*?\$[A-Za-z0-9_-]+[^\]]*?\]\([^)]+\)/g, " ")
-    .replace(/\$[A-Za-z0-9_-]+\b/g, " ");
+    .replace(/\[[^\]]*?\$[A-Za-z0-9:_-]+[^\]]*?\]\([^)]+\)/g, " ")
+    .replace(/\$[A-Za-z0-9:_-]+\b/g, " ");
 }
 
 function firstSentence(value) {
@@ -60,6 +60,7 @@ function stripPromptScaffolding(value) {
   next = next.replace(/\b(?:in|inside)\s+(?:this|the selected|the current|an? empty)\s+workspace\b/ig, "");
   next = next.replace(/\bwithout a folder\b/ig, "");
   next = next.replace(/\bfor me\b/ig, "");
+  next = next.replace(/\b(?:in|with|via|through|using|from|on)\s*(?:[.!?]+)?$/i, "");
   return normalizeWhitespace(next)
     .replace(/^[^A-Za-z0-9]+/, "")
     .replace(/[.!?]+$/, "");

--- a/desktop/src/main/substrate/thread-title-summarizer.test.js
+++ b/desktop/src/main/substrate/thread-title-summarizer.test.js
@@ -1,0 +1,13 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { summarizeEarlyConversationThreadTitle } from "./thread-title-summarizer.js";
+
+test("summarizeEarlyConversationThreadTitle strips namespaced skill tokens from prompt-derived titles", () => {
+  assert.equal(
+    summarizeEarlyConversationThreadTitle({
+      userText: "any important emails in $gmail:gmail ?",
+    }),
+    "Any important emails",
+  );
+});

--- a/desktop/src/renderer/components/ThreadView.tsx
+++ b/desktop/src/renderer/components/ThreadView.tsx
@@ -126,6 +126,7 @@ export function ThreadView(props: ThreadViewProps) {
         clarificationPending={clarificationPending}
         configNotices={configNotices}
         effectiveThreadBusy={effectiveThreadBusy}
+        extensionOverview={extensionOverview}
         footerStatusText={footerStatusText}
         grantWorkspacePermission={grantWorkspacePermission}
         hasStructuredQuestions={hasStructuredQuestions}

--- a/desktop/src/renderer/components/thread-view/thread-entry-list.tsx
+++ b/desktop/src/renderer/components/thread-view/thread-entry-list.tsx
@@ -2,6 +2,7 @@ import { memo, useRef, useState } from "react";
 import { Check, ChevronRight, Copy } from "lucide-react";
 
 import { ThreadMarkdown } from "../../thread-markdown.js";
+import { ShortcutPillRow } from "../composer/shortcut-pill-row.js";
 import {
   coerceDisplayText,
   firstLinePreview,
@@ -14,9 +15,12 @@ import { type DesktopThreadEntry } from "../../lib/live-thread-data.js";
 import { getFileIcon, getFileLabel } from "../../lib/file-icons";
 import { resolveWorkspaceFilePath } from "../right-rail/RightRailSection";
 import { useStreamingEntryBody } from "../../state/session/session-stream-live-bodies.ts";
+import type { DesktopExtensionOverviewResult } from "../../../main/contracts";
+import { stripResolvedPromptShortcutText } from "../../../shared/prompt-shortcuts.ts";
 
 type ThreadEntryListProps = {
   entries: DesktopThreadEntry[];
+  extensionOverview: Pick<DesktopExtensionOverviewResult, "apps" | "plugins" | "skills"> | null;
   suppressFileChanges?: boolean;
   threadId: string;
   workspaceRoot: string | null;
@@ -71,11 +75,13 @@ function EntryCopyButton({ text }: { text: string }) {
 }
 
 function ActivityGroupCard({
+  extensionOverview,
   group,
   suppressFileChanges = false,
   threadId,
   workspaceRoot,
 }: {
+  extensionOverview: Pick<DesktopExtensionOverviewResult, "apps" | "plugins" | "skills"> | null;
   group: Extract<ThreadGroupedEntry, { kind: "activity-group" }>;
   suppressFileChanges?: boolean;
   threadId: string;
@@ -113,7 +119,13 @@ function ActivityGroupCard({
         </summary>
         <div className="mt-1.5 space-y-0.5 pl-5">
           {visibleEntries.map((entry) => (
-            <ThreadEntryCard entry={entry} key={entry.id} threadId={threadId} workspaceRoot={workspaceRoot} />
+            <ThreadEntryCard
+              entry={entry}
+              extensionOverview={extensionOverview}
+              key={entry.id}
+              threadId={threadId}
+              workspaceRoot={workspaceRoot}
+            />
           ))}
         </div>
       </details>
@@ -123,10 +135,12 @@ function ActivityGroupCard({
 
 const ThreadEntryCard = memo(function ThreadEntryCard({
   entry,
+  extensionOverview,
   threadId,
   workspaceRoot,
 }: {
   entry: DesktopThreadEntry;
+  extensionOverview: Pick<DesktopExtensionOverviewResult, "apps" | "plugins" | "skills"> | null;
   threadId: string;
   workspaceRoot: string | null;
 }) {
@@ -137,12 +151,16 @@ const ThreadEntryCard = memo(function ThreadEntryCard({
       : "body" in entry
         ? coerceDisplayText(entry.body)
         : "";
+  const visibleUserBody = entry.kind === "user" && extensionOverview
+    ? stripResolvedPromptShortcutText(entryBody, extensionOverview)
+    : entryBody;
 
   if (entry.kind === "user") {
     return (
       <article className="ml-auto w-full max-w-[78%] rounded-xl bg-[color-mix(in_oklch,var(--color-ink)_5%,white)] px-3 py-2 text-[0.8125rem]">
+        <ShortcutPillRow className="mb-2" overview={extensionOverview} prompt={entryBody} />
         <ThreadMarkdown className="thread-markdown-user" workspaceRoot={workspaceRoot}>
-          {entryBody}
+          {visibleUserBody}
         </ThreadMarkdown>
       </article>
     );
@@ -318,6 +336,7 @@ const ThreadEntryCard = memo(function ThreadEntryCard({
 
 function ThreadEntryListInner({
   entries,
+  extensionOverview,
   suppressFileChanges = false,
   threadId,
   workspaceRoot,
@@ -336,9 +355,18 @@ function ThreadEntryListInner({
     <>
       {groupedEntries.map((grouped) =>
         grouped.kind === "passthrough" ? (
-          grouped.entry.kind === "fileChange" && suppressFileChanges ? null : <ThreadEntryCard entry={grouped.entry} key={grouped.entry.id} threadId={threadId} workspaceRoot={workspaceRoot} />
+          grouped.entry.kind === "fileChange" && suppressFileChanges
+            ? null
+            : <ThreadEntryCard entry={grouped.entry} extensionOverview={extensionOverview} key={grouped.entry.id} threadId={threadId} workspaceRoot={workspaceRoot} />
         ) : (
-          <ActivityGroupCard key={grouped.id} group={grouped} suppressFileChanges={suppressFileChanges} threadId={threadId} workspaceRoot={workspaceRoot} />
+          <ActivityGroupCard
+            extensionOverview={extensionOverview}
+            group={grouped}
+            key={grouped.id}
+            suppressFileChanges={suppressFileChanges}
+            threadId={threadId}
+            workspaceRoot={workspaceRoot}
+          />
         ),
       )}
     </>

--- a/desktop/src/renderer/components/thread-view/thread-transcript.tsx
+++ b/desktop/src/renderer/components/thread-view/thread-transcript.tsx
@@ -8,10 +8,11 @@ import { ThreadClarificationPanel } from "./thread-clarification-panel.js";
 import { shouldShowReviewArtifacts } from "./thread-transcript-visibility.js";
 import { summarizeCommand } from "./thread-view-utils.js";
 import { perfCount } from "../../lib/perf-debug.ts";
-import { type DesktopApprovalDecision, type DesktopApprovalEvent, type DesktopInputQuestion, type DesktopInputRequestState, type DesktopThreadChangeGroup, type DesktopThreadEntry, type DesktopThreadSnapshot } from "../../../main/contracts";
+import { type DesktopApprovalDecision, type DesktopApprovalEvent, type DesktopExtensionOverviewResult, type DesktopInputQuestion, type DesktopInputRequestState, type DesktopThreadChangeGroup, type DesktopThreadEntry, type DesktopThreadSnapshot } from "../../../main/contracts";
 
 type ThreadTranscriptProps = {
   selectedThread: DesktopThreadSnapshot;
+  extensionOverview: Pick<DesktopExtensionOverviewResult, "apps" | "plugins" | "skills"> | null;
   threadInteractionState: string | null;
   selectedThreadApprovals: DesktopApprovalEvent[];
   respondToApproval: (approval: DesktopApprovalEvent, decision: DesktopApprovalDecision) => Promise<void>;
@@ -177,6 +178,7 @@ function StatusFooter({
 
 export function ThreadTranscript({
   selectedThread,
+  extensionOverview,
   threadInteractionState,
   selectedThreadApprovals,
   respondToApproval,
@@ -236,6 +238,7 @@ export function ThreadTranscript({
           {selectedThread.entries.length > 0 ? (
             <ThreadEntryList
               entries={selectedThread.entries}
+              extensionOverview={extensionOverview}
               suppressFileChanges={hasReviewArtifacts}
               threadId={selectedThread.id}
               workspaceRoot={threadFolderRoot}

--- a/desktop/src/shared/prompt-shortcuts.test.js
+++ b/desktop/src/shared/prompt-shortcuts.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { stripResolvedPromptShortcutText } from "./prompt-shortcuts.ts";
+import { resolvePromptShortcutSuggestions, stripResolvedPromptShortcutText } from "./prompt-shortcuts.ts";
 
 function createOverview() {
   return {
@@ -41,5 +41,47 @@ test("stripResolvedPromptShortcutText removes resolved app tokens but leaves unr
   assert.equal(
     stripResolvedPromptShortcutText("Ask $outlook-email and explain $PATH lookup.", createOverview()),
     "Ask and explain $PATH lookup.",
+  );
+});
+
+test("stripResolvedPromptShortcutText removes resolved tokens case-insensitively", () => {
+  assert.equal(
+    stripResolvedPromptShortcutText("Any important emails in $GMAIL:GMAIL ?", createOverview()),
+    "Any important emails?",
+  );
+});
+
+test("resolvePromptShortcutSuggestions falls back to unique app ids when human aliases collide", () => {
+  const overview = {
+    apps: [
+      {
+        id: "connector_outlook_email",
+        name: "Outlook Email",
+        description: "Primary mailbox",
+        installUrl: null,
+        isAccessible: true,
+        isEnabled: true,
+        pluginDisplayNames: [],
+      },
+      {
+        id: "connector_outlook_email_v2",
+        name: "Outlook Email",
+        description: "Shared mailbox",
+        installUrl: null,
+        isAccessible: true,
+        isEnabled: true,
+        pluginDisplayNames: [],
+      },
+    ],
+    plugins: [],
+    skills: [],
+  };
+
+  assert.deepEqual(
+    resolvePromptShortcutSuggestions("$out", overview).map((entry) => `${entry.label}:${entry.token}`),
+    [
+      "Outlook Email:connector_outlook_email",
+      "Outlook Email:connector_outlook_email_v2",
+    ],
   );
 });

--- a/desktop/src/shared/prompt-shortcuts.test.js
+++ b/desktop/src/shared/prompt-shortcuts.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { stripResolvedPromptShortcutText } from "./prompt-shortcuts.ts";
+
+function createOverview() {
+  return {
+    apps: [
+      {
+        id: "connector_outlook_email",
+        name: "Outlook Email",
+        description: null,
+        installUrl: null,
+        isAccessible: true,
+        isEnabled: true,
+        pluginDisplayNames: [],
+      },
+    ],
+    plugins: [],
+    skills: [
+      {
+        name: "gmail:gmail",
+        description: null,
+        path: "/Users/george/.codex/plugins/gmail/skills/gmail/SKILL.md",
+        scope: "plugin",
+        enabled: true,
+        cwd: null,
+      },
+    ],
+  };
+}
+
+test("stripResolvedPromptShortcutText removes resolved namespaced skill tokens from display copy", () => {
+  assert.equal(
+    stripResolvedPromptShortcutText("any important emails in $gmail:gmail ?", createOverview()),
+    "any important emails?",
+  );
+});
+
+test("stripResolvedPromptShortcutText removes resolved app tokens but leaves unresolved env-style text alone", () => {
+  assert.equal(
+    stripResolvedPromptShortcutText("Ask $outlook-email and explain $PATH lookup.", createOverview()),
+    "Ask and explain $PATH lookup.",
+  );
+});

--- a/desktop/src/shared/prompt-shortcuts.ts
+++ b/desktop/src/shared/prompt-shortcuts.ts
@@ -22,6 +22,10 @@ export type DesktopActivePromptShortcutQuery = {
   readonly end: number;
 };
 
+function escapeShortcutRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function firstString(...values: Array<unknown>): string | null {
   for (const value of values) {
     if (typeof value !== "string") {
@@ -312,6 +316,11 @@ function chooseSuggestionAppToken(
   app: DesktopAppRecord,
   overview: Pick<DesktopExtensionOverviewResult, "apps" | "plugins" | "skills">,
 ): string | null {
+  const preferredToken = chooseAppToken(app);
+  if (preferredToken && resolveShortcutTargetKind(preferredToken, overview) === "app") {
+    return preferredToken;
+  }
+
   for (const alias of buildAppAliasKeys(app)) {
     if (resolveShortcutTargetKind(alias, overview) === "app") {
       return alias;
@@ -511,6 +520,34 @@ export function resolvePromptShortcutMatches(
   }
 
   return matches;
+}
+
+export function stripResolvedPromptShortcutText(
+  prompt: string,
+  overview: Pick<DesktopExtensionOverviewResult, "apps" | "plugins" | "skills">,
+): string {
+  if (typeof prompt !== "string" || !prompt.includes("$")) {
+    return prompt;
+  }
+
+  const matches = resolvePromptShortcutMatches(prompt, overview);
+  if (matches.length === 0) {
+    return prompt;
+  }
+
+  let nextPrompt = prompt;
+  for (const token of new Set(matches.map((match) => match.token))) {
+    const matcher = new RegExp(`(^|[^A-Za-z0-9_])\\$${escapeShortcutRegex(token)}(?=$|[^A-Za-z0-9:_-])`, "gu");
+    nextPrompt = nextPrompt.replace(matcher, "$1");
+  }
+
+  return nextPrompt
+    .replace(/\b(?:in|with|via|through|using|from|on)\s+([,.!?;:]|$)/gi, "$1")
+    .replace(/\s+([,.!?;:])/g, "$1")
+    .replace(/([([{])\s+/g, "$1")
+    .replace(/\s+([)\]}])/g, "$1")
+    .replace(/\s{2,}/g, " ")
+    .trim();
 }
 
 export function resolvePromptShortcutSuggestions(

--- a/desktop/src/shared/prompt-shortcuts.ts
+++ b/desktop/src/shared/prompt-shortcuts.ts
@@ -243,10 +243,11 @@ function resolveAppShortcut(token: string, apps: DesktopAppRecord[]): DesktopApp
     return null;
   }
 
-  return apps.find((app) =>
+  const matches = apps.filter((app) =>
     app.isEnabled
     && app.isAccessible
-    && buildAppAliasKeys(app).includes(normalizedToken)) ?? null;
+    && buildAppAliasKeys(app).includes(normalizedToken));
+  return matches.length === 1 ? matches[0] : null;
 }
 
 function buildSkillLabel(skill: DesktopSkillRecord): string {
@@ -317,12 +318,19 @@ function chooseSuggestionAppToken(
   overview: Pick<DesktopExtensionOverviewResult, "apps" | "plugins" | "skills">,
 ): string | null {
   const preferredToken = chooseAppToken(app);
-  if (preferredToken && resolveShortcutTargetKind(preferredToken, overview) === "app") {
+  if (
+    preferredToken
+    && resolveShortcutTargetKind(preferredToken, overview) === "app"
+    && resolveAppShortcut(preferredToken, overview.apps)?.id === app.id
+  ) {
     return preferredToken;
   }
 
   for (const alias of buildAppAliasKeys(app)) {
-    if (resolveShortcutTargetKind(alias, overview) === "app") {
+    if (
+      resolveShortcutTargetKind(alias, overview) === "app"
+      && resolveAppShortcut(alias, overview.apps)?.id === app.id
+    ) {
       return alias;
     }
   }
@@ -537,7 +545,7 @@ export function stripResolvedPromptShortcutText(
 
   let nextPrompt = prompt;
   for (const token of new Set(matches.map((match) => match.token))) {
-    const matcher = new RegExp(`(^|[^A-Za-z0-9_])\\$${escapeShortcutRegex(token)}(?=$|[^A-Za-z0-9:_-])`, "gu");
+    const matcher = new RegExp(`(^|[^A-Za-z0-9_])\\$${escapeShortcutRegex(token)}(?=$|[^A-Za-z0-9:_-])`, "giu");
     nextPrompt = nextPrompt.replace(matcher, "$1");
   }
 


### PR DESCRIPTION
## Summary

This stops shortcut syntax from leaking into places people treat as normal conversation. User messages still carry the raw shortcut token for runtime resolution, but the desktop transcript now strips the token from visible message text, renders a dedicated pill for the resolved skill or app, and keeps thread title generation from reusing those raw identifiers.

## What changed

- prefer human-readable shortcut labels when building resolved shortcut metadata, including app aliases when they are unambiguous
- render shortcut pills in the transcript while keeping the raw `$token` out of the visible user message body
- strip namespaced skill tokens from thread-title summarization so generated titles reflect the task instead of the invocation syntax
- add focused coverage for prompt shortcut resolution and title sanitization

## Validation

- `node scripts/check-public-boundary.mjs`
- `pnpm --dir desktop typecheck`
- `pnpm --dir desktop test:unit`
- `pnpm --dir desktop check:structure`
- `pnpm --dir desktop build`

## Issues

Fixes #17
Fixes #22
