### PR TITLE
[codex] keep thread-created extensions visible in management

### DIFF
--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -6,6 +6,10 @@ import { DesktopSessionController } from "./session-controller.js";
 import { resolveDesktopProfile } from "./bootstrap/desktop-bootstrap.js";
 import { resolveSignedInDesktopProfile } from "./bootstrap/bootstrap-profile.js";
 import {
+  filterProfileCodexHomeRoots,
+  ManagementInventoryChangeTracker,
+} from "./settings/management-inventory-change.ts";
+import {
   createMainWindow,
   focusMainWindow,
 } from "./window";
@@ -50,6 +54,7 @@ const threadAccumulator = new ThreadStateAccumulator();
 const threadInputQueue = new ThreadInputQueueService();
 const workspaceFileActivity = new WorkspaceFileActivityTracker();
 const runtimeFileChangeTracker = new RuntimeFileChangeTracker();
+const managementInventoryChangeTracker = new ManagementInventoryChangeTracker();
 const workspaceState = new DesktopWorkspaceStateService({
   env: process.env,
   resolveProfile: async () => await resolveSignedInDesktopProfile(appServerManager, process.env),
@@ -523,6 +528,13 @@ appServerManager.on("notification", (message) => {
   }
   runtimeFileChangeTracker.observe(message);
   if (threadId) {
+    const threadRunContext = desktopSessionController.getThreadRunContext(threadId);
+    managementInventoryChangeTracker.observe(
+      message,
+      filterProfileCodexHomeRoots(threadRunContext?.grants.map((grant) => grant.rootPath) ?? []),
+    );
+  }
+  if (threadId) {
     const folderRoot = currentThreadState?.workspaceRoot ?? currentThreadState?.cwd ?? null;
     const runContext = desktopSessionController.getThreadRunContext(threadId);
     const outsideWorkspacePaths = collectOutOfWorkspacePathsFromRuntimeMessage(
@@ -614,6 +626,9 @@ appServerManager.on("notification", (message) => {
       void persistInteractionState(threadId).catch(() => {});
     }
     runtimeFileChangeTracker.clear(threadId);
+    if (managementInventoryChangeTracker.consume(threadId)) {
+      emitDesktopRuntimeEvent({ kind: "managementInventoryChanged" });
+    }
 
     const completionStatus = completionStatusLabel(messageParams?.turn?.status ?? messageParams?.status);
     const completionResult = threadInputQueue.handleTurnCompleted({

--- a/desktop/src/main/session/desktop-run-start-service.ts
+++ b/desktop/src/main/session/desktop-run-start-service.ts
@@ -171,9 +171,12 @@ function buildProfileExtensionRuntimeInstruction({
     instructions.push(
       `When creating or installing Sense-1 skills, treat ${profileCodexHome} as the active profile CODEX_HOME. Install them there so they are callable from any thread in this profile.`,
     );
+    instructions.push(
+      `This run already has write access to ${profileCodexHome}. Do not claim sandbox, workspace-boundary, or permission blocking for profile skill installation when writing under that root.`,
+    );
     if (shortcutNames.has("skill-creator")) {
       instructions.push(
-        `When the user asks for a new Sense-1 skill, finish with a callable profile skill in ${profileCodexHome}/skills. Do not stop at a TODO-only template or placeholder scaffold.`,
+        `When the user asks for a new Sense-1 skill, finish with a callable installed profile skill in ${profileCodexHome}/skills. Do not stop at a TODO-only template, placeholder scaffold, or a draft left in the selected workspace for later move/install unless the user explicitly asked for workspace-local scaffold output.`,
       );
     }
   }
@@ -186,6 +189,9 @@ function buildProfileExtensionRuntimeInstruction({
       : "";
     instructions.push(
       `When scaffolding a Sense-1 profile plugin, treat ${profileCodexHome} as the active home root. Create the plugin under ${profilePluginsDir} and, if you need a marketplace entry for home-local discovery, write it to ${profileMarketplacePath}.`,
+    );
+    instructions.push(
+      `Do not leave the finished plugin scaffold in the selected workspace for later manual move/install when ${profileCodexHome} is writable in this run.`,
     );
     if (pluginCreatorSkillPath && pluginCreatorScriptPath) {
       instructions.push(

--- a/desktop/src/main/session/session-controller.test.js
+++ b/desktop/src/main/session/session-controller.test.js
@@ -6393,8 +6393,11 @@ test("runDesktopTask keeps folder-bound creator shortcuts inside the selected wo
   );
   assert.match(developerInstructions, /profile plugin/u);
   assert.match(developerInstructions, /profile CODEX_HOME/u);
+  assert.match(developerInstructions, /already has write access/u);
+  assert.match(developerInstructions, /Do not claim sandbox, workspace-boundary, or permission blocking/u);
   assert.match(developerInstructions, /create_basic_plugin\.py/u);
   assert.match(developerInstructions, /Do not stop at a TODO-only template/u);
+  assert.match(developerInstructions, /or a draft left in the selected workspace for later move\/install/u);
 });
 
 test("runDesktopTask falls back to plain text when shortcut overview lookup fails", async () => {

--- a/desktop/src/main/settings/management-inventory-change.test.js
+++ b/desktop/src/main/settings/management-inventory-change.test.js
@@ -1,0 +1,99 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  collectManagementInventoryPathsFromRuntimeMessage,
+  filterProfileCodexHomeRoots,
+  isManagementInventoryPath,
+  ManagementInventoryChangeTracker,
+} from "./management-inventory-change.ts";
+
+const profileCodexHome = "/tmp/profile/codex-home";
+const workspaceRoot = "/tmp/project";
+
+test("filterProfileCodexHomeRoots keeps only profile codex-home grants", () => {
+  assert.deepEqual(
+    filterProfileCodexHomeRoots([
+      workspaceRoot,
+      profileCodexHome,
+      `${workspaceRoot}/nested/codex-home`,
+      profileCodexHome,
+      null,
+    ]),
+    [
+      profileCodexHome,
+      `${workspaceRoot}/nested/codex-home`,
+    ],
+  );
+});
+
+test("isManagementInventoryPath recognizes skills, plugins, marketplace, temp plugins, and config", () => {
+  assert.equal(isManagementInventoryPath(`${profileCodexHome}/skills/my-skill/SKILL.md`, [profileCodexHome]), true);
+  assert.equal(isManagementInventoryPath(`${profileCodexHome}/plugins/my-plugin/.codex-plugin/plugin.json`, [profileCodexHome]), true);
+  assert.equal(isManagementInventoryPath(`${profileCodexHome}/.agents/plugins/marketplace.json`, [profileCodexHome]), true);
+  assert.equal(isManagementInventoryPath(`${profileCodexHome}/.tmp/plugins/plugins/my-plugin/.app.json`, [profileCodexHome]), true);
+  assert.equal(isManagementInventoryPath(`${profileCodexHome}/config.toml`, [profileCodexHome]), true);
+  assert.equal(isManagementInventoryPath("/tmp/project/skills/not-a-profile-skill/SKILL.md", [profileCodexHome]), false);
+});
+
+test("collectManagementInventoryPathsFromRuntimeMessage filters runtime changes to profile-managed inventory", () => {
+  const paths = collectManagementInventoryPathsFromRuntimeMessage({
+    method: "item/completed",
+    params: {
+      threadId: "thread-1",
+      item: {
+        type: "fileChange",
+        changes: [
+          { path: `${profileCodexHome}/skills/my-skill/SKILL.md` },
+          { path: `${profileCodexHome}/config.toml` },
+          { path: "/tmp/project/src/index.ts" },
+        ],
+      },
+    },
+  }, [profileCodexHome]);
+
+  assert.deepEqual(paths, [
+    `${profileCodexHome}/skills/my-skill/SKILL.md`,
+    `${profileCodexHome}/config.toml`,
+  ]);
+});
+
+test("collectManagementInventoryPathsFromRuntimeMessage ignores workspace-local inventory lookalikes", () => {
+  const paths = collectManagementInventoryPathsFromRuntimeMessage({
+    method: "item/completed",
+    params: {
+      threadId: "thread-1",
+      item: {
+        type: "fileChange",
+        changes: [
+          { path: `${workspaceRoot}/skills/workspace-draft/SKILL.md` },
+          { path: `${workspaceRoot}/plugins/workspace-plugin/.codex-plugin/plugin.json` },
+          { path: `${workspaceRoot}/config.toml` },
+        ],
+      },
+    },
+  }, [workspaceRoot]);
+
+  assert.deepEqual(paths, []);
+});
+
+test("ManagementInventoryChangeTracker records runtime inventory changes once per turn", () => {
+  const tracker = new ManagementInventoryChangeTracker();
+
+  tracker.observe({
+    method: "turn/started",
+    params: { threadId: "thread-1" },
+  }, [profileCodexHome]);
+  tracker.observe({
+    method: "turn/diff/updated",
+    params: {
+      threadId: "thread-1",
+      diffs: [
+        { path: `${profileCodexHome}/plugins/my-plugin/.codex-plugin/plugin.json` },
+      ],
+    },
+  }, [profileCodexHome]);
+
+  assert.equal(tracker.consume("thread-1"), true);
+  assert.equal(tracker.consume("thread-1"), false);
+});

--- a/desktop/src/main/settings/management-inventory-change.ts
+++ b/desktop/src/main/settings/management-inventory-change.ts
@@ -1,0 +1,172 @@
+import path from "node:path";
+
+import { isPathWithinAnyRoot, isPathWithinRoot } from "../workspace/workspace-boundary.ts";
+
+interface AppServerNotification {
+  method?: unknown;
+  params?: unknown;
+}
+
+function firstString(...values: Array<unknown>): string | null {
+  for (const value of values) {
+    if (typeof value !== "string") {
+      continue;
+    }
+
+    const trimmed = value.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  return null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function uniquePaths(paths: string[]): string[] {
+  return Array.from(new Set(paths.map((candidate) => path.resolve(candidate))));
+}
+
+export function filterProfileCodexHomeRoots(
+  roots: Array<string | null | undefined>,
+): string[] {
+  return uniquePaths(
+    roots
+      .map((candidate) => firstString(candidate))
+      .filter((candidate): candidate is string => Boolean(candidate))
+      .filter((candidate) => path.basename(path.resolve(candidate)) === "codex-home"),
+  );
+}
+
+function collectFileChangePaths(item: unknown): string[] {
+  const record = asRecord(item);
+  if (!record || record.type !== "fileChange" || !Array.isArray(record.changes)) {
+    return [];
+  }
+
+  return record.changes
+    .map((change) => asRecord(change))
+    .map((change) => firstString(change?.path))
+    .filter((candidate): candidate is string => Boolean(candidate));
+}
+
+function collectDiffPaths(diffs: unknown): string[] {
+  if (!Array.isArray(diffs)) {
+    return [];
+  }
+
+  return diffs
+    .map((diff) => asRecord(diff))
+    .map((diff) => firstString(diff?.path))
+    .filter((candidate): candidate is string => Boolean(candidate));
+}
+
+function resolveInventoryRoots(codexHomeRoots: Array<string | null | undefined>): string[] {
+  const roots = filterProfileCodexHomeRoots(codexHomeRoots);
+
+  const inventoryRoots: string[] = [];
+  for (const root of roots) {
+    inventoryRoots.push(path.join(root, "skills"));
+    inventoryRoots.push(path.join(root, "plugins"));
+    inventoryRoots.push(path.join(root, ".agents", "plugins"));
+    inventoryRoots.push(path.join(root, ".tmp", "plugins"));
+  }
+  return inventoryRoots;
+}
+
+export function isManagementInventoryPath(
+  candidatePath: string | null | undefined,
+  codexHomeRoots: Array<string | null | undefined>,
+): boolean {
+  const resolvedPath = firstString(candidatePath);
+  if (!resolvedPath) {
+    return false;
+  }
+
+  const absolutePath = path.resolve(resolvedPath);
+  const configRoots = codexHomeRoots
+    .flatMap((root) => filterProfileCodexHomeRoots([root]))
+    .map((root) => path.join(root, "config.toml"));
+  if (configRoots.includes(absolutePath)) {
+    return true;
+  }
+
+  return isPathWithinAnyRoot(absolutePath, resolveInventoryRoots(codexHomeRoots));
+}
+
+export function collectManagementInventoryPathsFromRuntimeMessage(
+  message: AppServerNotification | Record<string, unknown> | null | undefined,
+  codexHomeRoots: Array<string | null | undefined>,
+): string[] {
+  const method = firstString(message?.method);
+  const params = asRecord(message?.params);
+  if (!method || !params) {
+    return [];
+  }
+
+  let changedPaths: string[] = [];
+  if (method === "item/completed") {
+    changedPaths = collectFileChangePaths(params.item);
+  } else if (method === "turn/diff/updated") {
+    changedPaths = collectDiffPaths(params.diffs);
+  }
+
+  return uniquePaths(changedPaths.filter((candidate) => isManagementInventoryPath(candidate, codexHomeRoots)));
+}
+
+export class ManagementInventoryChangeTracker {
+  readonly #changedThreadIds = new Set<string>();
+
+  observe(
+    message: AppServerNotification | Record<string, unknown> | null | undefined,
+    codexHomeRoots: Array<string | null | undefined>,
+  ): void {
+    const record = asRecord(message);
+    const method = firstString(record?.method);
+    const params = asRecord(record?.params);
+    const threadId = firstString(params?.threadId);
+    if (!method || !threadId) {
+      return;
+    }
+
+    if (method === "turn/started") {
+      this.#changedThreadIds.delete(threadId);
+      return;
+    }
+
+    if (collectManagementInventoryPathsFromRuntimeMessage(record, codexHomeRoots).length > 0) {
+      this.#changedThreadIds.add(threadId);
+    }
+  }
+
+  consume(threadId: string | null | undefined): boolean {
+    const resolvedThreadId = firstString(threadId);
+    if (!resolvedThreadId) {
+      return false;
+    }
+
+    const hasChanged = this.#changedThreadIds.has(resolvedThreadId);
+    this.#changedThreadIds.delete(resolvedThreadId);
+    return hasChanged;
+  }
+
+  clear(threadId: string | null | undefined): void {
+    const resolvedThreadId = firstString(threadId);
+    if (!resolvedThreadId) {
+      return;
+    }
+
+    this.#changedThreadIds.delete(resolvedThreadId);
+  }
+
+  clearAll(): void {
+    this.#changedThreadIds.clear();
+  }
+}

--- a/desktop/src/renderer/components/thread-view/thread-entry-list.tsx
+++ b/desktop/src/renderer/components/thread-view/thread-entry-list.tsx
@@ -2,7 +2,6 @@ import { memo, useRef, useState } from "react";
 import { Blocks, Check, ChevronRight, Copy, PlugZap, Sparkles } from "lucide-react";
 
 import { ThreadMarkdown } from "../../thread-markdown.js";
-import { ShortcutPillRow } from "../composer/shortcut-pill-row.js";
 import {
   coerceDisplayText,
   firstLinePreview,
@@ -193,7 +192,6 @@ const ThreadEntryCard = memo(function ThreadEntryCard({
         {"promptShortcuts" in entry && Array.isArray(entry.promptShortcuts) && entry.promptShortcuts.length > 0 ? (
           <ThreadEntryShortcutPills matches={entry.promptShortcuts} />
         ) : null}
-        <ShortcutPillRow className="mb-2" overview={extensionOverview} prompt={entryBody} />
         <ThreadMarkdown className="thread-markdown-user" workspaceRoot={workspaceRoot}>
           {visibleUserBody}
         </ThreadMarkdown>

--- a/desktop/src/renderer/features/management/management-runtime-events.test.js
+++ b/desktop/src/renderer/features/management/management-runtime-events.test.js
@@ -1,0 +1,10 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { shouldReloadManagementOverviewForRuntimeEvent } from "./management-runtime-events.ts";
+
+test("shouldReloadManagementOverviewForRuntimeEvent only reloads for inventory changes", () => {
+  assert.equal(shouldReloadManagementOverviewForRuntimeEvent({ kind: "managementInventoryChanged" }), true);
+  assert.equal(shouldReloadManagementOverviewForRuntimeEvent({ kind: "accountChanged" }), false);
+  assert.equal(shouldReloadManagementOverviewForRuntimeEvent(null), false);
+});

--- a/desktop/src/renderer/features/management/management-runtime-events.ts
+++ b/desktop/src/renderer/features/management/management-runtime-events.ts
@@ -1,0 +1,7 @@
+import type { DesktopRuntimeEvent } from "../../../main/contracts";
+
+export function shouldReloadManagementOverviewForRuntimeEvent(
+  event: DesktopRuntimeEvent | null | undefined,
+): boolean {
+  return event?.kind === "managementInventoryChanged";
+}

--- a/desktop/src/renderer/features/management/use-desktop-management.ts
+++ b/desktop/src/renderer/features/management/use-desktop-management.ts
@@ -13,6 +13,7 @@ import type {
   DesktopSkillUninstallRequest,
 } from "../../../main/contracts";
 import { requireDesktopBridge } from "../../state/session/desktop-bridge.js";
+import { shouldReloadManagementOverviewForRuntimeEvent } from "./management-runtime-events.ts";
 
 export function useDesktopManagement({
   enabled,
@@ -50,6 +51,23 @@ export function useDesktopManagement({
   useEffect(() => {
     void loadOverview(false);
   }, [loadOverview]);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const bridge = requireDesktopBridge();
+    const unsubscribe = bridge.session.onRuntimeEvent((event) => {
+      if (shouldReloadManagementOverviewForRuntimeEvent(event)) {
+        void loadOverview(true);
+      }
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [enabled, loadOverview]);
 
   const setPluginEnabled = useCallback(async (request: DesktopPluginEnabledRequest) => {
     const bridge = requireDesktopBridge();

--- a/desktop/src/renderer/lib/live-thread-data.test.js
+++ b/desktop/src/renderer/lib/live-thread-data.test.js
@@ -118,7 +118,6 @@ test("buildThreadEntries counts non-shortcut mention attachments as files", () =
     },
   ]);
 });
-
 test("buildChangeGroups and progress summary reflect live file changes", () => {
   const entries = buildThreadEntries([
     {

--- a/desktop/src/shared/contracts/events.ts
+++ b/desktop/src/shared/contracts/events.ts
@@ -110,6 +110,9 @@ export type DesktopRuntimeEvent =
       readonly kind: "accountChanged";
     }
   | {
+      readonly kind: "managementInventoryChanged";
+    }
+  | {
       readonly kind: "threadContentChanged";
       readonly threadId: string | null;
     }


### PR DESCRIPTION
This fixes the extension-creator workspace flow end to end for folder-bound threads.

Before this change, creator shortcuts such as `skill-creator`, `plugin-creator`, and `skill-installer` still had a split-brain behavior. The product expectation was that they should run from the selected workspace, ask for or use the profile `codex-home` write grant when they need to install profile-scoped inventory, and then leave the resulting skills/plugins/MCP config visible on the management page. In practice, two things went wrong. First, creator flows could still be forced toward profile-managed paths in a way that tripped the workspace-boundary model. Second, even when inventory was written successfully, the management page only refreshed after explicit actions taken from the page itself, so thread-created extensions could remain invisible until a manual reload.

The root cause was that the desktop runtime treated creator shortcuts and management visibility as two separate concerns. The run-start path needed special handling for profile `codex-home` writes, while the management page only reloaded from direct management mutations. There was no narrow runtime signal for “this turn changed managed extension inventory under the granted profile home”, and the transcript/shortcut mapping path also needed to keep the creator mentions intact so the thread stream still reflected what happened.

This branch fixes that in two layers. It keeps folder-bound creator shortcuts rooted in the selected workspace and grants profile `codex-home` as an additional writable root instead of replacing the run cwd. It also preserves shortcut mentions through the thread stream. On top of that, it adds a targeted management-inventory detector in the main process, watches for completed-turn writes under granted profile `codex-home` inventory roots such as `skills`, `plugins`, `.agents/plugins`, `.tmp/plugins`, and `config.toml`, and emits a dedicated runtime event when that inventory changes. The management hook listens for that event and refetches the overview once, which makes newly created or installed skills/plugins/MCP-related config visible on the management page without broad polling or refreshes on every thread-content update.

Validation was focused on the affected paths. I ran the session-controller suite that covers the creator-shortcut workspace behavior, added focused tests for the inventory detector and runtime-event reload gate, reran the live-thread data tests that cover shortcut-pill preservation, and ran `pnpm --dir desktop typecheck`. I also reran the narrow workspace-boundary tests. I did not run a full Electron manual flow in the desktop app, and the existing `pnpm --dir desktop check` structure warnings remain unchanged.
