### PR TITLE
[codex] persist trusted skill approvals by profile

### DIFF
--- a/desktop/src/main/runtime/live-thread-runtime.d.ts
+++ b/desktop/src/main/runtime/live-thread-runtime.d.ts
@@ -108,6 +108,7 @@ export function describePolicyRules(settings?: Record<string, unknown> | null): 
 export function runDesktopTask(
   manager: AppServerProcessManager,
   request: DesktopTaskRunRequest & {
+    readonly onThreadReady?: ((threadId: string) => void | Promise<void>) | null;
     readonly personality?: string | null;
     readonly runtimeInstructions?: string | null;
     readonly settings?: Record<string, unknown> | null;

--- a/desktop/src/main/runtime/live-thread-runtime.js
+++ b/desktop/src/main/runtime/live-thread-runtime.js
@@ -191,6 +191,7 @@ export async function runDesktopTask(
     cwd,
     inputItems,
     model,
+    onThreadReady = null,
     personality,
     prompt,
     reasoningEffort,
@@ -254,6 +255,9 @@ export async function runDesktopTask(
   });
   thread = ensuredThread.thread;
   resolvedThreadId = ensuredThread.threadId;
+  if (typeof onThreadReady === "function") {
+    await onThreadReady(resolvedThreadId);
+  }
   const turnAttachments = (Array.isArray(attachments) ? attachments : [])
     .map((path) => firstString(path))
     .filter(Boolean);

--- a/desktop/src/main/session-controller.ts
+++ b/desktop/src/main/session-controller.ts
@@ -10,6 +10,8 @@ import {
 import { resolveSignedInDesktopProfile } from "./bootstrap/bootstrap-profile.js";
 import {
   DEFAULT_DESKTOP_SETTINGS,
+  applyDesktopSettingsPatch,
+  resolveDesktopSettings as resolveStoredDesktopSettings,
   type DesktopSettingsPatch,
 } from "./settings/desktop-settings.js";
 import type {
@@ -100,7 +102,12 @@ import { DesktopQueryService } from "./substrate/desktop-query-service.ts";
 import { DesktopAutomationService } from "./automation/desktop-automation-service.ts";
 import { DesktopTenantService } from "./tenant/desktop-tenant-service.ts";
 import { updateSubstrateSessionThreadTitle } from "./substrate/substrate.js";
-import { resolveProfileCodexHome, resolveProfileSubstrateDbPath } from "./profile/profile-state.js";
+import {
+  loadDesktopSettings,
+  persistDesktopSettings,
+  resolveProfileCodexHome,
+  resolveProfileSubstrateDbPath,
+} from "./profile/profile-state.js";
 import {
   type DesktopVoiceClient,
   DesktopRealtimeTranscriptionClient,
@@ -154,6 +161,7 @@ export class DesktopSessionController {
     workspaceFolderBinding: DEFAULT_DESKTOP_SETTINGS.workspaceFolderBinding,
     approvalOperationPosture: DEFAULT_DESKTOP_SETTINGS.approvalOperationPosture,
     approvalTrustedWorkspaces: DEFAULT_DESKTOP_SETTINGS.approvalTrustedWorkspaces,
+    trustedSkillApprovals: DEFAULT_DESKTOP_SETTINGS.trustedSkillApprovals,
   };
 
   readonly #manager: AppServerProcessManager;
@@ -263,8 +271,30 @@ export class DesktopSessionController {
         });
       },
       loadPersistedApprovals: async () => await this.#workspaceState.loadPendingApprovals(),
+      loadTrustedSkillApprovals: async () => {
+        const profile = await this.#resolveProfile();
+        const settings = resolveStoredDesktopSettings(
+          await loadDesktopSettings(profile.id, this.#env) as unknown as Record<string, unknown>,
+        );
+        return settings.trustedSkillApprovals;
+      },
       persistPendingApprovals: async (approvals) =>
         await this.#workspaceState.persistPendingApprovals(approvals),
+      persistTrustedSkillApprovals: async (approvals) => {
+        const profile = await this.#resolveProfile();
+        const saved = await loadDesktopSettings(profile.id, this.#env);
+        const nextTrustedSettings = applyDesktopSettingsPatch(
+          saved as unknown as Record<string, unknown>,
+          {
+            trustedSkillApprovals: approvals,
+          },
+        ) as unknown as Parameters<typeof persistDesktopSettings>[1];
+        await persistDesktopSettings(
+          profile.id,
+          nextTrustedSettings,
+          this.#env,
+        );
+      },
       queueApprovalEvent: (input) => {
         this.#substrateSync.enqueueWrite(async () => {
           await appendApprovalEventRecord({

--- a/desktop/src/main/session-controller.ts
+++ b/desktop/src/main/session-controller.ts
@@ -824,7 +824,11 @@ export class DesktopSessionController {
   }
 
   async updateDesktopSettings(partial: DesktopSettingsPatch): Promise<DesktopSettingsResult> {
-    return await this.#desktopSettings.updateDesktopSettings(partial);
+    const result = await this.#desktopSettings.updateDesktopSettings(partial);
+    if (Object.hasOwn(partial, "trustedSkillApprovals")) {
+      await this.#approvals.reloadTrustedSkillApprovals();
+    }
+    return result;
   }
 
   async getDesktopExtensionOverview(

--- a/desktop/src/main/session/desktop-approval-service.ts
+++ b/desktop/src/main/session/desktop-approval-service.ts
@@ -9,6 +9,7 @@ import type {
   DesktopTaskRunResult,
 } from "../contracts.ts";
 import { DesktopApprovalResolutionCache } from "./approval-resolution-cache.ts";
+import { commandMatchesSkillApprovalPath } from "../../shared/skill-approval-key.js";
 
 type RecordAuditEventInput = {
   details?: Record<string, unknown>;
@@ -34,7 +35,9 @@ type SyntheticApprovalState = {
 type DesktopApprovalServiceOptions = {
   appendApprovalEvent: (input: ApprovalEventRecord) => Promise<void>;
   loadPersistedApprovals: () => Promise<unknown[]>;
+  loadTrustedSkillApprovals: () => Promise<string[]>;
   persistPendingApprovals: (approvals: DesktopApprovalEvent[]) => Promise<void>;
+  persistTrustedSkillApprovals: (approvals: string[]) => Promise<void>;
   queueApprovalEvent: (input: ApprovalEventRecord) => void;
   recordAuditEvent: (input: RecordAuditEventInput) => void;
   rememberThreadInteractionState: (
@@ -87,7 +90,9 @@ function interactionStateForResolvedApproval(
 export class DesktopApprovalService {
   readonly #appendApprovalEvent: (input: ApprovalEventRecord) => Promise<void>;
   readonly #loadPersistedApprovals: () => Promise<unknown[]>;
+  readonly #loadTrustedSkillApprovals: () => Promise<string[]>;
   readonly #persistPendingApprovals: (approvals: DesktopApprovalEvent[]) => Promise<void>;
+  readonly #persistTrustedSkillApprovals: (approvals: string[]) => Promise<void>;
   readonly #queueApprovalEvent: (input: ApprovalEventRecord) => void;
   readonly #recordAuditEvent: (input: RecordAuditEventInput) => void;
   readonly #rememberThreadInteractionState: (
@@ -101,6 +106,8 @@ export class DesktopApprovalService {
   ) => void;
   readonly #pendingApprovalsById = new Map<number, DesktopApprovalEvent>();
   readonly #syntheticApprovalsById = new Map<number, SyntheticApprovalState>();
+  readonly #threadSkillApprovalsByThreadId = new Map<string, string[]>();
+  readonly #trustedSkillApprovals = new Set<string>();
   readonly #approvalResolutionCache = new DesktopApprovalResolutionCache();
   readonly #locallyResolvedRuntimeApprovalIds = new Set<number>();
   #approvalRestoreReady: Promise<void> = Promise.resolve();
@@ -109,7 +116,9 @@ export class DesktopApprovalService {
   constructor({
     appendApprovalEvent,
     loadPersistedApprovals,
+    loadTrustedSkillApprovals,
     persistPendingApprovals,
+    persistTrustedSkillApprovals,
     queueApprovalEvent,
     recordAuditEvent,
     rememberThreadInteractionState,
@@ -117,7 +126,9 @@ export class DesktopApprovalService {
   }: DesktopApprovalServiceOptions) {
     this.#appendApprovalEvent = appendApprovalEvent;
     this.#loadPersistedApprovals = loadPersistedApprovals;
+    this.#loadTrustedSkillApprovals = loadTrustedSkillApprovals;
     this.#persistPendingApprovals = persistPendingApprovals;
+    this.#persistTrustedSkillApprovals = persistTrustedSkillApprovals;
     this.#queueApprovalEvent = queueApprovalEvent;
     this.#recordAuditEvent = recordAuditEvent;
     this.#rememberThreadInteractionState = rememberThreadInteractionState;
@@ -142,6 +153,21 @@ export class DesktopApprovalService {
     return Array.from(this.#pendingApprovalsById.values());
   }
 
+  rememberThreadSkillApprovals(threadId: string, approvals: string[]): void {
+    const resolvedThreadId = typeof threadId === "string" ? threadId.trim() : "";
+    const resolvedApprovals = Array.isArray(approvals)
+      ? [...new Set(approvals.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0))]
+      : [];
+    if (!resolvedThreadId) {
+      return;
+    }
+    if (resolvedApprovals.length === 0) {
+      this.#threadSkillApprovalsByThreadId.delete(resolvedThreadId);
+      return;
+    }
+    this.#threadSkillApprovalsByThreadId.set(resolvedThreadId, resolvedApprovals);
+  }
+
   allocateSyntheticApprovalId(): number {
     const approvalId = this.#nextSyntheticApprovalId;
     this.#nextSyntheticApprovalId -= 1;
@@ -163,6 +189,10 @@ export class DesktopApprovalService {
     if (event.kind === "approvalRequested") {
       const approval = normalizeDesktopApprovalEvent(event.approval, fallbackRunContext);
       if (approval) {
+        if (this.#shouldAutoAcceptTrustedSkillApproval(approval)) {
+          void this.#autoAcceptTrustedSkillApproval(approval);
+          return true;
+        }
         this.#rememberPendingApproval(approval);
       }
       return true;
@@ -233,6 +263,9 @@ export class DesktopApprovalService {
       this.#respondRuntimeApproval(requestId, approval, decision);
 
       if (approval) {
+        if (decision === "acceptForSession") {
+          await this.#rememberTrustedSkillApprovals(approval.threadId);
+        }
         this.#recordAuditEvent({
           eventType: "run.approval.resolved",
           runContext: approval.runContext,
@@ -274,6 +307,8 @@ export class DesktopApprovalService {
   resetForProfileChange(): void {
     this.#pendingApprovalsById.clear();
     this.#syntheticApprovalsById.clear();
+    this.#threadSkillApprovalsByThreadId.clear();
+    this.#trustedSkillApprovals.clear();
     this.#approvalResolutionCache.clear();
     this.#locallyResolvedRuntimeApprovalIds.clear();
     this.#nextSyntheticApprovalId = -1;
@@ -282,6 +317,12 @@ export class DesktopApprovalService {
 
   async #restorePersistedApprovals(): Promise<void> {
     try {
+      const trustedApprovals = await this.#loadTrustedSkillApprovals();
+      for (const approval of trustedApprovals) {
+        if (typeof approval === "string" && approval.trim()) {
+          this.#trustedSkillApprovals.add(approval.trim());
+        }
+      }
       const saved = await this.#loadPersistedApprovals();
       for (const raw of saved) {
         const approval = raw as DesktopApprovalEvent;
@@ -297,6 +338,16 @@ export class DesktopApprovalService {
   async #persistApprovals(): Promise<void> {
     try {
       await this.#persistPendingApprovals(Array.from(this.#pendingApprovalsById.values()));
+    } catch {
+      // Non-fatal — best-effort durability.
+    }
+  }
+
+  async #persistTrustedApprovals(): Promise<void> {
+    try {
+      await this.#persistTrustedSkillApprovals(
+        [...this.#trustedSkillApprovals].sort((left, right) => left.localeCompare(right)),
+      );
     } catch {
       // Non-fatal — best-effort durability.
     }
@@ -372,5 +423,49 @@ export class DesktopApprovalService {
       requestId: approval.id,
       verb: approvalEventVerbForDecision(decision),
     });
+  }
+
+  #shouldAutoAcceptTrustedSkillApproval(approval: DesktopApprovalEvent): boolean {
+    if (approval.kind !== "command") {
+      return false;
+    }
+
+    const threadApprovals = this.#threadSkillApprovalsByThreadId.get(approval.threadId) ?? [];
+    return threadApprovals.length > 0
+      && threadApprovals.every((entry) => this.#trustedSkillApprovals.has(entry))
+      && threadApprovals.some((entry) => commandMatchesSkillApprovalPath(approval.command, entry));
+  }
+
+  async #rememberTrustedSkillApprovals(threadId: string): Promise<void> {
+    const threadApprovals = this.#threadSkillApprovalsByThreadId.get(threadId) ?? [];
+    if (threadApprovals.length === 0) {
+      return;
+    }
+
+    let changed = false;
+    for (const approval of threadApprovals) {
+      if (this.#trustedSkillApprovals.has(approval)) {
+        continue;
+      }
+      this.#trustedSkillApprovals.add(approval);
+      changed = true;
+    }
+
+    if (changed) {
+      await this.#persistTrustedApprovals();
+    }
+  }
+
+  async #autoAcceptTrustedSkillApproval(approval: DesktopApprovalEvent): Promise<void> {
+    this.#approvalResolutionCache.rememberResponse(approval, "acceptForSession");
+    this.#locallyResolvedRuntimeApprovalIds.add(approval.id);
+    try {
+      this.#respondRuntimeApproval(approval.id, approval, "acceptForSession");
+      await this.#resolveLocalApproval(approval, "acceptForSession", { persist: false });
+    } catch {
+      this.#locallyResolvedRuntimeApprovalIds.delete(approval.id);
+      this.#approvalResolutionCache.forget(approval.id);
+      this.#rememberPendingApproval(approval);
+    }
   }
 }

--- a/desktop/src/main/session/desktop-approval-service.ts
+++ b/desktop/src/main/session/desktop-approval-service.ts
@@ -149,6 +149,10 @@ export class DesktopApprovalService {
     return this.#approvalRestoreReady;
   }
 
+  async reloadTrustedSkillApprovals(): Promise<void> {
+    await this.#reloadTrustedSkillApprovals();
+  }
+
   listPendingApprovals(): DesktopApprovalEvent[] {
     return Array.from(this.#pendingApprovalsById.values());
   }
@@ -264,7 +268,7 @@ export class DesktopApprovalService {
 
       if (approval) {
         if (decision === "acceptForSession") {
-          await this.#rememberTrustedSkillApprovals(approval.threadId);
+          await this.#rememberTrustedSkillApprovalsForApproval(approval);
         }
         this.#recordAuditEvent({
           eventType: "run.approval.resolved",
@@ -317,12 +321,7 @@ export class DesktopApprovalService {
 
   async #restorePersistedApprovals(): Promise<void> {
     try {
-      const trustedApprovals = await this.#loadTrustedSkillApprovals();
-      for (const approval of trustedApprovals) {
-        if (typeof approval === "string" && approval.trim()) {
-          this.#trustedSkillApprovals.add(approval.trim());
-        }
-      }
+      await this.#reloadTrustedSkillApprovals();
       const saved = await this.#loadPersistedApprovals();
       for (const raw of saved) {
         const approval = raw as DesktopApprovalEvent;
@@ -350,6 +349,16 @@ export class DesktopApprovalService {
       );
     } catch {
       // Non-fatal — best-effort durability.
+    }
+  }
+
+  async #reloadTrustedSkillApprovals(): Promise<void> {
+    this.#trustedSkillApprovals.clear();
+    const trustedApprovals = await this.#loadTrustedSkillApprovals();
+    for (const approval of trustedApprovals) {
+      if (typeof approval === "string" && approval.trim()) {
+        this.#trustedSkillApprovals.add(approval.trim());
+      }
     }
   }
 
@@ -436,24 +445,33 @@ export class DesktopApprovalService {
       && threadApprovals.some((entry) => commandMatchesSkillApprovalPath(approval.command, entry));
   }
 
-  async #rememberTrustedSkillApprovals(threadId: string): Promise<void> {
-    const threadApprovals = this.#threadSkillApprovalsByThreadId.get(threadId) ?? [];
-    if (threadApprovals.length === 0) {
+  async #rememberTrustedSkillApprovalsForApproval(approval: DesktopApprovalEvent): Promise<void> {
+    const matchingApprovals = this.#matchingThreadSkillApprovalsForCommand(approval);
+    if (matchingApprovals.length === 0) {
       return;
     }
 
     let changed = false;
-    for (const approval of threadApprovals) {
-      if (this.#trustedSkillApprovals.has(approval)) {
+    for (const matchingApproval of matchingApprovals) {
+      if (this.#trustedSkillApprovals.has(matchingApproval)) {
         continue;
       }
-      this.#trustedSkillApprovals.add(approval);
+      this.#trustedSkillApprovals.add(matchingApproval);
       changed = true;
     }
 
     if (changed) {
       await this.#persistTrustedApprovals();
     }
+  }
+
+  #matchingThreadSkillApprovalsForCommand(approval: DesktopApprovalEvent): string[] {
+    if (approval.kind !== "command") {
+      return [];
+    }
+
+    const threadApprovals = this.#threadSkillApprovalsByThreadId.get(approval.threadId) ?? [];
+    return threadApprovals.filter((entry) => commandMatchesSkillApprovalPath(approval.command, entry));
   }
 
   async #autoAcceptTrustedSkillApproval(approval: DesktopApprovalEvent): Promise<void> {

--- a/desktop/src/main/session/desktop-run-start-service.ts
+++ b/desktop/src/main/session/desktop-run-start-service.ts
@@ -68,6 +68,7 @@ import { createPermissionRequiredResult } from "./desktop-run-start-results.ts";
 import { applyTenantMembershipToActor, resolveTenantMembershipForProfile } from "../tenant/tenant-state.ts";
 import type { DesktopExtensionService } from "../settings/desktop-extension-service.ts";
 import { extractPromptShortcutTokens, resolvePromptShortcutInputItems } from "./desktop-prompt-shortcuts.ts";
+import { collectSkillApprovalKeys } from "./skill-approval-state.ts";
 
 const PROFILE_CODEX_HOME_SHORTCUTS = new Set([
   "plugin-creator",
@@ -476,6 +477,7 @@ export class DesktopRunStartService {
           );
         }
       }
+      const skillApprovalKeys = await collectSkillApprovalKeys(inputItems);
       const profileCodexHomeShortcutNames = resolveProfileCodexHomeShortcutNames(inputItems);
       const shouldUseProfileCodexHomeCwd =
         [...profileCodexHomeShortcutNames].some((name) => PROFILE_CODEX_HOME_CWD_SHORTCUTS.has(name));
@@ -507,6 +509,9 @@ export class DesktopRunStartService {
         cwd: effectiveCwd,
         inputItems: inputItems.length > 0 ? inputItems : undefined,
         model: resolvedModel,
+        onThreadReady: async (threadId) => {
+          this.#approvals.rememberThreadSkillApprovals(threadId, skillApprovalKeys);
+        },
         personality: resolvedPersonality,
         reasoningEffort: resolvedEffort ?? undefined,
         runtimeInstructions: resolvedRuntimeInstructions,

--- a/desktop/src/main/session/session-controller.test.js
+++ b/desktop/src/main/session/session-controller.test.js
@@ -7579,6 +7579,344 @@ test("trusted skill approvals persist across controller sessions until the skill
   assert.equal(thirdBootstrap.pendingApprovals[0]?.id, 603);
 });
 
+test("acceptForSession only trusts the skill that matched the approved command", async () => {
+  const root = await makeTempRoot();
+  const env = createTestEnv(root);
+  const workspaceRoot = path.join(root, "workspace-skill-trust-multi");
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  await grantWorkspaceReadPermission(env, workspaceRoot);
+
+  const profileCodexHome = resolveProfileCodexHome(CANONICAL_PROFILE_ID, env);
+  const autopilotDir = path.join(profileCodexHome, "skills", "autopilot");
+  const autopilotPath = path.join(autopilotDir, "SKILL.md");
+  const virwordDir = path.join(profileCodexHome, "skills", "virword");
+  const virwordPath = path.join(virwordDir, "SKILL.md");
+  await fs.mkdir(autopilotDir, { recursive: true });
+  await fs.mkdir(virwordDir, { recursive: true });
+  await fs.writeFile(autopilotPath, "# Autopilot\n", "utf8");
+  await fs.writeFile(virwordPath, "# Virword\n", "utf8");
+
+  const manager = {
+    handleProfileChange: async () => {},
+    off: () => {},
+    on: () => {},
+    request: async (method) => {
+      if (method === "account/read") {
+        return {
+          account: {
+            email: "george@example.com",
+            type: "chatgpt",
+          },
+          authMode: "chatgpt",
+          requiresOpenaiAuth: false,
+        };
+      }
+
+      if (method === "model/list") {
+        return {
+          data: [
+            {
+              id: "gpt-5.4-mini",
+              supportedReasoningEfforts: ["minimal", "low", "medium", "high", "xhigh"],
+            },
+          ],
+        };
+      }
+
+      if (method === "config/read") {
+        return { config: {} };
+      }
+
+      if (method === "plugin/list") {
+        return { marketplaces: [] };
+      }
+
+      if (method === "app/list") {
+        return { data: [] };
+      }
+
+      if (method === "mcpServerStatus/list") {
+        return { data: [] };
+      }
+
+      if (method === "skills/list") {
+        return {
+          data: [
+            {
+              cwd: profileCodexHome,
+              skills: [
+                { name: "autopilot", path: autopilotPath, enabled: true },
+                { name: "virword", path: virwordPath, enabled: true },
+              ],
+            },
+          ],
+        };
+      }
+
+      if (method === "thread/start") {
+        return {
+          thread: {
+            id: "thread-skill-trust-multi",
+            name: "Multi skill trust thread",
+            preview: "Multi skill trust thread",
+            updatedAt: Math.floor(Date.now() / 1000),
+            status: {
+              type: "active",
+              activeFlags: [],
+            },
+          },
+        };
+      }
+
+      if (method === "turn/start") {
+        return {
+          turn: {
+            id: "turn-skill-trust-multi",
+          },
+        };
+      }
+
+      throw new Error(`Unexpected method: ${method}`);
+    },
+    respondCalls: [],
+    respond(requestId, payload) {
+      this.respondCalls.push({ requestId, payload });
+    },
+    start: async () => {},
+  };
+
+  const controller = new DesktopSessionController(manager, {
+    appStartedAt: "2026-03-24T10:00:00.000Z",
+    env,
+    openExternal: async () => {},
+    runtimeInfo: {
+      appVersion: "0.1.0",
+      electronVersion: "35.2.1",
+      platform: "darwin",
+      startedAt: "2026-03-24T10:00:00.000Z",
+    },
+  });
+
+  const run = await controller.runDesktopTask({
+    prompt: "Use $autopilot and $virword in this thread.",
+    workspaceRoot,
+  });
+  assert.equal(run.status, "started");
+
+  controller.ingestRuntimeEvent({
+    kind: "approvalRequested",
+    approval: makeApproval(701, run.threadId, {
+      command: ["codex", "run", autopilotPath],
+      reason: "Autopilot skill approval required.",
+    }),
+  });
+  await controller.respondToDesktopApproval({
+    decision: "acceptForSession",
+    requestId: 701,
+  });
+
+  await waitFor(async () => {
+    const settings = await controller.getDesktopSettings();
+    assert.equal(settings.settings.trustedSkillApprovals.length, 1);
+    assert.match(settings.settings.trustedSkillApprovals[0] ?? "", /autopilot\/SKILL\.md/);
+  });
+
+  controller.ingestRuntimeEvent({
+    kind: "approvalRequested",
+    approval: makeApproval(702, run.threadId, {
+      command: ["codex", "run", virwordPath],
+      reason: "Virword skill approval required.",
+    }),
+  });
+  await flushSubstrateWrites();
+
+  const bootstrap = await controller.getBootstrap();
+  assert.deepEqual(manager.respondCalls, [
+    {
+      requestId: 701,
+      payload: "acceptForSession",
+    },
+  ]);
+  assert.equal(bootstrap.pendingApprovals.length, 1);
+  assert.equal(bootstrap.pendingApprovals[0]?.id, 702);
+});
+
+test("trusted skill revocations take effect without restarting the controller", async () => {
+  const root = await makeTempRoot();
+  const env = createTestEnv(root);
+  const workspaceRootA = path.join(root, "workspace-skill-trust-revoke-a");
+  const workspaceRootB = path.join(root, "workspace-skill-trust-revoke-b");
+  await fs.mkdir(workspaceRootA, { recursive: true });
+  await fs.mkdir(workspaceRootB, { recursive: true });
+  await grantWorkspaceReadPermission(env, workspaceRootA);
+  await grantWorkspaceReadPermission(env, workspaceRootB);
+
+  const profileCodexHome = resolveProfileCodexHome(CANONICAL_PROFILE_ID, env);
+  const skillDir = path.join(profileCodexHome, "skills", "autopilot");
+  const skillPath = path.join(skillDir, "SKILL.md");
+  await fs.mkdir(skillDir, { recursive: true });
+  await fs.writeFile(skillPath, "# Autopilot\n", "utf8");
+
+  let threadCounter = 0;
+  const manager = {
+    handleProfileChange: async () => {},
+    off: () => {},
+    on: () => {},
+    request: async (method) => {
+      if (method === "account/read") {
+        return {
+          account: {
+            email: "george@example.com",
+            type: "chatgpt",
+          },
+          authMode: "chatgpt",
+          requiresOpenaiAuth: false,
+        };
+      }
+
+      if (method === "model/list") {
+        return {
+          data: [
+            {
+              id: "gpt-5.4-mini",
+              supportedReasoningEfforts: ["minimal", "low", "medium", "high", "xhigh"],
+            },
+          ],
+        };
+      }
+
+      if (method === "config/read") {
+        return { config: {} };
+      }
+
+      if (method === "plugin/list") {
+        return { marketplaces: [] };
+      }
+
+      if (method === "app/list") {
+        return { data: [] };
+      }
+
+      if (method === "mcpServerStatus/list") {
+        return { data: [] };
+      }
+
+      if (method === "skills/list") {
+        return {
+          data: [
+            {
+              cwd: profileCodexHome,
+              skills: [
+                {
+                  name: "autopilot",
+                  path: skillPath,
+                  enabled: true,
+                },
+              ],
+            },
+          ],
+        };
+      }
+
+      if (method === "thread/start") {
+        threadCounter += 1;
+        return {
+          thread: {
+            id: `thread-skill-trust-revoke-${threadCounter}`,
+            name: "Skill trust revoke thread",
+            preview: "Skill trust revoke thread",
+            updatedAt: Math.floor(Date.now() / 1000),
+            status: {
+              type: "active",
+              activeFlags: [],
+            },
+          },
+        };
+      }
+
+      if (method === "turn/start") {
+        return {
+          turn: {
+            id: `turn-skill-trust-revoke-${threadCounter}`,
+          },
+        };
+      }
+
+      throw new Error(`Unexpected method: ${method}`);
+    },
+    respondCalls: [],
+    respond(requestId, payload) {
+      this.respondCalls.push({ requestId, payload });
+    },
+    start: async () => {},
+  };
+
+  const controller = new DesktopSessionController(manager, {
+    appStartedAt: "2026-03-24T10:00:00.000Z",
+    env,
+    openExternal: async () => {},
+    runtimeInfo: {
+      appVersion: "0.1.0",
+      electronVersion: "35.2.1",
+      platform: "darwin",
+      startedAt: "2026-03-24T10:00:00.000Z",
+    },
+  });
+
+  const firstRun = await controller.runDesktopTask({
+    prompt: "Use $autopilot once.",
+    workspaceRoot: workspaceRootA,
+  });
+  assert.equal(firstRun.status, "started");
+
+  controller.ingestRuntimeEvent({
+    kind: "approvalRequested",
+    approval: makeApproval(711, firstRun.threadId, {
+      command: ["codex", "run", skillPath],
+      reason: "Skill approval required.",
+    }),
+  });
+  await controller.respondToDesktopApproval({
+    decision: "acceptForSession",
+    requestId: 711,
+  });
+
+  await waitFor(async () => {
+    const settings = await controller.getDesktopSettings();
+    assert.equal(settings.settings.trustedSkillApprovals.length, 1);
+  });
+
+  const updatedSettings = await controller.updateDesktopSettings({
+    trustedSkillApprovals: [],
+  });
+  assert.deepEqual(updatedSettings.settings.trustedSkillApprovals, []);
+
+  const secondRun = await controller.runDesktopTask({
+    prompt: "Use $autopilot after trust is revoked.",
+    workspaceRoot: workspaceRootB,
+  });
+  assert.equal(secondRun.status, "started");
+
+  controller.ingestRuntimeEvent({
+    kind: "approvalRequested",
+    approval: makeApproval(712, secondRun.threadId, {
+      command: ["codex", "run", skillPath],
+      reason: "Skill approval required again.",
+    }),
+  });
+  await flushSubstrateWrites();
+
+  const bootstrap = await controller.getBootstrap();
+  assert.deepEqual(manager.respondCalls, [
+    {
+      requestId: 711,
+      payload: "acceptForSession",
+    },
+  ]);
+  assert.equal(bootstrap.pendingApprovals.length, 1);
+  assert.equal(bootstrap.pendingApprovals[0]?.id, 712);
+});
+
 test("acceptForSession resolutions log approval.trusted for the linked session", async () => {
   const root = await makeTempRoot();
   const env = createTestEnv(root);

--- a/desktop/src/main/session/session-controller.test.js
+++ b/desktop/src/main/session/session-controller.test.js
@@ -7329,6 +7329,256 @@ test("acceptForSession trust does not carry into a new controller session", asyn
   assert.equal(bootstrap.pendingApprovals[0]?.id, 404);
 });
 
+test("trusted skill approvals persist across controller sessions until the skill changes", async () => {
+  const root = await makeTempRoot();
+  const env = createTestEnv(root);
+  const workspaceRootA = path.join(root, "workspace-skill-trust-a");
+  const workspaceRootB = path.join(root, "workspace-skill-trust-b");
+  const workspaceRootC = path.join(root, "workspace-skill-trust-c");
+  await fs.mkdir(workspaceRootA, { recursive: true });
+  await fs.mkdir(workspaceRootB, { recursive: true });
+  await fs.mkdir(workspaceRootC, { recursive: true });
+  await grantWorkspaceReadPermission(env, workspaceRootA);
+  await grantWorkspaceReadPermission(env, workspaceRootB);
+  await grantWorkspaceReadPermission(env, workspaceRootC);
+
+  const profileCodexHome = resolveProfileCodexHome(CANONICAL_PROFILE_ID, env);
+  const skillDir = path.join(profileCodexHome, "skills", "autopilot");
+  const skillPath = path.join(skillDir, "SKILL.md");
+  await fs.mkdir(skillDir, { recursive: true });
+  await fs.writeFile(skillPath, "# Autopilot\n", "utf8");
+
+  let threadCounter = 0;
+  function createManager() {
+    return {
+      handleProfileChange: async () => {},
+      off: () => {},
+      on: () => {},
+      request: async (method) => {
+        if (method === "account/read") {
+          return {
+            account: {
+              email: "george@example.com",
+              type: "chatgpt",
+            },
+            authMode: "chatgpt",
+            requiresOpenaiAuth: false,
+          };
+        }
+
+        if (method === "model/list") {
+          return {
+            data: [
+              {
+                id: "gpt-5.4-mini",
+                supportedReasoningEfforts: ["minimal", "low", "medium", "high", "xhigh"],
+              },
+            ],
+          };
+        }
+
+        if (method === "config/read") {
+          return { config: {} };
+        }
+
+        if (method === "plugin/list") {
+          return { marketplaces: [] };
+        }
+
+        if (method === "app/list") {
+          return { data: [] };
+        }
+
+        if (method === "mcpServerStatus/list") {
+          return { data: [] };
+        }
+
+        if (method === "skills/list") {
+          return {
+            data: [
+              {
+                cwd: profileCodexHome,
+                skills: [
+                  {
+                    name: "autopilot",
+                    path: skillPath,
+                    enabled: true,
+                  },
+                ],
+              },
+            ],
+          };
+        }
+
+        if (method === "thread/start") {
+          threadCounter += 1;
+          return {
+            thread: {
+              id: `thread-skill-trust-${threadCounter}`,
+              name: "Skill trust thread",
+              preview: "Skill trust thread",
+              updatedAt: Math.floor(Date.now() / 1000),
+              status: {
+                type: "active",
+                activeFlags: [],
+              },
+            },
+          };
+        }
+
+        if (method === "turn/start") {
+          return {
+            turn: {
+              id: `turn-skill-trust-${threadCounter}`,
+            },
+          };
+        }
+
+        throw new Error(`Unexpected method: ${method}`);
+      },
+      respondCalls: [],
+      respond(requestId, payload) {
+        this.respondCalls.push({ requestId, payload });
+      },
+      start: async () => {},
+    };
+  }
+
+  const firstManager = createManager();
+  const firstController = new DesktopSessionController(firstManager, {
+    appStartedAt: "2026-03-24T10:00:00.000Z",
+    env,
+    openExternal: async () => {},
+    runtimeInfo: {
+      appVersion: "0.1.0",
+      electronVersion: "35.2.1",
+      platform: "darwin",
+      startedAt: "2026-03-24T10:00:00.000Z",
+    },
+  });
+
+  const firstRun = await firstController.runDesktopTask({
+    prompt: "Use $autopilot to prepare a change summary.",
+    workspaceRoot: workspaceRootA,
+  });
+  assert.equal(firstRun.status, "started");
+
+  firstController.ingestRuntimeEvent({
+    kind: "approvalRequested",
+    approval: makeApproval(601, firstRun.threadId, {
+      command: ["codex", "run", skillPath],
+      reason: "Skill approval required.",
+    }),
+  });
+  await firstController.respondToDesktopApproval({
+    decision: "acceptForSession",
+    requestId: 601,
+  });
+
+  await waitFor(async () => {
+    const settings = await firstController.getDesktopSettings();
+    assert.equal(settings.settings.trustedSkillApprovals.length, 1);
+  });
+
+  const secondManager = createManager();
+  const secondController = new DesktopSessionController(secondManager, {
+    appStartedAt: "2026-03-24T10:10:00.000Z",
+    env,
+    openExternal: async () => {},
+    runtimeInfo: {
+      appVersion: "0.1.0",
+      electronVersion: "35.2.1",
+      platform: "darwin",
+      startedAt: "2026-03-24T10:10:00.000Z",
+    },
+  });
+
+  const secondRun = await secondController.runDesktopTask({
+    prompt: "Use $autopilot to prep another summary.",
+    workspaceRoot: workspaceRootB,
+  });
+  assert.equal(secondRun.status, "started");
+
+  secondController.ingestRuntimeEvent({
+    kind: "approvalRequested",
+    approval: makeApproval(602, secondRun.threadId, {
+      command: ["codex", "run", skillPath],
+      reason: "Skill approval required.",
+    }),
+  });
+
+  await waitFor(async () => {
+    assert.deepEqual(secondManager.respondCalls, [
+      {
+        requestId: 602,
+        payload: "acceptForSession",
+      },
+    ]);
+    const bootstrap = await secondController.getBootstrap();
+    assert.equal(bootstrap.pendingApprovals.length, 0);
+  });
+
+  secondController.ingestRuntimeEvent({
+    kind: "approvalRequested",
+    approval: makeApproval(604, secondRun.threadId, {
+      command: ["git", "status"],
+      reason: "Non-skill command should still prompt.",
+    }),
+  });
+  await flushSubstrateWrites();
+
+  const nonSkillBootstrap = await secondController.getBootstrap();
+  assert.deepEqual(secondManager.respondCalls, [
+    {
+      requestId: 602,
+      payload: "acceptForSession",
+    },
+  ]);
+  assert.equal(nonSkillBootstrap.pendingApprovals.length, 1);
+  assert.equal(nonSkillBootstrap.pendingApprovals[0]?.id, 604);
+  await secondController.respondToDesktopApproval({
+    decision: "decline",
+    requestId: 604,
+  });
+
+  await fs.writeFile(skillPath, "# Autopilot changed\n", "utf8");
+  const changedAt = new Date("2026-03-24T10:20:00.000Z");
+  await fs.utimes(skillPath, changedAt, changedAt);
+
+  const thirdManager = createManager();
+  const thirdController = new DesktopSessionController(thirdManager, {
+    appStartedAt: "2026-03-24T10:20:00.000Z",
+    env,
+    openExternal: async () => {},
+    runtimeInfo: {
+      appVersion: "0.1.0",
+      electronVersion: "35.2.1",
+      platform: "darwin",
+      startedAt: "2026-03-24T10:20:00.000Z",
+    },
+  });
+
+  const thirdRun = await thirdController.runDesktopTask({
+    prompt: "Use $autopilot after it changed.",
+    workspaceRoot: workspaceRootC,
+  });
+  assert.equal(thirdRun.status, "started");
+
+  thirdController.ingestRuntimeEvent({
+    kind: "approvalRequested",
+    approval: makeApproval(603, thirdRun.threadId, {
+      command: ["codex", "run", skillPath],
+      reason: "Skill approval required.",
+    }),
+  });
+  await flushSubstrateWrites();
+
+  const thirdBootstrap = await thirdController.getBootstrap();
+  assert.deepEqual(thirdManager.respondCalls, []);
+  assert.equal(thirdBootstrap.pendingApprovals.length, 1);
+  assert.equal(thirdBootstrap.pendingApprovals[0]?.id, 603);
+});
+
 test("acceptForSession resolutions log approval.trusted for the linked session", async () => {
   const root = await makeTempRoot();
   const env = createTestEnv(root);

--- a/desktop/src/main/session/skill-approval-state.ts
+++ b/desktop/src/main/session/skill-approval-state.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs/promises";
+
+import type { DesktopAppServerInputItem } from "../contracts";
+import {
+  buildSkillApprovalKey,
+  isSkillApprovalPath,
+  normalizeSkillApprovalPath,
+} from "../../shared/skill-approval-key.js";
+
+function uniqueStrings(values: Array<string | null | undefined>): string[] {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+  for (const value of values) {
+    if (!value || seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    unique.push(value);
+  }
+  return unique;
+}
+
+export async function resolveSkillApprovalKey(skillPath: string): Promise<string | null> {
+  const normalizedPath = normalizeSkillApprovalPath(skillPath);
+  if (!normalizedPath || !isSkillApprovalPath(normalizedPath)) {
+    return null;
+  }
+
+  try {
+    const stat = await fs.stat(normalizedPath);
+    return buildSkillApprovalKey(normalizedPath, String(Math.floor(stat.mtimeMs)));
+  } catch {
+    return buildSkillApprovalKey(normalizedPath, "missing");
+  }
+}
+
+export async function collectSkillApprovalKeys(
+  inputItems: DesktopAppServerInputItem[],
+): Promise<string[]> {
+  const skillPaths = uniqueStrings(
+    inputItems
+      .filter((item): item is DesktopAppServerInputItem & { type: "mention"; path?: string } => item.type === "mention")
+      .map((item) => normalizeSkillApprovalPath(item.path))
+      .filter((skillPath): skillPath is string => Boolean(skillPath && isSkillApprovalPath(skillPath))),
+  );
+
+  return uniqueStrings(
+    await Promise.all(
+      skillPaths.map(async (skillPath) => await resolveSkillApprovalKey(skillPath)),
+    ),
+  );
+}

--- a/desktop/src/main/settings/desktop-settings-service.ts
+++ b/desktop/src/main/settings/desktop-settings-service.ts
@@ -50,6 +50,7 @@ export const DESKTOP_DEFAULT_SETTINGS: DesktopSettings = {
   workspaceFolderBinding: DEFAULT_DESKTOP_SETTINGS.workspaceFolderBinding,
   approvalOperationPosture: DEFAULT_DESKTOP_SETTINGS.approvalOperationPosture,
   approvalTrustedWorkspaces: DEFAULT_DESKTOP_SETTINGS.approvalTrustedWorkspaces,
+  trustedSkillApprovals: DEFAULT_DESKTOP_SETTINGS.trustedSkillApprovals,
 };
 
 type RecordAuditEvent = (input: {

--- a/desktop/src/main/settings/desktop-settings.d.ts
+++ b/desktop/src/main/settings/desktop-settings.d.ts
@@ -19,6 +19,7 @@ export type DesktopSettingsPatch = Partial<
     | "workspaceFolderBinding"
     | "approvalOperationPosture"
     | "approvalTrustedWorkspaces"
+    | "trustedSkillApprovals"
   >
 > & {
   readonly workspaceDefaults?: Partial<DesktopWorkspaceDefaults>;
@@ -38,6 +39,7 @@ export interface DesktopApprovalDefaults {
   readonly sandboxPosture?: DesktopSandboxPosture;
   readonly approvalOperationPosture?: DesktopSettings["approvalOperationPosture"];
   readonly approvalTrustedWorkspaces?: DesktopSettings["approvalTrustedWorkspaces"];
+  readonly trustedSkillApprovals?: DesktopSettings["trustedSkillApprovals"];
 }
 
 export interface DesktopGeneralDefaults {

--- a/desktop/src/main/settings/desktop-settings.js
+++ b/desktop/src/main/settings/desktop-settings.js
@@ -10,6 +10,7 @@ export const DEFAULT_DESKTOP_SETTINGS = Object.freeze({
   sandboxPosture: "workspaceWrite",
   approvalOperationPosture: "askAll",
   approvalTrustedWorkspaces: "",
+  trustedSkillApprovals: [],
   adminApprovalPosture: "requireRisky",
   roleApprovalLevel: "ownerOnly",
   workspaceReadonly: "allow",
@@ -131,6 +132,25 @@ function normalizeApprovalTrustedWorkspaces(value) {
   return value.trim();
 }
 
+function normalizeTrustedSkillApprovals(value) {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const seen = new Set();
+  const approvals = [];
+  for (const entry of value) {
+    const resolved = firstString(entry)?.replaceAll("\\", "/");
+    if (!resolved || seen.has(resolved)) {
+      continue;
+    }
+    seen.add(resolved);
+    approvals.push(resolved);
+  }
+
+  return approvals;
+}
+
 function normalizeRoleApprovalLevel(value) {
   const resolved = firstString(value);
   if (resolved === "ownerOnly" || resolved === "anyAuthenticated") {
@@ -198,6 +218,7 @@ function normalizeApprovalDefaults(value) {
   const sandboxPosture = normalizeSandboxPosture(record.sandboxPosture);
   const approvalOperationPosture = normalizeApprovalOperationPosture(record.approvalOperationPosture);
   const approvalTrustedWorkspaces = normalizeApprovalTrustedWorkspaces(record.approvalTrustedWorkspaces);
+  const trustedSkillApprovals = normalizeTrustedSkillApprovals(record.trustedSkillApprovals);
 
   if (approvalPosture) {
     approvalDefaults.approvalPosture = approvalPosture;
@@ -210,6 +231,9 @@ function normalizeApprovalDefaults(value) {
   }
   if (approvalTrustedWorkspaces !== undefined) {
     approvalDefaults.approvalTrustedWorkspaces = approvalTrustedWorkspaces;
+  }
+  if (trustedSkillApprovals !== undefined) {
+    approvalDefaults.trustedSkillApprovals = trustedSkillApprovals;
   }
 
   return Object.keys(approvalDefaults).length > 0 ? approvalDefaults : undefined;
@@ -296,6 +320,7 @@ function buildLegacyProfileLayer(raw) {
     sandboxPosture: raw.sandboxPosture,
     approvalOperationPosture: raw.approvalOperationPosture,
     approvalTrustedWorkspaces: raw.approvalTrustedWorkspaces,
+    trustedSkillApprovals: raw.trustedSkillApprovals,
   });
   const generalDefaults = normalizeGeneralDefaults(raw);
   const modelRestrictions = normalizeModelRestrictions(raw.modelRestrictions);
@@ -351,6 +376,9 @@ function buildPatchLayer(patch = {}) {
       ...(patch.approvalOperationPosture !== undefined ? { approvalOperationPosture: patch.approvalOperationPosture } : {}),
       ...(patch.approvalTrustedWorkspaces !== undefined
         ? { approvalTrustedWorkspaces: patch.approvalTrustedWorkspaces }
+        : {}),
+      ...(patch.trustedSkillApprovals !== undefined
+        ? { trustedSkillApprovals: patch.trustedSkillApprovals }
         : {}),
       ...(patch.approvalDefaults ?? {}),
     },

--- a/desktop/src/main/settings/desktop-settings.test.js
+++ b/desktop/src/main/settings/desktop-settings.test.js
@@ -210,3 +210,37 @@ test("applyDesktopSettingsPatch keeps cleared trusted workspace rules honest", (
 
   assert.equal(resolveDesktopSettings(next).approvalTrustedWorkspaces, "");
 });
+
+test("applyDesktopSettingsPatch persists trusted skill approvals under approval defaults", () => {
+  const next = applyDesktopSettingsPatch(
+    {
+      version: 2,
+      policy: {
+        system: null,
+        organization: null,
+        profile: null,
+        workspaces: {},
+      },
+    },
+    {
+      trustedSkillApprovals: [
+        "/Users/george/.codex/skills/autopilot/SKILL.md::mtime:1",
+        "/Users/george/.codex/skills/autopilot/SKILL.md::mtime:1",
+        "/Users/george/.codex/plugins/gmail/skills/gmail/SKILL.md::mtime:2",
+      ],
+    },
+  );
+
+  assert.deepEqual(next.policy.profile, {
+    approvalDefaults: {
+      trustedSkillApprovals: [
+        "/Users/george/.codex/skills/autopilot/SKILL.md::mtime:1",
+        "/Users/george/.codex/plugins/gmail/skills/gmail/SKILL.md::mtime:2",
+      ],
+    },
+  });
+  assert.deepEqual(resolveDesktopSettings(next).trustedSkillApprovals, [
+    "/Users/george/.codex/skills/autopilot/SKILL.md::mtime:1",
+    "/Users/george/.codex/plugins/gmail/skills/gmail/SKILL.md::mtime:2",
+  ]);
+});

--- a/desktop/src/main/settings/policy-settings.js
+++ b/desktop/src/main/settings/policy-settings.js
@@ -27,6 +27,7 @@ const DESKTOP_SETTING_KEYS = Object.freeze([
   "sandboxPosture",
   "approvalOperationPosture",
   "approvalTrustedWorkspaces",
+  "trustedSkillApprovals",
   "adminApprovalPosture",
   "roleApprovalLevel",
   "workspaceReadonly",
@@ -113,6 +114,29 @@ function normalizeApprovalTrustedWorkspaces(value, fallback = "") {
   return value.trim();
 }
 
+function normalizeTrustedSkillApprovals(value, fallback = []) {
+  if (!Array.isArray(value)) {
+    return fallback;
+  }
+
+  const seen = new Set();
+  const approvals = [];
+  for (const entry of value) {
+    const resolved = firstString(entry);
+    if (!resolved) {
+      continue;
+    }
+    const normalized = resolved.replaceAll("\\", "/");
+    if (seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    approvals.push(normalized);
+  }
+
+  return approvals;
+}
+
 function normalizeRuntimeInstructions(value, fallback = null) {
   if (typeof value !== "string") {
     return fallback;
@@ -159,6 +183,9 @@ export function normalizeDesktopSettingsLayer(settings = {}) {
   }
   if (typeof record.approvalTrustedWorkspaces === "string") {
     normalized.approvalTrustedWorkspaces = normalizeApprovalTrustedWorkspaces(record.approvalTrustedWorkspaces, "");
+  }
+  if (Array.isArray(record.trustedSkillApprovals)) {
+    normalized.trustedSkillApprovals = normalizeTrustedSkillApprovals(record.trustedSkillApprovals, []);
   }
   const adminApprovalPosture = normalizeAdminApprovalPosture(record.adminApprovalPosture, null);
   if (adminApprovalPosture) {

--- a/desktop/src/renderer/components/settings/GeneralSettingsSection.tsx
+++ b/desktop/src/renderer/components/settings/GeneralSettingsSection.tsx
@@ -2,6 +2,7 @@ import { Button } from "../ui/button";
 import { cn } from "../../lib/cn";
 import { resolveSettingsUpdateSummary } from "../../features/updates/update-presentation.js";
 import type { DesktopModelEntry, DesktopSettings, DesktopUpdateState } from "../../../main/contracts";
+import { matchesSkillApprovalPath, parseSkillApprovalKey } from "../../../shared/skill-approval-key.js";
 
 const REASONING_LABELS: Record<string, string> = {
   none: "None",
@@ -47,6 +48,13 @@ export function GeneralSettingsSection({
   updateState,
 }: GeneralSettingsSectionProps) {
   const updateSummary = resolveSettingsUpdateSummary(updateState);
+  const trustedSkillApprovals = settingsData?.trustedSkillApprovals ?? [];
+
+  function removeTrustedSkillApproval(skillPath: string) {
+    void saveSettings({
+      trustedSkillApprovals: trustedSkillApprovals.filter((entry) => !matchesSkillApprovalPath(entry, skillPath)),
+    });
+  }
 
   return (
     <>
@@ -141,6 +149,56 @@ export function GeneralSettingsSection({
               <p className="mt-[0.2rem] text-[0.8125rem] leading-[1.52] text-ink-muted">Higher reasoning uses more tokens but produces more thorough analysis.</p>
             )}
           </label>
+
+          <div className="rounded-xl bg-surface-low px-[0.9rem] py-[0.85rem]">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="min-w-0">
+                <p className="text-[0.75rem] font-medium uppercase leading-[1.2] tracking-[0.05em] text-ink-faint">Trusted skills</p>
+                <p className="mt-[0.35rem] text-[0.875rem] leading-[1.6] text-ink-muted">
+                  Sense-1 remembers approved skills at the profile level and reuses them across threads and workspaces until the skill changes or you revoke trust.
+                </p>
+              </div>
+              {trustedSkillApprovals.length > 0 ? (
+                <Button
+                  className="rounded-full"
+                  onClick={() => void saveSettings({ trustedSkillApprovals: [] })}
+                  size="sm"
+                  variant="secondary"
+                >
+                  Clear all
+                </Button>
+              ) : null}
+            </div>
+            {trustedSkillApprovals.length > 0 ? (
+              <div className="mt-3 flex flex-col gap-2">
+                {trustedSkillApprovals.map((entry) => {
+                  const skillPath = parseSkillApprovalKey(entry).path ?? entry;
+                  const skillName = skillPath.split("/").slice(-2, -1)[0] ?? skillPath;
+                  return (
+                    <div className="flex items-center justify-between gap-3 rounded-lg bg-white px-3 py-2" key={entry}>
+                      <div className="min-w-0">
+                        <p className="truncate text-[0.875rem] font-medium leading-[1.45] text-ink">{skillName}</p>
+                        <p className="truncate text-[0.75rem] leading-[1.5] text-ink-muted">{skillPath}</p>
+                      </div>
+                      <Button
+                        className="shrink-0 rounded-full"
+                        onClick={() => removeTrustedSkillApproval(skillPath)}
+                        size="sm"
+                        variant="secondary"
+                      >
+                        Revoke
+                      </Button>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <p className="mt-3 text-[0.8125rem] leading-[1.52] text-ink-muted">No skill approvals have been trusted for this profile yet.</p>
+            )}
+            {settingsError?.key === "trustedSkillApprovals" ? (
+              <p className="mt-[0.65rem] text-[0.8125rem] leading-[1.52] text-[oklch(65%_0.15_25)]">{settingsError.message}</p>
+            ) : null}
+          </div>
         </div>
       ) : (
         <p className="mt-[1.25rem] text-[0.875rem] leading-[1.6] text-ink-muted">Loading settings...</p>

--- a/desktop/src/shared/contracts/settings.ts
+++ b/desktop/src/shared/contracts/settings.ts
@@ -12,6 +12,7 @@ export interface DesktopSettings {
   readonly workspaceFolderBinding: "inherit" | "none";
   readonly approvalOperationPosture: "askAll" | "askRisky" | "autoAll";
   readonly approvalTrustedWorkspaces: string;
+  readonly trustedSkillApprovals: string[];
 }
 
 export interface DesktopSettingsUpdateRequest {

--- a/desktop/src/shared/skill-approval-key.d.ts
+++ b/desktop/src/shared/skill-approval-key.d.ts
@@ -1,0 +1,9 @@
+export function normalizeSkillApprovalPath(value: string | null | undefined): string | null;
+export function buildSkillApprovalKey(skillPath: string, versionToken: string): string;
+export function parseSkillApprovalKey(entry: string | null | undefined): {
+  path: string | null;
+  versionToken: string | null;
+};
+export function matchesSkillApprovalPath(entry: string, skillPath: string): boolean;
+export function commandMatchesSkillApprovalPath(command: unknown, entry: string | null | undefined): boolean;
+export function isSkillApprovalPath(skillPath: string | null | undefined): boolean;

--- a/desktop/src/shared/skill-approval-key.js
+++ b/desktop/src/shared/skill-approval-key.js
@@ -1,0 +1,67 @@
+const SKILL_APPROVAL_SEPARATOR = "::mtime:";
+
+export function normalizeSkillApprovalPath(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  return trimmed.replaceAll("\\", "/");
+}
+
+export function buildSkillApprovalKey(skillPath, versionToken) {
+  const normalizedPath = normalizeSkillApprovalPath(skillPath);
+  const normalizedVersion = typeof versionToken === "string" ? versionToken.trim() : "";
+  if (!normalizedPath) {
+    return "";
+  }
+  if (!normalizedVersion) {
+    return normalizedPath;
+  }
+  return `${normalizedPath}${SKILL_APPROVAL_SEPARATOR}${normalizedVersion}`;
+}
+
+export function parseSkillApprovalKey(entry) {
+  const normalizedEntry = normalizeSkillApprovalPath(entry);
+  if (!normalizedEntry) {
+    return {
+      path: null,
+      versionToken: null,
+    };
+  }
+
+  const separatorIndex = normalizedEntry.lastIndexOf(SKILL_APPROVAL_SEPARATOR);
+  if (separatorIndex === -1) {
+    return {
+      path: normalizedEntry,
+      versionToken: null,
+    };
+  }
+
+  return {
+    path: normalizedEntry.slice(0, separatorIndex),
+    versionToken: normalizedEntry.slice(separatorIndex + SKILL_APPROVAL_SEPARATOR.length) || null,
+  };
+}
+
+export function matchesSkillApprovalPath(entry, skillPath) {
+  return parseSkillApprovalKey(entry).path === normalizeSkillApprovalPath(skillPath);
+}
+
+export function commandMatchesSkillApprovalPath(command, entry) {
+  const skillPath = parseSkillApprovalKey(entry).path;
+  if (!skillPath || !Array.isArray(command)) {
+    return false;
+  }
+
+  return command.some((part) => normalizeSkillApprovalPath(part) === skillPath);
+}
+
+export function isSkillApprovalPath(skillPath) {
+  const normalizedPath = normalizeSkillApprovalPath(skillPath);
+  return Boolean(normalizedPath?.endsWith("/SKILL.md"));
+}


### PR DESCRIPTION
## Summary

This stops Sense-1 from re-asking for the same trusted skill approval on every thread. Trusted approvals now live at the profile layer, keyed to the actual skill identity, and auto-accept stays limited to commands that still match that trusted skill path.

## What changed

- persist trusted skill approvals under desktop profile settings instead of thread or workspace state
- register skill fingerprint data when a run starts so later approvals can be matched safely
- tighten desktop approval auto-accept so it only fires when the pending command still matches the trusted skill path
- expose trusted skill approvals in settings with revoke and clear-all controls
- add controller and settings coverage for persistence, restore, and unsafe-command rejection

## Validation

- `node scripts/check-public-boundary.mjs`
- `pnpm --dir desktop typecheck`
- `pnpm --dir desktop test:unit`
- `pnpm --dir desktop check:structure`
- `pnpm --dir desktop build`

## Issues

Fixes #19
