### PR TITLE
[codex] keep home launch menus above workspace cards

### DIFF
--- a/desktop/src/renderer/components/start-surface/StartSurfaceCollectionsPanel.tsx
+++ b/desktop/src/renderer/components/start-surface/StartSurfaceCollectionsPanel.tsx
@@ -83,7 +83,7 @@ export function StartSurfaceCollectionsPanel(props: StartSurfaceCollectionsPanel
   } = props;
 
   return (
-    <div className="mx-auto mt-6 min-h-0 w-full max-w-3xl flex-1 space-y-5 overflow-y-auto pb-4">
+    <div className="relative z-0 mx-auto mt-6 min-h-0 w-full max-w-3xl flex-1 space-y-5 overflow-y-auto pb-4">
       {workInFolder && workspaceFolder ? null : workspaceThreadGroups.workspaces.length > 0 ? (
         <section>
           <p className="mb-2 text-xs font-semibold uppercase tracking-[0.11em] text-muted">Workspaces</p>

--- a/desktop/src/renderer/components/start-surface/StartSurfaceLaunchPanel.tsx
+++ b/desktop/src/renderer/components/start-surface/StartSurfaceLaunchPanel.tsx
@@ -240,7 +240,7 @@ export function StartSurfaceLaunchPanel(props: StartSurfaceLaunchPanelProps) {
         </article>
       ) : null}
 
-      <section className="relative mx-auto mt-8 w-full max-w-3xl shrink-0 rounded-2xl bg-white p-3 shadow-[0_14px_32px_rgba(10,15,20,0.06)]">
+      <section className="relative z-20 isolate mx-auto mt-8 w-full max-w-3xl shrink-0 rounded-2xl bg-white p-3 shadow-[0_14px_32px_rgba(10,15,20,0.06)]">
         {taskError ? <p className="mb-3 rounded-xl bg-surface-soft px-3 py-2 text-sm text-ink-soft" role="alert">{taskError}</p> : null}
         {!(workInFolder && workspaceFolder) ? (
           <div className="mb-3 flex flex-wrap gap-2">
@@ -249,7 +249,7 @@ export function StartSurfaceLaunchPanel(props: StartSurfaceLaunchPanelProps) {
           </div>
         ) : null}
         {visibleShortcutSuggestions.length > 0 ? (
-          <div className="mb-3">
+          <div className="relative z-30 mb-3">
             <ShortcutSuggestionMenu
               activeIndex={shortcutSelectionIndex}
               onSelect={(suggestion) => applyShortcutSuggestion(suggestion.token)}


### PR DESCRIPTION
## Summary

This fixes the home-surface stacking bug that let the plugins and skills selector render underneath workspace folder cards. The selector now stays in the intended overlay layer without changing the surrounding layout structure.

## What changed

- align the launch panel and collections panel stacking context so the selector stays above workspace cards
- keep the existing home-surface layout intact while correcting the overlay order

## Validation

- `node scripts/check-public-boundary.mjs`
- `pnpm --dir desktop typecheck`
- `pnpm --dir desktop test:unit`
- `pnpm --dir desktop check:structure`
- `pnpm --dir desktop build`

## Issues

Fixes #21
