### PR TITLE
[codex] filter fake workspace roots from session history

### DIFF
--- a/desktop/src/main/bootstrap/bootstrap-threads.js
+++ b/desktop/src/main/bootstrap/bootstrap-threads.js
@@ -11,6 +11,7 @@ import {
 } from "../substrate/substrate-reader.js";
 import { getSubstrateSessionByThreadId } from "../substrate/substrate.js";
 import { asRecord, firstString } from "./bootstrap-shared.js";
+import { normalizeUserFacingWorkspaceRoot } from "../../shared/workspace-roots.ts";
 
 const THREAD_READ_SUMMARY_PARAMS = {
   includeTurns: false,
@@ -125,12 +126,12 @@ async function loadThreadWorkspaceRootFromSubstrate(profileId, threadId, env = p
     });
     const workspaceRoot = firstString(workspace?.root_path);
     if (workspaceRoot) {
-      return path.resolve(workspaceRoot);
+      return normalizeUserFacingWorkspaceRoot(path.resolve(workspaceRoot));
     }
   }
 
   const metadataWorkspaceRoot = firstString(session.metadata?.workspaceRoot);
-  return metadataWorkspaceRoot ? path.resolve(metadataWorkspaceRoot) : null;
+  return metadataWorkspaceRoot ? normalizeUserFacingWorkspaceRoot(path.resolve(metadataWorkspaceRoot)) : null;
 }
 
 export async function resolveThreadWorkspaceRoot(
@@ -148,7 +149,7 @@ export async function resolveThreadWorkspaceRoot(
   if (rememberedWorkspaceRoot) {
     try {
       await fs.access(rememberedWorkspaceRoot);
-      return path.resolve(rememberedWorkspaceRoot);
+      return normalizeUserFacingWorkspaceRoot(path.resolve(rememberedWorkspaceRoot));
     } catch {
       // Fall through to substrate-backed recovery when the remembered mount path has gone stale.
     }
@@ -272,7 +273,7 @@ export function normalizeRecentThreads(
       entry?.last_updated_at,
       entry?.lastUpdatedAt,
     ) || new Date().toISOString();
-    const workspaceRoot = firstString(workspaceRootByThreadId[id]);
+    const workspaceRoot = normalizeUserFacingWorkspaceRoot(workspaceRootByThreadId[id]);
 
     return {
       id,
@@ -346,7 +347,7 @@ export function mergeRecentThreadMetadata(
         interactionState:
           firstString(selectedThread?.interactionState, nextThread.interactionState) || "conversation",
         updatedAt: firstString(selectedThread?.updatedAt, nextThread.updatedAt) || nextThread.updatedAt,
-        workspaceRoot: firstString(selectedThread?.workspaceRoot, nextThread.workspaceRoot),
+        workspaceRoot: normalizeUserFacingWorkspaceRoot(firstString(selectedThread?.workspaceRoot, nextThread.workspaceRoot)),
       };
     }
 
@@ -364,7 +365,7 @@ export function mergeRecentThreadMetadata(
       state: firstString(selectedThread.state) || "idle",
       interactionState: firstString(selectedThread.interactionState) || "conversation",
       updatedAt: firstString(selectedThread.updatedAt) || new Date().toISOString(),
-      workspaceRoot: firstString(selectedThread.workspaceRoot),
+      workspaceRoot: normalizeUserFacingWorkspaceRoot(selectedThread.workspaceRoot),
     });
   }
 
@@ -497,7 +498,7 @@ export async function loadRecentThreads(
         if (!threadId || session.status === "archived") {
           return null;
         }
-        const workspaceRoot = firstString(workspaceRootByThreadId[threadId]);
+        const workspaceRoot = normalizeUserFacingWorkspaceRoot(workspaceRootByThreadId[threadId]);
         return {
           id: threadId,
           title: firstString(session.title) || "Untitled thread",
@@ -535,7 +536,7 @@ export function buildSelectedThreadFallback(summary) {
   return {
     ...summary,
     updatedLabel: formatUpdatedLabel(summary.updatedAt),
-    workspaceRoot: firstString(summary.workspaceRoot),
+    workspaceRoot: normalizeUserFacingWorkspaceRoot(summary.workspaceRoot),
     entries: [],
     changeGroups: [],
     progressSummary: [],

--- a/desktop/src/main/bootstrap/bootstrap-threads.test.js
+++ b/desktop/src/main/bootstrap/bootstrap-threads.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { mergeSubstrateSessionsIntoRecentThreads } from "./bootstrap-threads.js";
+import { mergeSubstrateSessionsIntoRecentThreads, normalizeRecentThreads } from "./bootstrap-threads.js";
 
 test("mergeSubstrateSessionsIntoRecentThreads restores unseen substrate sessions with workspace roots", () => {
   const merged = mergeSubstrateSessionsIntoRecentThreads(
@@ -40,4 +40,25 @@ test("mergeSubstrateSessionsIntoRecentThreads restores unseen substrate sessions
   assert.equal(merged[0]?.id, "thread-substrate");
   assert.equal(merged[0]?.workspaceRoot, "/tmp/recovered-workspace");
   assert.equal(merged[0]?.subtitle, "recovered-workspace");
+});
+
+test("normalizeRecentThreads drops session artifact roots from bootstrap summaries", () => {
+  const normalized = normalizeRecentThreads(
+    {
+      data: [
+        {
+          id: "thread-chat-only",
+          title: "Chat only",
+          updated_at: "2026-04-09T09:00:00.000Z",
+          state: "idle",
+        },
+      ],
+    },
+    {
+      "thread-chat-only": "/Users/george/Sense-1 Workspace/sessions/sess_chat_only",
+    },
+  );
+
+  assert.equal(normalized[0]?.workspaceRoot, null);
+  assert.equal(normalized[0]?.interactionState, "conversation");
 });

--- a/desktop/src/renderer/features/workspace/use-workspace-collections.ts
+++ b/desktop/src/renderer/features/workspace/use-workspace-collections.ts
@@ -15,6 +15,7 @@ import {
   sortProjectedSessionsByContinuity,
   synthesizeProjectedWorkspaceFromSessions,
 } from "./workspace-continuity.js";
+import { normalizeUserFacingWorkspaceRoot } from "../../../shared/workspace-roots.ts";
 
 type WorkspaceCollectionsResult = {
   activeWorkspaceProjection: ProjectedWorkspaceRecord | null;
@@ -40,6 +41,7 @@ export function useWorkspaceCollections({
   selectedProfileId: string;
 }): WorkspaceCollectionsResult {
   perfCount("render.useWorkspaceCollections");
+  const resolvedActiveWorkspaceRoot = normalizeUserFacingWorkspaceRoot(activeWorkspaceRoot);
   const [projectedWorkspaces, setProjectedWorkspaces] = useState<ProjectedWorkspaceRecord[]>([]);
   const [knownWorkspaces, setKnownWorkspaces] = useState<SubstrateWorkspaceRecord[]>([]);
   const [archivedWorkspaces, setArchivedWorkspaces] = useState<SubstrateWorkspaceRecord[]>([]);
@@ -100,7 +102,7 @@ export function useWorkspaceCollections({
   }, [isSignedIn, selectedProfileId]);
 
   useEffect(() => {
-    if (!isSignedIn || !activeWorkspaceRoot) {
+    if (!isSignedIn || !resolvedActiveWorkspaceRoot) {
       activeWorkspaceRequestIdRef.current += 1;
       setActiveWorkspaceProjection(null);
       setWorkspaceSessions([]);
@@ -126,7 +128,7 @@ export function useWorkspaceCollections({
       try {
         const [wsResult, recentSessionResult, recentWorkspaceResult] = await Promise.all([
           bridge?.projections?.workspaceByRoot
-            ? bridge.projections.workspaceByRoot({ rootPath: activeWorkspaceRoot })
+            ? bridge.projections.workspaceByRoot({ rootPath: resolvedActiveWorkspaceRoot })
             : Promise.resolve({ workspace: null }),
           bridge?.substrate?.recentSessions
             ? bridge.substrate.recentSessions({ limit: 200 }) as Promise<{ sessions: SubstrateSessionRecord[] }>
@@ -139,7 +141,7 @@ export function useWorkspaceCollections({
           return;
         }
 
-        const fallbackWorkspaceRecord = findSubstrateWorkspaceByRoot(recentWorkspaceResult.workspaces, activeWorkspaceRoot);
+        const fallbackWorkspaceRecord = findSubstrateWorkspaceByRoot(recentWorkspaceResult.workspaces, resolvedActiveWorkspaceRoot);
         let workspace = wsResult.workspace ?? (
           fallbackWorkspaceRecord
             ? projectSubstrateWorkspaceToProjectedWorkspace(fallbackWorkspaceRecord)
@@ -162,7 +164,7 @@ export function useWorkspaceCollections({
           const fallbackSessions = (Array.isArray(recentSessionResult.sessions) ? recentSessionResult.sessions : [])
             .filter((session) => matchesWorkspaceSession(session, {
               workspaceId: workspace?.workspace_id ?? fallbackWorkspaceRecord?.id ?? null,
-              workspaceRoot: activeWorkspaceRoot,
+              workspaceRoot: resolvedActiveWorkspaceRoot,
             }))
             .map((session) => projectSubstrateSessionToProjectedSession(
               session,
@@ -173,7 +175,7 @@ export function useWorkspaceCollections({
         if (!workspace && sessions.length > 0) {
           workspace = synthesizeProjectedWorkspaceFromSessions({
             profileId: sessions[0]?.profile_id ?? selectedProfileId,
-            rootPath: activeWorkspaceRoot,
+            rootPath: resolvedActiveWorkspaceRoot,
             sessions,
           });
         }
@@ -195,7 +197,7 @@ export function useWorkspaceCollections({
     return () => {
       isActive = false;
     };
-  }, [activeWorkspaceRoot, isSignedIn, selectedProfileId]);
+  }, [isSignedIn, resolvedActiveWorkspaceRoot, selectedProfileId]);
 
   return {
     activeWorkspaceProjection,

--- a/desktop/src/renderer/features/workspace/workspace-continuity.js
+++ b/desktop/src/renderer/features/workspace/workspace-continuity.js
@@ -1,3 +1,5 @@
+import { normalizeUserFacingWorkspaceRoot } from "../../../shared/workspace-roots.ts";
+
 function firstString(...values) {
   for (const value of values) {
     if (typeof value !== "string") {
@@ -14,12 +16,7 @@ function firstString(...values) {
 }
 
 export function normalizeWorkspaceRoot(workspaceRoot) {
-  const resolvedWorkspaceRoot = firstString(workspaceRoot);
-  if (!resolvedWorkspaceRoot) {
-    return null;
-  }
-
-  return resolvedWorkspaceRoot.replace(/\\/g, "/").replace(/\/+$/, "");
+  return normalizeUserFacingWorkspaceRoot(firstString(workspaceRoot));
 }
 
 function toTimestamp(value) {
@@ -143,13 +140,18 @@ export function synthesizeProjectedWorkspaceFromSessions({
   sessions = [],
   workspaceId = null,
 }) {
+  const normalizedRootPath = normalizeWorkspaceRoot(rootPath);
+  if (!normalizedRootPath) {
+    return null;
+  }
+
   const orderedSessions = sortProjectedSessionsByContinuity(sessions);
   const latestSession = orderedSessions[0] ?? null;
   return {
-    workspace_id: firstString(workspaceId) ?? `workspace:${normalizeWorkspaceRoot(rootPath) ?? "unknown"}`,
+    workspace_id: firstString(workspaceId) ?? `workspace:${normalizedRootPath}`,
     profile_id: firstString(profileId, latestSession?.profile_id) ?? "",
     scope_id: "",
-    root_path: firstString(rootPath) ?? "",
+    root_path: normalizedRootPath,
     display_name: null,
     status: "active",
     archived_at: null,

--- a/desktop/src/renderer/features/workspace/workspace-continuity.test.js
+++ b/desktop/src/renderer/features/workspace/workspace-continuity.test.js
@@ -127,6 +127,24 @@ test("matchesWorkspaceSession falls back to metadata.workspaceRoot when projecti
   );
 });
 
+test("matchesWorkspaceSession ignores session artifact roots when recovering workspace continuity", () => {
+  assert.equal(
+    matchesWorkspaceSession(
+      {
+        workspace_id: null,
+        metadata: {
+          workspaceRoot: "/Users/george/Sense-1 Workspace/sessions/sess_chat_only",
+        },
+      },
+      {
+        workspaceId: null,
+        workspaceRoot: "/Users/george/Sense-1 Workspace/sessions/sess_chat_only",
+      },
+    ),
+    false,
+  );
+});
+
 test("projectSubstrateSessionToProjectedSession produces a resumable session shape for fallback UI history", () => {
   const projected = projectSubstrateSessionToProjectedSession(
     {
@@ -173,4 +191,23 @@ test("synthesizeProjectedWorkspaceFromSessions creates an active workspace shell
   assert.equal(workspace.last_session_id, "sess_alpha");
   assert.equal(workspace.last_thread_id, "thread_alpha");
   assert.equal(workspace.status, "active");
+});
+
+test("synthesizeProjectedWorkspaceFromSessions refuses to synthesize fake workspaces from session artifact roots", () => {
+  assert.equal(
+    synthesizeProjectedWorkspaceFromSessions({
+      profileId: "ops-team",
+      rootPath: "/Users/george/Sense-1 Workspace/sessions/sess_chat_only",
+      sessions: [
+        {
+          session_id: "sess_chat_only",
+          profile_id: "ops-team",
+          codex_thread_id: "thread_chat_only",
+          started_at: "2026-03-24T08:00:00Z",
+          last_activity_at: "2026-03-24T08:05:00Z",
+        },
+      ],
+    }),
+    null,
+  );
 });

--- a/desktop/src/renderer/features/workspace/workspace-sidebar.test.js
+++ b/desktop/src/renderer/features/workspace/workspace-sidebar.test.js
@@ -69,6 +69,24 @@ test("home view keeps workspace groups visible but collapsed by default", () => 
   );
 });
 
+test("session artifact roots stay in standalone threads instead of forming fake workspace groups", () => {
+  const result = buildWorkspaceSidebarGroups({
+    threads: [
+      {
+        id: "thread-chat",
+        title: "Chat only",
+        updatedAt: "2026-03-26T10:00:00.000Z",
+        workspaceRoot: "/Users/george/Sense-1 Workspace/sessions/sess_chat_only",
+      },
+    ],
+    savedOrder: [],
+    activeWorkspaceRoot: null,
+  });
+
+  assert.deepEqual(result.workspaces, []);
+  assert.deepEqual(result.standalone.map((thread) => thread.id), ["thread-chat"]);
+});
+
 test("workspace view keeps full workspace history visible while expanding the active workspace", () => {
   const result = buildWorkspaceSidebarGroups({
     threads: [

--- a/desktop/src/renderer/features/workspace/workspace-sidebar.ts
+++ b/desktop/src/renderer/features/workspace/workspace-sidebar.ts
@@ -1,4 +1,5 @@
 import type { DesktopThreadSnapshot } from "../../../main/contracts";
+import { normalizeUserFacingWorkspaceRoot } from "../../../shared/workspace-roots.ts";
 
 export type WorkspaceSidebarThread = {
   readonly id: string;
@@ -20,7 +21,7 @@ export function toWorkspaceSidebarThreadSummary(
     title: thread.title,
     updatedAt: thread.updatedAt,
     updatedLabel: thread.updatedLabel,
-    workspaceRoot: thread.workspaceRoot,
+    workspaceRoot: normalizeUserFacingWorkspaceRoot(thread.workspaceRoot),
     state: thread.state,
     threadInputState: thread.threadInputState,
   };
@@ -247,7 +248,7 @@ export function buildWorkspaceSidebarGroups<T extends WorkspaceSidebarThread>(pa
   const standalone: T[] = [];
 
   for (const thread of params.threads) {
-    const root = typeof thread.workspaceRoot === "string" ? thread.workspaceRoot.trim() : "";
+    const root = normalizeUserFacingWorkspaceRoot(thread.workspaceRoot) ?? "";
     if (!root) {
       standalone.push(thread);
       continue;

--- a/desktop/src/shared/workspace-roots.test.js
+++ b/desktop/src/shared/workspace-roots.test.js
@@ -19,6 +19,10 @@ test("isSessionArtifactWorkspaceRoot detects sense session artifact paths", () =
     isSessionArtifactWorkspaceRoot("/Users/george/projects/real-workspace"),
     false,
   );
+  assert.equal(
+    isSessionArtifactWorkspaceRoot("/repo/sessions/sess_migration"),
+    false,
+  );
 });
 
 test("normalizeUserFacingWorkspaceRoot drops session artifact roots but keeps real folders", () => {

--- a/desktop/src/shared/workspace-roots.test.js
+++ b/desktop/src/shared/workspace-roots.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  isSessionArtifactWorkspaceRoot,
+  normalizeUserFacingWorkspaceRoot,
+} from "./workspace-roots.ts";
+
+test("isSessionArtifactWorkspaceRoot detects sense session artifact paths", () => {
+  assert.equal(
+    isSessionArtifactWorkspaceRoot("/Users/george/Sense-1 Workspace/sessions/sess_1234"),
+    true,
+  );
+  assert.equal(
+    isSessionArtifactWorkspaceRoot("C:\\Users\\george\\Sense-1 Workspace\\sessions\\sess_1234"),
+    true,
+  );
+  assert.equal(
+    isSessionArtifactWorkspaceRoot("/Users/george/projects/real-workspace"),
+    false,
+  );
+});
+
+test("normalizeUserFacingWorkspaceRoot drops session artifact roots but keeps real folders", () => {
+  assert.equal(
+    normalizeUserFacingWorkspaceRoot("/Users/george/Sense-1 Workspace/sessions/sess_1234"),
+    null,
+  );
+  assert.equal(
+    normalizeUserFacingWorkspaceRoot("/Users/george/projects/real-workspace/"),
+    "/Users/george/projects/real-workspace",
+  );
+});

--- a/desktop/src/shared/workspace-roots.ts
+++ b/desktop/src/shared/workspace-roots.ts
@@ -13,6 +13,13 @@ function firstString(...values: Array<unknown>): string | null {
   return null;
 }
 
+const APP_ARTIFACT_ROOT_NAMES = [
+  "Sense-1 Workspace",
+  "sense-1-workspace",
+  "Sense-1",
+  "sense-1",
+];
+
 export function normalizeWorkspaceRootPath(workspaceRoot: string | null | undefined): string | null {
   const resolvedWorkspaceRoot = firstString(workspaceRoot);
   if (!resolvedWorkspaceRoot) {
@@ -28,7 +35,10 @@ export function isSessionArtifactWorkspaceRoot(workspaceRoot: string | null | un
     return false;
   }
 
-  return /(?:^|\/)sessions\/sess[_-][^/]+(?:\/|$)/i.test(normalizedWorkspaceRoot);
+  return APP_ARTIFACT_ROOT_NAMES.some((rootName) => {
+    const escapedRootName = rootName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return new RegExp(`(?:^|/)${escapedRootName}/sessions/sess[_-][^/]+(?:/|$)`, "i").test(normalizedWorkspaceRoot);
+  });
 }
 
 export function normalizeUserFacingWorkspaceRoot(workspaceRoot: string | null | undefined): string | null {

--- a/desktop/src/shared/workspace-roots.ts
+++ b/desktop/src/shared/workspace-roots.ts
@@ -1,0 +1,41 @@
+function firstString(...values: Array<unknown>): string | null {
+  for (const value of values) {
+    if (typeof value !== "string") {
+      continue;
+    }
+
+    const trimmed = value.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  return null;
+}
+
+export function normalizeWorkspaceRootPath(workspaceRoot: string | null | undefined): string | null {
+  const resolvedWorkspaceRoot = firstString(workspaceRoot);
+  if (!resolvedWorkspaceRoot) {
+    return null;
+  }
+
+  return resolvedWorkspaceRoot.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+export function isSessionArtifactWorkspaceRoot(workspaceRoot: string | null | undefined): boolean {
+  const normalizedWorkspaceRoot = normalizeWorkspaceRootPath(workspaceRoot);
+  if (!normalizedWorkspaceRoot) {
+    return false;
+  }
+
+  return /(?:^|\/)sessions\/sess[_-][^/]+(?:\/|$)/i.test(normalizedWorkspaceRoot);
+}
+
+export function normalizeUserFacingWorkspaceRoot(workspaceRoot: string | null | undefined): string | null {
+  const normalizedWorkspaceRoot = normalizeWorkspaceRootPath(workspaceRoot);
+  if (!normalizedWorkspaceRoot || isSessionArtifactWorkspaceRoot(normalizedWorkspaceRoot)) {
+    return null;
+  }
+
+  return normalizedWorkspaceRoot;
+}


### PR DESCRIPTION
## Summary

This prevents session artifact folders from showing up as fake workspaces in the desktop UI. Sense-1 now normalizes workspace roots once and drops `sessions/sess_*` artifact paths before bootstrap, continuity, and sidebar code can synthesize user-facing workspace entries from them.

## What changed

- add shared workspace-root normalization helpers with direct tests for session artifact detection
- filter fake artifact roots out of bootstrap recovery, workspace continuity, and sidebar session synthesis
- keep workspace collection loading aligned with the same root-normalization rules so the renderer and bootstrap path agree
- add regression coverage for recovered sessions and sidebar fallback state

## Validation

- `node scripts/check-public-boundary.mjs`
- `pnpm --dir desktop typecheck`
- `pnpm --dir desktop test:unit`
- `pnpm --dir desktop check:structure`
- `pnpm --dir desktop build`

## Issues

Fixes #23
