### PR TITLE
[codex] fix creator shortcut workspace boundary flow

### DIFF
--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -524,7 +524,12 @@ appServerManager.on("notification", (message) => {
   runtimeFileChangeTracker.observe(message);
   if (threadId) {
     const folderRoot = currentThreadState?.workspaceRoot ?? currentThreadState?.cwd ?? null;
-    const outsideWorkspacePaths = collectOutOfWorkspacePathsFromRuntimeMessage(message, folderRoot);
+    const runContext = desktopSessionController.getThreadRunContext(threadId);
+    const outsideWorkspacePaths = collectOutOfWorkspacePathsFromRuntimeMessage(
+      message,
+      folderRoot,
+      runContext?.grants.map((grant) => grant.rootPath) ?? [],
+    );
     if (outsideWorkspacePaths.length > 0) {
       const blockedPath = outsideWorkspacePaths[0];
       const entryDelta = threadAccumulator.appendSyntheticEntry(threadId, {

--- a/desktop/src/main/runtime/live-thread-runtime-request.js
+++ b/desktop/src/main/runtime/live-thread-runtime-request.js
@@ -139,6 +139,20 @@ function normalizeRuntimeGrant(grant, fallbackRootPath = null) {
   };
 }
 
+function resolveWritableRoots(workspaceRoot = null, cwd = null, grantRoots = []) {
+  return Array.from(
+    new Set(
+      [
+        workspaceRoot,
+        ...grantRoots,
+        cwd,
+      ]
+        .map((rootPath) => resolveRuntimePath(rootPath))
+        .filter(Boolean),
+    ),
+  );
+}
+
 export function normalizeRuntimeRunContext(runContext, { workspaceRoot = null, cwd = null } = {}) {
   const baseContext = cloneRunContext(runContext);
   if (!baseContext?.actor || !baseContext?.scope || !baseContext?.policy) {
@@ -159,9 +173,10 @@ export function normalizeRuntimeRunContext(runContext, { workspaceRoot = null, c
   };
 }
 
-export function buildTurnSandboxPolicy(sandboxPolicy, workspaceRoot = null, cwd = null) {
+export function buildTurnSandboxPolicy(sandboxPolicy, workspaceRoot = null, cwd = null, grantRoots = []) {
   const resolvedWorkspaceRoot = resolveRuntimePath(workspaceRoot);
   const resolvedCwd = resolveRuntimePath(cwd);
+  const writableRoots = resolveWritableRoots(resolvedWorkspaceRoot, resolvedCwd, grantRoots);
   if (sandboxPolicy === "danger-full-access") {
     return {
       type: "dangerFullAccess",
@@ -169,11 +184,11 @@ export function buildTurnSandboxPolicy(sandboxPolicy, workspaceRoot = null, cwd 
   }
 
   if (sandboxPolicy === "read-only" || sandboxPolicy === "readOnly") {
-    if (!resolvedWorkspaceRoot && resolvedCwd) {
+    if (!resolvedWorkspaceRoot && writableRoots.length > 0) {
       return {
         type: "workspaceWrite",
         networkAccess: true,
-        writableRoots: [resolvedCwd],
+        writableRoots,
       };
     }
 
@@ -182,9 +197,8 @@ export function buildTurnSandboxPolicy(sandboxPolicy, workspaceRoot = null, cwd 
     };
   }
 
-  const writableRoot = resolvedWorkspaceRoot || resolvedCwd;
   if (sandboxPolicy === "workspace-write" || sandboxPolicy === "workspaceWrite") {
-    if (!writableRoot) {
+    if (writableRoots.length === 0) {
       return {
         type: "readOnly",
       };
@@ -193,15 +207,15 @@ export function buildTurnSandboxPolicy(sandboxPolicy, workspaceRoot = null, cwd 
     return {
       type: "workspaceWrite",
       networkAccess: true,
-      writableRoots: [writableRoot],
+      writableRoots,
     };
   }
 
-  if (writableRoot) {
+  if (writableRoots.length > 0) {
     return {
       type: "workspaceWrite",
       networkAccess: true,
-      writableRoots: [writableRoot],
+      writableRoots,
     };
   }
 
@@ -267,17 +281,24 @@ export function buildRunContext(request, workspaceRoot = null) {
   const resolvedWorkspaceRoot = firstString(
     workspaceRoot,
     request?.workspaceRoot,
-    Array.isArray(baseContext.grants) ? firstString(baseContext.grants[0]?.rootPath) : null,
   );
+  const grantRoots = Array.isArray(baseContext.grants)
+    ? baseContext.grants
+        .map((grant) => firstString(grant?.rootPath))
+        .filter(Boolean)
+    : [];
   const executionPolicyMode = firstString(baseContext.policy?.executionPolicyMode);
   const sandboxPolicy = firstString(
     baseContext.policy?.sandboxPolicy,
     executionPolicyMode === "preview" ? "readOnly" : null,
     executionPolicyMode === "auto" || executionPolicyMode === "apply" ? "workspaceWrite" : null,
   ) || (resolvedWorkspaceRoot ? "workspaceWrite" : "readOnly");
-  const resolvedWritableRoot = sandboxPolicy === "workspaceWrite"
-    ? firstString(resolvedWorkspaceRoot, request?.cwd)
-    : null;
+  const resolvedWritableRoots =
+    sandboxPolicy === "workspaceWrite"
+      ? resolveWritableRoots(resolvedWorkspaceRoot, request?.cwd, grantRoots)
+      : !resolvedWorkspaceRoot && request?.cwd
+        ? resolveWritableRoots(null, request?.cwd, grantRoots)
+        : resolveWritableRoots(null, null, grantRoots);
   const approvalPolicy = firstString(
     baseContext.policy?.approvalPolicy,
     executionPolicyMode === "preview" || executionPolicyMode === "auto" || executionPolicyMode === "apply"
@@ -289,14 +310,12 @@ export function buildRunContext(request, workspaceRoot = null) {
   return {
     actor: baseContext.actor,
     scope: baseContext.scope,
-    grants: resolvedWritableRoot
-      ? [
-          {
-            kind: "workspaceRoot",
-            rootPath: resolvedWritableRoot,
-            access: "workspaceWrite",
-          },
-        ]
+    grants: resolvedWritableRoots.length > 0
+      ? resolvedWritableRoots.map((rootPath) => ({
+          kind: "workspaceRoot",
+          rootPath,
+          access: "workspaceWrite",
+        }))
       : [],
     policy: {
       executionPolicyMode: executionPolicyMode || "defaultProfilePrivateScope",

--- a/desktop/src/main/runtime/live-thread-runtime.js
+++ b/desktop/src/main/runtime/live-thread-runtime.js
@@ -238,6 +238,7 @@ export async function runDesktopTask(
     executionOverrides.sandboxPolicy,
     resolvedWorkspaceRoot,
     resolvedCwd,
+    executionContext.grants.map((grant) => grant.rootPath),
   );
   const runtimeCwd = resolveRuntimePath(resolvedCwd);
   const ensuredThread = await ensureDesktopThread(manager, {

--- a/desktop/src/main/session/desktop-prompt-shortcuts.test.js
+++ b/desktop/src/main/session/desktop-prompt-shortcuts.test.js
@@ -5,6 +5,7 @@ import {
   extractPromptShortcutTokens,
   replaceActivePromptShortcut,
   resolveActivePromptShortcutQuery,
+  resolveInputItemPromptShortcutMatches,
   resolvePromptShortcutInputItems,
   resolvePromptShortcutSuggestions,
 } from "./desktop-prompt-shortcuts.ts";
@@ -177,6 +178,35 @@ test("resolvePromptShortcutInputItems ignores unresolved or disabled shortcuts",
   assert.deepEqual(
     resolvePromptShortcutInputItems("Try $autopilot and $gmail and $missing", overview),
     [],
+  );
+});
+
+test("resolveInputItemPromptShortcutMatches ignores plain file mention attachments", () => {
+  assert.deepEqual(
+    resolveInputItemPromptShortcutMatches([
+      { type: "mention", name: "brief.md", path: "/tmp/session/brief.md" },
+      { type: "mention", name: "autopilot", path: "/Users/george/.codex/skills/autopilot/SKILL.md" },
+      { type: "mention", name: "Linear", path: "app://linear" },
+    ]).map((match) => ({
+      kind: match.kind,
+      label: match.label,
+      token: match.token,
+      path: match.item.path,
+    })),
+    [
+      {
+        kind: "skill",
+        label: "autopilot",
+        token: "autopilot",
+        path: "/Users/george/.codex/skills/autopilot/SKILL.md",
+      },
+      {
+        kind: "app",
+        label: "Linear",
+        token: "linear",
+        path: "app://linear",
+      },
+    ],
   );
 });
 

--- a/desktop/src/main/session/desktop-prompt-shortcuts.ts
+++ b/desktop/src/main/session/desktop-prompt-shortcuts.ts
@@ -2,6 +2,7 @@ export {
   extractPromptShortcutTokens,
   replaceActivePromptShortcut,
   resolveActivePromptShortcutQuery,
+  resolveInputItemPromptShortcutMatches,
   resolvePromptShortcutInputItems,
   resolvePromptShortcutMatches,
   resolvePromptShortcutSuggestions,

--- a/desktop/src/main/session/desktop-run-start-service.ts
+++ b/desktop/src/main/session/desktop-run-start-service.ts
@@ -75,12 +75,6 @@ const PROFILE_CODEX_HOME_SHORTCUTS = new Set([
   "skill-installer",
 ]);
 
-const PROFILE_CODEX_HOME_CWD_SHORTCUTS = new Set([
-  "plugin-creator",
-  "skill-creator",
-  "skill-installer",
-]);
-
 function firstShortcutName(inputItems: DesktopAppServerInputItem[]): string[] {
   return inputItems
     .filter((item): item is DesktopAppServerInputItem & { type: "mention"; name?: string } => item.type === "mention")
@@ -123,6 +117,36 @@ function mergeRuntimeInstructions(baseInstructions: string, extraInstruction: st
     return trimmedExtra;
   }
   return `${trimmedBase}\n\n${trimmedExtra}`;
+}
+
+function withAdditionalWritableRoots(
+  runContext: DesktopRunContext,
+  additionalRoots: Array<string | null | undefined>,
+): DesktopRunContext {
+  const uniqueRoots = Array.from(
+    new Set(
+      [
+        ...runContext.grants.map((grant) => grant.rootPath),
+        ...additionalRoots,
+      ]
+        .map((rootPath) => typeof rootPath === "string" ? rootPath.trim() : "")
+        .filter(Boolean)
+        .map((rootPath) => path.resolve(rootPath)),
+    ),
+  );
+
+  if (uniqueRoots.length === 0) {
+    return runContext;
+  }
+
+  return {
+    ...runContext,
+    grants: uniqueRoots.map((rootPath) => ({
+      kind: "workspaceRoot",
+      rootPath,
+      access: "workspaceWrite",
+    })),
+  };
 }
 
 function buildProfileExtensionRuntimeInstruction({
@@ -455,6 +479,7 @@ export class DesktopRunStartService {
       ? resolveSessionArtifactRoot(profileArtifactRoot, attachmentSessionId)
       : effectiveCwd;
 
+    let runtimeRunContext = runContext;
     let result: DesktopStartedTaskRunResult;
     try {
       const normalizedAttachments = await normalizeAttachmentPaths({
@@ -477,11 +502,9 @@ export class DesktopRunStartService {
         }
       }
       const profileCodexHomeShortcutNames = resolveProfileCodexHomeShortcutNames(inputItems);
-      const shouldUseProfileCodexHomeCwd =
-        [...profileCodexHomeShortcutNames].some((name) => PROFILE_CODEX_HOME_CWD_SHORTCUTS.has(name));
-      if (shouldUseProfileCodexHomeCwd) {
-        effectiveCwd = resolveProfileCodexHome(profile.id, this.#env);
-        await fs.mkdir(effectiveCwd, { recursive: true });
+      const profileCodexHome = resolveProfileCodexHome(profile.id, this.#env);
+      if (profileCodexHomeShortcutNames.size > 0) {
+        runtimeRunContext = withAdditionalWritableRoots(runContext, [profileCodexHome]);
       }
       const resolvedRuntimeInstructions = mergeRuntimeInstructions(
         mergeRuntimeInstructions(
@@ -496,7 +519,7 @@ export class DesktopRunStartService {
         ),
         buildProfileExtensionRuntimeInstruction({
           inputItems,
-          profileCodexHome: resolveProfileCodexHome(profile.id, this.#env),
+          profileCodexHome,
           shortcutNames: profileCodexHomeShortcutNames,
         }),
       );
@@ -512,7 +535,7 @@ export class DesktopRunStartService {
         runtimeInstructions: resolvedRuntimeInstructions,
         settings: resolvedSettings.settings as unknown as Record<string, unknown>,
         workspaceRoot: effectiveWorkspaceRoot,
-        runContext,
+        runContext: runtimeRunContext,
       });
     } catch (error) {
       if (pendingSessionId) {
@@ -575,21 +598,21 @@ export class DesktopRunStartService {
       }
     }
 
-    this.#setRunContextByThreadId(result.threadId, result.runContext ?? runContext ?? null);
+    this.#setRunContextByThreadId(result.threadId, result.runContext ?? runtimeRunContext ?? runContext ?? null);
     await recordDesktopPolicyOutcome({
       dbPath: substrateDbPath,
       outcome: runPolicyOutcome,
       recordAuditEvent: (event) => {
         this.#recordAuditEvent(event);
       },
-      runContext: result.runContext ?? runContext ?? null,
+      runContext: result.runContext ?? runtimeRunContext ?? runContext ?? null,
       sessionId: substrateSession?.sessionId ?? null,
       threadId: result.threadId,
       workspaceRoot: effectiveWorkspaceRoot,
     });
     this.#recordAuditEvent({
       eventType: "run.started",
-      runContext: result.runContext ?? runContext ?? null,
+      runContext: result.runContext ?? runtimeRunContext ?? runContext ?? null,
       threadId: result.threadId,
       turnId: result.turnId,
       details: {
@@ -608,7 +631,7 @@ export class DesktopRunStartService {
     }
     await this.#rememberLastSelectedThread({ threadId: result.threadId });
     if (substrateSession?.sessionId) {
-      this.#setRunContextByThreadId(result.threadId, result.runContext ?? runContext ?? null);
+      this.#setRunContextByThreadId(result.threadId, result.runContext ?? runtimeRunContext ?? runContext ?? null);
     }
     await this.#substrateSync.flushDeferredMessages(result.threadId, substrateDbPath);
     await this.#workspaceService.rememberThreadInteractionState(

--- a/desktop/src/main/session/session-controller.test.js
+++ b/desktop/src/main/session/session-controller.test.js
@@ -6244,7 +6244,7 @@ test("runDesktopTask resolves native shortcut mentions before starting the turn"
   ]);
 });
 
-test("runDesktopTask routes profile-global creator shortcuts through profile codex home even when folder-bound", async () => {
+test("runDesktopTask keeps folder-bound creator shortcuts inside the selected workspace while granting profile codex home writes", async () => {
   const root = await makeTempRoot();
   const env = createTestEnv(root);
   const workspaceRoot = path.join(root, "workspace-profile-global-shortcuts");
@@ -6374,7 +6374,19 @@ test("runDesktopTask routes profile-global creator shortcuts through profile cod
     threadStart?.params.developerInstructions
     ?? threadStart?.params.config?.developer_instructions
     ?? "";
-  assert.equal(await fs.realpath(turnStart?.params.cwd), await fs.realpath(profileCodexHome));
+  assert.equal(await fs.realpath(turnStart?.params.cwd), await fs.realpath(workspaceRoot));
+  assert.deepEqual(
+    await Promise.all(
+      (turnStart?.params?.settings?.sense1?.runContext?.grants ?? []).map(async (grant) => await fs.realpath(grant.rootPath)),
+    ),
+    await Promise.all([fs.realpath(workspaceRoot), fs.realpath(profileCodexHome)]),
+  );
+  assert.deepEqual(
+    await Promise.all(
+      (turnStart?.params?.sandboxPolicy?.writableRoots ?? []).map(async (rootPath) => await fs.realpath(rootPath)),
+    ),
+    await Promise.all([fs.realpath(workspaceRoot), fs.realpath(profileCodexHome)]),
+  );
   assert.match(
     developerInstructions,
     new RegExp(profileCodexHome.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),

--- a/desktop/src/main/session/thread-entry-mapper.js
+++ b/desktop/src/main/session/thread-entry-mapper.js
@@ -1,4 +1,5 @@
 import { buildPlanState } from "./plan-state.ts";
+import { resolveInputItemPromptShortcutMatches } from "../../shared/prompt-shortcuts.ts";
 
 function firstString(...values) {
   for (const value of values) {
@@ -55,16 +56,21 @@ export function mapItemToEntry(item) {
 
   if (item.type === "userMessage") {
     const content = Array.isArray(item.content) ? item.content : [];
+    const promptShortcuts = resolveInputItemPromptShortcutMatches(content).map((match) => ({
+      kind: match.kind,
+      label: match.label,
+      token: match.token,
+    }));
     const text = content
       .filter((entry) => entry?.type === "text" && typeof entry.text === "string")
       .map((entry) => entry.text)
       .join("\n")
       .trim();
     const attachmentCount = content.filter(
-      (entry) => entry?.type === "mention" || entry?.type === "localImage",
+      (entry) => entry?.type === "localImage",
     ).length;
 
-    if (!text && attachmentCount === 0) {
+    if (!text && attachmentCount === 0 && promptShortcuts.length === 0) {
       return null;
     }
 
@@ -74,9 +80,14 @@ export function mapItemToEntry(item) {
       title: "You",
       body:
         text ||
-        (attachmentCount === 1
-          ? "Attached 1 file."
-          : `Attached ${attachmentCount} files.`),
+        (promptShortcuts.length > 0 && attachmentCount === 0
+          ? promptShortcuts.length === 1
+            ? "Used 1 shortcut."
+            : `Used ${promptShortcuts.length} shortcuts.`
+          : attachmentCount === 1
+            ? "Attached 1 file."
+            : `Attached ${attachmentCount} files.`),
+      ...(promptShortcuts.length > 0 ? { promptShortcuts } : {}),
     };
   }
 

--- a/desktop/src/main/session/thread-entry-mapper.js
+++ b/desktop/src/main/session/thread-entry-mapper.js
@@ -56,7 +56,9 @@ export function mapItemToEntry(item) {
 
   if (item.type === "userMessage") {
     const content = Array.isArray(item.content) ? item.content : [];
-    const promptShortcuts = resolveInputItemPromptShortcutMatches(content).map((match) => ({
+    const shortcutMatches = resolveInputItemPromptShortcutMatches(content);
+    const shortcutItems = new Set(shortcutMatches.map((match) => match.item));
+    const promptShortcuts = shortcutMatches.map((match) => ({
       kind: match.kind,
       label: match.label,
       token: match.token,
@@ -67,7 +69,7 @@ export function mapItemToEntry(item) {
       .join("\n")
       .trim();
     const attachmentCount = content.filter(
-      (entry) => entry?.type === "localImage",
+      (entry) => entry?.type === "localImage" || (entry?.type === "mention" && !shortcutItems.has(entry)),
     ).length;
 
     if (!text && attachmentCount === 0 && promptShortcuts.length === 0) {

--- a/desktop/src/main/session/thread-state-accumulator.test.js
+++ b/desktop/src/main/session/thread-state-accumulator.test.js
@@ -41,6 +41,21 @@ test("mapItemToEntry maps a userMessage item into a user entry", () => {
   });
 });
 
+test("mapItemToEntry counts non-shortcut mention attachments as files", () => {
+  const entry = mapItemToEntry({
+    id: "user-file-1",
+    type: "userMessage",
+    content: [{ type: "mention", name: "brief.md", path: "/tmp/session/brief.md" }],
+  });
+
+  assert.deepEqual(entry, {
+    id: "user-file-1",
+    kind: "user",
+    title: "You",
+    body: "Attached 1 file.",
+  });
+});
+
 test("mapItemToEntry maps an agentMessage item into an assistant entry", () => {
   const entry = mapItemToEntry({
     id: "agent-1",

--- a/desktop/src/main/workspace/workspace-boundary.test.js
+++ b/desktop/src/main/workspace/workspace-boundary.test.js
@@ -5,6 +5,7 @@ import path from "node:path";
 import fs from "node:fs/promises";
 
 import {
+  collectOutOfWorkspacePathsFromRuntimeMessage,
   deriveWorkspaceGrantRoot,
   findPromptPathsOutsideWorkspace,
   isPathWithinRoot,
@@ -38,5 +39,30 @@ test("deriveWorkspaceGrantRoot requests the parent folder for outside file targe
   assert.equal(
     deriveWorkspaceGrantRoot(["/tmp/outside/report.md"]),
     path.resolve("/tmp/outside"),
+  );
+});
+
+test("collectOutOfWorkspacePathsFromRuntimeMessage allows extra granted roots", () => {
+  const workspaceRoot = "/tmp/project";
+  const profileCodexHome = "/tmp/profile/codex-home";
+
+  assert.deepEqual(
+    collectOutOfWorkspacePathsFromRuntimeMessage(
+      {
+        method: "item/completed",
+        params: {
+          item: {
+            type: "fileChange",
+            changes: [
+              { path: "/tmp/project/notes.txt" },
+              { path: "/tmp/profile/codex-home/skills/new-skill/SKILL.md" },
+            ],
+          },
+        },
+      },
+      workspaceRoot,
+      [profileCodexHome],
+    ),
+    [],
   );
 });

--- a/desktop/src/main/workspace/workspace-boundary.ts
+++ b/desktop/src/main/workspace/workspace-boundary.ts
@@ -100,6 +100,13 @@ export function isPathWithinRoot(
   return Boolean(relativePath) && !relativePath.startsWith("..") && !path.isAbsolute(relativePath);
 }
 
+export function isPathWithinAnyRoot(
+  targetPath: string | null | undefined,
+  rootPaths: Array<string | null | undefined> | null | undefined,
+): boolean {
+  return (Array.isArray(rootPaths) ? rootPaths : []).some((rootPath) => isPathWithinRoot(targetPath, rootPath));
+}
+
 export function extractAbsolutePathsFromText(text: string | null | undefined): string[] {
   const source = firstString(text);
   if (!source) {
@@ -168,9 +175,14 @@ function collectItemPaths(item: unknown): string[] {
 export function collectOutOfWorkspacePathsFromRuntimeMessage(
   message: AppServerNotification | Record<string, unknown> | null | undefined,
   workspaceRoot: string | null | undefined,
+  allowedRoots: Array<string | null | undefined> = [],
 ): string[] {
   const resolvedRoot = firstString(workspaceRoot);
-  if (!resolvedRoot) {
+  const effectiveRoots = [
+    resolvedRoot,
+    ...allowedRoots,
+  ].filter(Boolean);
+  if (effectiveRoots.length === 0) {
     return [];
   }
 
@@ -180,7 +192,7 @@ export function collectOutOfWorkspacePathsFromRuntimeMessage(
 
   if (method === "item/started" || method === "item/completed") {
     for (const candidate of collectItemPaths(params?.item)) {
-      if (!isPathWithinRoot(candidate, resolvedRoot)) {
+      if (!isPathWithinAnyRoot(candidate, effectiveRoots)) {
         outside.add(path.resolve(candidate));
       }
     }
@@ -190,7 +202,7 @@ export function collectOutOfWorkspacePathsFromRuntimeMessage(
     const diffs = Array.isArray(params?.diffs) ? params.diffs : [];
     for (const diff of diffs) {
       const candidate = firstString(asRecord(diff)?.path);
-      if (candidate && !isPathWithinRoot(candidate, resolvedRoot)) {
+      if (candidate && !isPathWithinAnyRoot(candidate, effectiveRoots)) {
         outside.add(path.resolve(candidate));
       }
     }

--- a/desktop/src/renderer/components/thread-view/thread-entry-list.tsx
+++ b/desktop/src/renderer/components/thread-view/thread-entry-list.tsx
@@ -1,5 +1,5 @@
 import { memo, useRef, useState } from "react";
-import { Check, ChevronRight, Copy } from "lucide-react";
+import { Blocks, Check, ChevronRight, Copy, PlugZap, Sparkles } from "lucide-react";
 
 import { ThreadMarkdown } from "../../thread-markdown.js";
 import {
@@ -67,6 +67,38 @@ function EntryCopyButton({ text }: { text: string }) {
     >
       {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
     </button>
+  );
+}
+
+function ThreadEntryShortcutPills({
+  matches,
+}: {
+  matches: Array<{
+    kind: "app" | "plugin" | "skill";
+    label: string;
+    token: string;
+  }>;
+}) {
+  if (matches.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mb-2 flex flex-wrap items-center gap-2">
+      {matches.map((match) => {
+        const Icon = match.kind === "app" ? Blocks : match.kind === "plugin" ? PlugZap : Sparkles;
+        return (
+          <span
+            className="inline-flex items-center gap-1.5 rounded-full bg-ink px-3 py-1 text-[0.6875rem] font-semibold text-white shadow-[0_8px_20px_rgba(10,15,20,0.12)]"
+            key={`${match.kind}:${match.token}:${match.label}`}
+            title={`$${match.token} -> ${match.label}`}
+          >
+            <Icon className="size-3.5 text-white/80" />
+            <span className="font-bold">{match.label}</span>
+          </span>
+        );
+      })}
+    </div>
   );
 }
 
@@ -141,6 +173,9 @@ const ThreadEntryCard = memo(function ThreadEntryCard({
   if (entry.kind === "user") {
     return (
       <article className="ml-auto w-full max-w-[78%] rounded-xl bg-[color-mix(in_oklch,var(--color-ink)_5%,white)] px-3 py-2 text-[0.8125rem]">
+        {"promptShortcuts" in entry && Array.isArray(entry.promptShortcuts) && entry.promptShortcuts.length > 0 ? (
+          <ThreadEntryShortcutPills matches={entry.promptShortcuts} />
+        ) : null}
         <ThreadMarkdown className="thread-markdown-user" workspaceRoot={workspaceRoot}>
           {entryBody}
         </ThreadMarkdown>

--- a/desktop/src/renderer/lib/live-thread-data.d.ts
+++ b/desktop/src/renderer/lib/live-thread-data.d.ts
@@ -10,6 +10,11 @@ export type DesktopThreadEntry =
       kind: "user" | "assistant" | "tool" | "review" | "activity";
       title: string;
       body: string;
+      promptShortcuts?: Array<{
+        kind: "app" | "plugin" | "skill";
+        label: string;
+        token: string;
+      }>;
       status?: string;
     }
   | {

--- a/desktop/src/renderer/lib/live-thread-data.js
+++ b/desktop/src/renderer/lib/live-thread-data.js
@@ -1,3 +1,5 @@
+import { resolveInputItemPromptShortcutMatches } from "../../shared/prompt-shortcuts.ts";
+
 function firstString(...values) {
   for (const value of values) {
     if (typeof value !== "string") {
@@ -125,6 +127,11 @@ function fileNameFromPath(value) {
 }
 
 function mapUserMessageContent(content) {
+  const shortcuts = resolveInputItemPromptShortcutMatches(Array.isArray(content) ? content : []).map((match) => ({
+    kind: match.kind,
+    label: match.label,
+    token: match.token,
+  }));
   const text = (Array.isArray(content) ? content : [])
     .filter((entry) => entry?.type === "text" && typeof entry.text === "string")
     .map((entry) => entry.text)
@@ -132,19 +139,24 @@ function mapUserMessageContent(content) {
     .trim();
 
   const attachmentCount = (Array.isArray(content) ? content : []).filter(
-    (entry) => entry?.type === "mention" || entry?.type === "localImage",
+    (entry) => entry?.type === "localImage",
   ).length;
 
-  if (!text && attachmentCount === 0) {
+  if (!text && attachmentCount === 0 && shortcuts.length === 0) {
     return null;
   }
 
   return {
+    promptShortcuts: shortcuts,
     body:
       text ||
-      (attachmentCount === 1
-        ? "Attached 1 file."
-        : `Attached ${attachmentCount} files.`),
+      (shortcuts.length > 0 && attachmentCount === 0
+        ? shortcuts.length === 1
+          ? "Used 1 shortcut."
+          : `Used ${shortcuts.length} shortcuts.`
+        : attachmentCount === 1
+          ? "Attached 1 file."
+          : `Attached ${attachmentCount} files.`),
   };
 }
 
@@ -160,6 +172,7 @@ export function mapItemToThreadEntry(item) {
       kind: "user",
       title: "You",
       body: content.body,
+      ...(content.promptShortcuts.length > 0 ? { promptShortcuts: content.promptShortcuts } : {}),
     };
   }
 

--- a/desktop/src/renderer/lib/live-thread-data.js
+++ b/desktop/src/renderer/lib/live-thread-data.js
@@ -127,19 +127,22 @@ function fileNameFromPath(value) {
 }
 
 function mapUserMessageContent(content) {
-  const shortcuts = resolveInputItemPromptShortcutMatches(Array.isArray(content) ? content : []).map((match) => ({
+  const normalizedContent = Array.isArray(content) ? content : [];
+  const shortcutMatches = resolveInputItemPromptShortcutMatches(normalizedContent);
+  const shortcutItems = new Set(shortcutMatches.map((match) => match.item));
+  const shortcuts = shortcutMatches.map((match) => ({
     kind: match.kind,
     label: match.label,
     token: match.token,
   }));
-  const text = (Array.isArray(content) ? content : [])
+  const text = normalizedContent
     .filter((entry) => entry?.type === "text" && typeof entry.text === "string")
     .map((entry) => entry.text)
     .join("\n")
     .trim();
 
-  const attachmentCount = (Array.isArray(content) ? content : []).filter(
-    (entry) => entry?.type === "localImage",
+  const attachmentCount = normalizedContent.filter(
+    (entry) => entry?.type === "localImage" || (entry?.type === "mention" && !shortcutItems.has(entry)),
   ).length;
 
   if (!text && attachmentCount === 0 && shortcuts.length === 0) {

--- a/desktop/src/renderer/lib/live-thread-data.test.js
+++ b/desktop/src/renderer/lib/live-thread-data.test.js
@@ -98,6 +98,27 @@ test("buildThreadEntries keeps shortcut mentions so the transcript can render pi
   ]);
 });
 
+test("buildThreadEntries counts non-shortcut mention attachments as files", () => {
+  const entries = buildThreadEntries([
+    {
+      id: "user-file-1",
+      type: "userMessage",
+      content: [
+        { type: "mention", name: "brief.md", path: "/tmp/session/brief.md" },
+      ],
+    },
+  ]);
+
+  assert.deepEqual(entries, [
+    {
+      id: "user-file-1",
+      kind: "user",
+      title: "You",
+      body: "Attached 1 file.",
+    },
+  ]);
+});
+
 test("buildChangeGroups and progress summary reflect live file changes", () => {
   const entries = buildThreadEntries([
     {

--- a/desktop/src/renderer/lib/live-thread-data.test.js
+++ b/desktop/src/renderer/lib/live-thread-data.test.js
@@ -71,6 +71,33 @@ test("buildThreadEntries coerces non-string command output into safe text", () =
   assert.equal(entries[0].body, JSON.stringify({ changed: ["App.tsx"] }));
 });
 
+test("buildThreadEntries keeps shortcut mentions so the transcript can render pills", () => {
+  const entries = buildThreadEntries([
+    {
+      id: "user-shortcuts-1",
+      type: "userMessage",
+      content: [
+        { type: "mention", name: "skill-creator", path: "/Users/george/.codex/skills/.system/skill-creator/SKILL.md" },
+        { type: "mention", name: "plugin-creator", path: "/Users/george/.codex/skills/.system/plugin-creator/SKILL.md" },
+        { type: "text", text: "Create a reusable skill and plugin." },
+      ],
+    },
+  ]);
+
+  assert.deepEqual(entries, [
+    {
+      id: "user-shortcuts-1",
+      kind: "user",
+      title: "You",
+      body: "Create a reusable skill and plugin.",
+      promptShortcuts: [
+        { kind: "skill", label: "skill-creator", token: "skill-creator" },
+        { kind: "skill", label: "plugin-creator", token: "plugin-creator" },
+      ],
+    },
+  ]);
+});
+
 test("buildChangeGroups and progress summary reflect live file changes", () => {
   const entries = buildThreadEntries([
     {

--- a/desktop/src/shared/contracts/thread-core.ts
+++ b/desktop/src/shared/contracts/thread-core.ts
@@ -96,6 +96,11 @@ export type DesktopThreadEntry =
       readonly kind: "user" | "assistant" | "tool" | "review" | "activity";
       readonly title: string;
       readonly body: string;
+      readonly promptShortcuts?: Array<{
+        readonly kind: "app" | "plugin" | "skill";
+        readonly label: string;
+        readonly token: string;
+      }>;
       readonly status?: string;
     }
   | {

--- a/desktop/src/shared/prompt-shortcuts.ts
+++ b/desktop/src/shared/prompt-shortcuts.ts
@@ -284,6 +284,10 @@ function chooseAppToken(app: DesktopAppRecord): string | null {
   return normalizeShortcutKey(app.name) ?? normalizeShortcutKey(app.id);
 }
 
+function fileBasename(filePath: string): string {
+  return filePath.split(/[\\/]/).filter(Boolean).at(-1) ?? filePath;
+}
+
 function resolveShortcutTargetKind(
   token: string,
   overview: Pick<DesktopExtensionOverviewResult, "apps" | "plugins" | "skills">,
@@ -692,4 +696,68 @@ export function resolvePromptShortcutInputItems(
   overview: Pick<DesktopExtensionOverviewResult, "apps" | "plugins" | "skills">,
 ): DesktopAppServerInputItem[] {
   return resolvePromptShortcutMatches(prompt, overview).map((match) => match.item);
+}
+
+export function resolveInputItemPromptShortcutMatches(
+  inputItems: DesktopAppServerInputItem[],
+): DesktopPromptShortcutMatch[] {
+  const matches: DesktopPromptShortcutMatch[] = [];
+  const seenKeys = new Set<string>();
+
+  for (const item of inputItems) {
+    if (item?.type !== "mention") {
+      continue;
+    }
+
+    const itemPath = firstString(item.path);
+    if (!itemPath) {
+      continue;
+    }
+
+    const itemName = firstString(item.name);
+    const normalizedName = normalizeShortcutKey(itemName);
+    const parts = normalizedName?.split(":").filter(Boolean) ?? [];
+    const namespace = parts[0] ?? null;
+    const localName = parts.at(-1) ?? null;
+    const fallbackToken = normalizeShortcutKey(
+      itemPath.startsWith("app://")
+        ? itemPath.slice("app://".length)
+        : fileBasename(itemPath).replace(/\.[^.]+$/u, ""),
+    );
+
+    const kind: DesktopPromptShortcutMatch["kind"] =
+      itemPath.startsWith("app://")
+        ? "app"
+        : parts.length >= 2 && namespace === localName
+          ? "plugin"
+          : "skill";
+    const token = localName ?? normalizedName ?? fallbackToken;
+    if (!token) {
+      continue;
+    }
+
+    const label =
+      kind === "app"
+        ? firstString(itemName, itemPath.slice("app://".length))
+        : kind === "plugin"
+          ? firstString(localName, namespace, itemName)
+          : firstString(localName, itemName, fallbackToken);
+    if (!label) {
+      continue;
+    }
+
+    const key = `${kind}:${itemPath}`;
+    if (seenKeys.has(key)) {
+      continue;
+    }
+    seenKeys.add(key);
+    matches.push({
+      item,
+      kind,
+      label,
+      token,
+    });
+  }
+
+  return matches;
 }

--- a/desktop/src/shared/prompt-shortcuts.ts
+++ b/desktop/src/shared/prompt-shortcuts.ts
@@ -55,6 +55,23 @@ function normalizeShortcutKey(value: unknown): string | null {
   return normalized || null;
 }
 
+function normalizeInputItemPath(value: unknown): string | null {
+  const resolved = firstString(value);
+  if (!resolved) {
+    return null;
+  }
+
+  return resolved.replaceAll("\\", "/");
+}
+
+function isPromptShortcutMentionPath(value: unknown): boolean {
+  const normalizedPath = normalizeInputItemPath(value);
+  return Boolean(
+    normalizedPath
+      && (normalizedPath.startsWith("app://") || normalizedPath.endsWith("/SKILL.md")),
+  );
+}
+
 function dedupeKeys(values: Array<string | null | undefined>): string[] {
   const seen = new Set<string>();
   const keys: string[] = [];
@@ -755,7 +772,7 @@ export function resolveInputItemPromptShortcutMatches(
     }
 
     const itemPath = firstString(item.path);
-    if (!itemPath) {
+    if (!itemPath || !isPromptShortcutMentionPath(itemPath)) {
       continue;
     }
 


### PR DESCRIPTION
## Summary

This fixes the folder-bound creator shortcut flow that was hard-blocking `$skill-creator`, `$plugin-creator`, and `$skill-installer` runs when the thread was rooted in a selected workspace.

In the broken flow, Sense-1 rewrote the run `cwd` to profile `codex-home` as soon as one of those creator shortcuts was resolved. That moved the active write target outside the chosen workspace, so the desktop boundary guard immediately stopped the run with `Workspace boundary blocked` even when desktop settings were already configured to allow file changes. The same shortcut mentions were also flattened away in the transcript path, so the thread stream lost the shortcut pills that the composer had already resolved.

## Root cause

The regression came from two independent pieces of state getting collapsed together:

- The session startup path treated creator shortcuts as a reason to replace the run `cwd` with profile `codex-home`.
- The runtime sandbox and boundary code only carried a single writable root, so there was no way to keep the selected workspace as the active `cwd` while also allowing writes into profile `codex-home` for the installed skill/plugin output.
- User-message transcript mapping converted mention items into a generic attachment count, which dropped the metadata needed to render shortcut pills in the thread stream.

## Fix

The fix keeps the selected workspace as the run `cwd` and separately propagates an additional writable root for profile `codex-home` when creator shortcuts are present. That extra root now flows through:

- session startup runtime context construction,
- turn sandbox policy generation,
- workspace boundary filtering.

This means folder-bound creator flows can still install into profile `codex-home` without being forced out of the selected workspace.

On the renderer side, user-message mapping now preserves resolved shortcut metadata and the transcript renders shortcut pills for those entries, so the thread stream matches what the composer resolved before send.

## Validation

I validated the fix with focused automated checks:

- `node --test desktop/src/main/session/session-controller.test.js desktop/src/main/workspace/workspace-boundary.test.js`
- `node --test desktop/src/renderer/lib/live-thread-data.test.js`
- `pnpm --dir desktop typecheck`

Closes #30.
