### PR TITLE
[codex] Establish extension lifecycle contract for management flows

### DIFF
--- a/EXTENSION_LIFECYCLE_CONTRACT.md
+++ b/EXTENSION_LIFECYCLE_CONTRACT.md
@@ -1,0 +1,114 @@
+# Extension Lifecycle Contract
+
+This document defines the first normalized management contract for Sense-1 extensions. It is intentionally additive: the existing tab-specific records remain in `DesktopExtensionOverviewResult`, and the new normalized `managedExtensions` collection exists to stabilize downstream lifecycle, ownership, and management work.
+
+## Why This Exists
+
+Sense-1 already aggregates extension data from multiple app-server and profile-local sources in `desktop/src/main/settings/desktop-extension-service.ts`, but the current public contract is only a set of tab-specific inventory arrays:
+
+- `plugins`
+- `apps`
+- `mcpServers`
+- `skills`
+
+That shape is enough for a flat inventory page, but not for a real extension lifecycle product. The normalized contract captures orthogonal state dimensions and explicit ownership so later issues can build backend lifecycle rules and frontend detail views on stable data.
+
+## Upstream Inputs Observed Today
+
+`DesktopExtensionService.getOverview()` currently merges the following upstream inputs:
+
+- `config/read`
+- `plugin/list`
+- `app/list`
+- `mcpServerStatus/list`
+- `skills/list`
+- `account/read`
+- profile-local `config.toml` toggles
+- plugin-local metadata from:
+  - `.app.json`
+  - `.mcp.json`
+  - `skills/*/SKILL.md`
+
+See:
+
+- `desktop/src/main/settings/desktop-extension-service.ts`
+- `desktop/src/shared/contracts/management.ts`
+
+## Merge Rules
+
+### Provider state
+
+Provider state is derived from `account/read` plus `config/read`, with local environment detection for Gemini and Ollama. This remains unchanged by the normalized extension contract.
+
+### Plugin records
+
+Plugin records are sourced from `plugin/list`, then enriched with local plugin metadata:
+
+1. Start with app-server marketplace/plugin summary fields.
+2. Overlay enablement from config:
+   - runtime config first
+   - then profile-local `config.toml` toggles when runtime config is stale
+3. Enrich installed state, `sourcePath`, `appIds`, plugin-owned skills, and plugin-owned MCP IDs from plugin-local files under the resolved plugin root.
+
+### App records
+
+App records are sourced from `app/list`, then backfilled with plugin linkage based on plugin metadata:
+
+1. Start with app-server app summary fields.
+2. Overlay enablement from config:
+   - runtime config first
+   - then profile-local `config.toml` toggles when runtime config is stale
+3. Backfill plugin ownership hints from plugin metadata when the runtime app payload is incomplete.
+
+### Skill records
+
+Skill records are sourced from `skills/list`, then merged with plugin-local skill discovery:
+
+1. Start with runtime skill records.
+2. Add plugin-owned skills found under installed plugin `skills/*/SKILL.md`.
+3. Preserve runtime skill data when a skill already exists in the runtime payload.
+
+### MCP records
+
+MCP records are sourced from `mcpServerStatus/list` plus config:
+
+1. Use the union of configured MCP IDs and runtime status IDs.
+2. Derive enablement from config.
+3. Derive runtime state, auth state hints, and tools/resources counts from runtime status.
+4. Backfill plugin ownership from plugin-local `.mcp.json` when available.
+
+## Normalized Managed Extension Contract
+
+The normalized contract adds `contractVersion: 1` and `managedExtensions` to `DesktopExtensionOverviewResult`.
+
+Each managed extension record models orthogonal state dimensions separately:
+
+- `installState`: `discoverable` or `installed`
+- `enablementState`: `enabled` or `disabled`
+- `authState`: `not-required`, `required`, `connected`, or `failed`
+- `healthState`: `healthy`, `warning`, or `error`
+- `ownership`: `built-in`, `profile-owned`, `plugin-owned`, or `marketplace-installed`
+
+It also carries:
+
+- `ownerPluginIds`
+- bundled child IDs for plugin records
+- `capabilities`
+- `sourcePath`
+- `marketplaceName`
+- `marketplacePath`
+- action capability hints:
+  - `canOpen`
+  - `canUninstall`
+  - `canDisable`
+
+## Current Intentional Limits
+
+The first contract version is intentionally conservative.
+
+1. `managedExtensions` is additive and does not replace the current tab arrays.
+2. Action capability hints describe what the current backend can safely support; they are not a promise of final Codex parity yet.
+3. App install/discovery semantics are still partly inferred because current `app/list` payloads do not cleanly distinguish every lifecycle state.
+4. Plugin-owned MCP linkage depends on plugin-local `.mcp.json`; if a plugin does not provide that file, MCP ownership falls back to profile-owned.
+
+These limits should be revisited in later lifecycle issues once `plugin/read`, richer auth flows, and full management detail surfaces are implemented.

--- a/desktop/src/main/settings/desktop-extension-service.test.js
+++ b/desktop/src/main/settings/desktop-extension-service.test.js
@@ -37,9 +37,25 @@ async function createInstalledPluginFixture() {
     }),
     "utf8",
   );
+  await fs.writeFile(
+    path.join(pluginRoot, ".mcp.json"),
+    JSON.stringify({
+      mcpServers: {
+        "plugin-mcp": {
+          type: "http",
+          url: "https://example.com/mcp",
+        },
+      },
+    }),
+    "utf8",
+  );
   await fs.mkdir(path.join(pluginRoot, "skills", "gmail"), { recursive: true });
   await fs.writeFile(path.join(pluginRoot, "skills", "gmail", "SKILL.md"), "# Gmail\n", "utf8");
   return pluginRoot;
+}
+
+function findManagedExtension(overview, kind, id) {
+  return overview.managedExtensions.find((entry) => entry.kind === kind && entry.id === id) ?? null;
 }
 
 test("getOverview preserves marketplace metadata and uses the profile codex home for plugin discovery", async () => {
@@ -140,6 +156,7 @@ test("getOverview preserves marketplace metadata and uses the profile codex home
       forceRefetch: true,
     });
 
+    assert.equal(overview.contractVersion, 1);
     const pluginListCall = managerCalls.find((entry) => entry.method === "plugin/list");
     const skillsListCall = managerCalls.find((entry) => entry.method === "skills/list");
     assert.deepEqual(pluginListCall?.params, {
@@ -178,6 +195,217 @@ test("getOverview preserves marketplace metadata and uses the profile codex home
       isEnabled: false,
       pluginDisplayNames: ["Gmail"],
       logoUrl: null,
+    });
+  } finally {
+    await fs.rm(runtimeStateRoot, { force: true, recursive: true });
+    await fs.rm(pluginRoot, { force: true, recursive: true });
+  }
+});
+
+test("getOverview emits normalized managed extensions with ownership, auth, and composition metadata", async () => {
+  const runtimeStateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-runtime-state-"));
+  const env = {
+    ...process.env,
+    SENSE1_RUNTIME_STATE_ROOT: runtimeStateRoot,
+  };
+  const pluginRoot = await createInstalledPluginFixture();
+  try {
+    const service = new DesktopExtensionService({
+      env,
+      manager: createManager(async (method) => {
+        if (method === "config/read") {
+          return {
+            config: {
+              apps: {
+                connector_gmail: {
+                  enabled: false,
+                },
+              },
+              mcp_servers: {
+                "plugin-mcp": {
+                  enabled: true,
+                  url: "https://example.com/mcp",
+                },
+              },
+              plugins: {
+                gmail: {
+                  enabled: true,
+                },
+              },
+            },
+          };
+        }
+
+        if (method === "plugin/list") {
+          return {
+            marketplaces: [
+              {
+                name: "OpenAI Curated",
+                path: "/tmp/openai-curated-marketplace.json",
+                plugins: [
+                  {
+                    id: "gmail",
+                    name: "gmail",
+                    installed: true,
+                    enabled: true,
+                    source: {
+                      path: pluginRoot,
+                    },
+                    installPolicy: "AVAILABLE",
+                    authPolicy: "ON_INSTALL",
+                    interface: {
+                      displayName: "Gmail",
+                      shortDescription: "Read and draft Gmail.",
+                      capabilities: ["Interactive", "Write"],
+                    },
+                  },
+                ],
+              },
+            ],
+          };
+        }
+
+        if (method === "app/list") {
+          return {
+            data: [
+              {
+                id: "connector_gmail",
+                name: "Gmail",
+                description: "Read Gmail",
+                installUrl: "https://chatgpt.com/gmail/install",
+                isAccessible: false,
+                isEnabled: false,
+                pluginDisplayNames: ["Gmail"],
+              },
+            ],
+          };
+        }
+
+        if (method === "mcpServerStatus/list") {
+          return {
+            data: [
+              {
+                id: "plugin-mcp",
+                state: "ready",
+                authStatus: "connected",
+                tools: [{ name: "search" }],
+                resources: [{ name: "docs" }],
+              },
+            ],
+          };
+        }
+
+        if (method === "skills/list") {
+          return { data: [] };
+        }
+
+        if (method === "account/read") {
+          return createAccountReadResult();
+        }
+
+        throw new Error(`Unexpected method: ${method}`);
+      }),
+      openExternal: async () => {},
+      resolveProfile: async () => ({ id: "default" }),
+    });
+
+    const overview = await service.getOverview({ forceRefetch: true });
+    const pluginRecord = findManagedExtension(overview, "plugin", "gmail");
+    const appRecord = findManagedExtension(overview, "app", "connector_gmail");
+    const skillRecord = findManagedExtension(overview, "skill", path.join(pluginRoot, "skills", "gmail", "SKILL.md"));
+    const mcpRecord = findManagedExtension(overview, "mcp", "plugin-mcp");
+
+    assert.deepEqual(pluginRecord, {
+      id: "gmail",
+      kind: "plugin",
+      name: "gmail",
+      displayName: "Gmail",
+      description: "Read and draft Gmail.",
+      installState: "installed",
+      enablementState: "enabled",
+      authState: "required",
+      healthState: "warning",
+      ownership: "marketplace-installed",
+      ownerPluginIds: [],
+      includedSkillIds: [path.join(pluginRoot, "skills", "gmail", "SKILL.md")],
+      includedAppIds: ["connector_gmail"],
+      includedMcpServerIds: ["plugin-mcp"],
+      capabilities: ["Interactive", "Write"],
+      sourcePath: pluginRoot,
+      marketplaceName: "OpenAI Curated",
+      marketplacePath: "/tmp/openai-curated-marketplace.json",
+      canOpen: true,
+      canUninstall: false,
+      canDisable: true,
+    });
+    assert.deepEqual(appRecord, {
+      id: "connector_gmail",
+      kind: "app",
+      name: "Gmail",
+      displayName: "Gmail",
+      description: "Read Gmail",
+      installState: "installed",
+      enablementState: "disabled",
+      authState: "required",
+      healthState: "warning",
+      ownership: "plugin-owned",
+      ownerPluginIds: ["gmail"],
+      includedSkillIds: [],
+      includedAppIds: [],
+      includedMcpServerIds: [],
+      capabilities: [],
+      sourcePath: null,
+      marketplaceName: null,
+      marketplacePath: null,
+      canOpen: false,
+      canUninstall: false,
+      canDisable: false,
+    });
+    assert.deepEqual(skillRecord, {
+      id: path.join(pluginRoot, "skills", "gmail", "SKILL.md"),
+      kind: "skill",
+      name: "gmail:gmail",
+      displayName: "gmail:gmail",
+      description: null,
+      installState: "installed",
+      enablementState: "enabled",
+      authState: "not-required",
+      healthState: "healthy",
+      ownership: "plugin-owned",
+      ownerPluginIds: ["gmail"],
+      includedSkillIds: [],
+      includedAppIds: [],
+      includedMcpServerIds: [],
+      capabilities: [],
+      sourcePath: path.join(pluginRoot, "skills", "gmail", "SKILL.md"),
+      marketplaceName: "OpenAI Curated",
+      marketplacePath: "/tmp/openai-curated-marketplace.json",
+      canOpen: true,
+      canUninstall: false,
+      canDisable: true,
+    });
+    assert.deepEqual(mcpRecord, {
+      id: "plugin-mcp",
+      kind: "mcp",
+      name: "plugin-mcp",
+      displayName: "plugin-mcp",
+      description: "https://example.com/mcp",
+      installState: "installed",
+      enablementState: "enabled",
+      authState: "connected",
+      healthState: "healthy",
+      ownership: "plugin-owned",
+      ownerPluginIds: ["gmail"],
+      includedSkillIds: [],
+      includedAppIds: [],
+      includedMcpServerIds: [],
+      capabilities: [],
+      sourcePath: null,
+      marketplaceName: "OpenAI Curated",
+      marketplacePath: "/tmp/openai-curated-marketplace.json",
+      canOpen: false,
+      canUninstall: false,
+      canDisable: true,
     });
   } finally {
     await fs.rm(runtimeStateRoot, { force: true, recursive: true });
@@ -284,9 +512,109 @@ test("getOverview merges file-backed plugin and app enablement when runtime conf
     const overview = await service.getOverview({ forceRefetch: true });
     assert.equal(overview.plugins[0]?.enabled, true);
     assert.equal(overview.apps[0]?.isEnabled, true);
+    assert.equal(findManagedExtension(overview, "plugin", "gmail@openai-curated")?.enablementState, "enabled");
+    assert.equal(findManagedExtension(overview, "app", "connector_gmail")?.enablementState, "enabled");
   } finally {
     await fs.rm(runtimeStateRoot, { force: true, recursive: true });
     await fs.rm(pluginRoot, { force: true, recursive: true });
+  }
+});
+
+test("getOverview does not treat apps linked only to discoverable plugins as installed plugin-owned inventory", async () => {
+  const runtimeStateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-runtime-state-"));
+  const env = {
+    ...process.env,
+    SENSE1_RUNTIME_STATE_ROOT: runtimeStateRoot,
+  };
+  const service = new DesktopExtensionService({
+    env,
+    manager: createManager(async (method) => {
+      if (method === "config/read") {
+        return { config: { apps: {}, plugins: {} } };
+      }
+
+      if (method === "plugin/list") {
+        return {
+          marketplaces: [
+            {
+              name: "OpenAI Curated",
+              path: "/tmp/openai-curated-marketplace.json",
+              plugins: [
+                {
+                  id: "gmail",
+                  name: "gmail",
+                  installed: false,
+                  enabled: false,
+                  interface: {
+                    displayName: "Gmail",
+                  },
+                },
+              ],
+            },
+          ],
+        };
+      }
+
+      if (method === "app/list") {
+        return {
+          data: [
+            {
+              id: "connector_gmail",
+              name: "Gmail",
+              installUrl: "https://chatgpt.com/gmail/install",
+              isAccessible: false,
+              isEnabled: false,
+              pluginDisplayNames: ["Gmail"],
+            },
+          ],
+        };
+      }
+
+      if (method === "mcpServerStatus/list") {
+        return { data: [] };
+      }
+
+      if (method === "skills/list") {
+        return { data: [] };
+      }
+
+      if (method === "account/read") {
+        return createAccountReadResult();
+      }
+
+      throw new Error(`Unexpected method: ${method}`);
+    }),
+    openExternal: async () => {},
+    resolveProfile: async () => ({ id: "default" }),
+  });
+
+  try {
+    const overview = await service.getOverview({ forceRefetch: true });
+    assert.deepEqual(findManagedExtension(overview, "app", "connector_gmail"), {
+      id: "connector_gmail",
+      kind: "app",
+      name: "Gmail",
+      displayName: "Gmail",
+      description: null,
+      installState: "discoverable",
+      enablementState: "disabled",
+      authState: "required",
+      healthState: "warning",
+      ownership: "built-in",
+      ownerPluginIds: [],
+      includedSkillIds: [],
+      includedAppIds: [],
+      includedMcpServerIds: [],
+      capabilities: [],
+      sourcePath: null,
+      marketplaceName: null,
+      marketplacePath: null,
+      canOpen: false,
+      canUninstall: false,
+      canDisable: false,
+    });
+  } finally {
+    await fs.rm(runtimeStateRoot, { force: true, recursive: true });
   }
 });
 

--- a/desktop/src/main/settings/desktop-extension-service.ts
+++ b/desktop/src/main/settings/desktop-extension-service.ts
@@ -11,6 +11,10 @@ import type {
   DesktopAppRecord,
   DesktopExtensionOverviewRequest,
   DesktopExtensionOverviewResult,
+  DesktopManagedExtensionAuthState,
+  DesktopManagedExtensionHealthState,
+  DesktopManagedExtensionOwnership,
+  DesktopManagedExtensionRecord,
   DesktopMcpServerEnabledRequest,
   DesktopMcpServerRecord,
   DesktopPluginInstallRequest,
@@ -61,6 +65,7 @@ type PluginInstallResult = {
 
 type LocalPluginMetadata = {
   readonly appIds: string[];
+  readonly mcpServerIds: string[];
   readonly sourcePath: string | null;
   readonly skills: DesktopSkillRecord[];
 };
@@ -96,6 +101,10 @@ function asBoolean(value: unknown, fallback = false): boolean {
 
 function asStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
+}
+
+function normalizeStoredPath(value: string | null | undefined): string {
+  return typeof value === "string" ? value.replaceAll("\\", "/") : "";
 }
 
 function uniqueStrings(values: Array<string | null | undefined>): string[] {
@@ -551,6 +560,7 @@ async function readPluginLocalMetadata(
   if (!sourcePath) {
     return {
       appIds: [],
+      mcpServerIds: [],
       sourcePath: null,
       skills: [],
     };
@@ -563,6 +573,12 @@ async function readPluginLocalMetadata(
     appIds = uniqueStrings(
       Object.values(appJson?.apps ?? {}).map((appRecord) => firstString(asRecord(appRecord).id)),
     );
+  } catch {}
+
+  let mcpServerIds: string[] = [];
+  try {
+    const mcpJson = JSON.parse(await fs.readFile(path.join(sourcePath, ".mcp.json"), "utf8")) as { mcpServers?: Record<string, unknown> };
+    mcpServerIds = uniqueStrings(Object.keys(mcpJson?.mcpServers ?? {}));
   } catch {}
 
   const skillsRoot = path.join(sourcePath, "skills");
@@ -594,6 +610,7 @@ async function readPluginLocalMetadata(
 
   return {
     appIds,
+    mcpServerIds,
     sourcePath,
     skills,
   };
@@ -741,6 +758,266 @@ function normalizeSkills(rawSkills: unknown): DesktopSkillRecord[] {
   return records.sort((left, right) => left.name.localeCompare(right.name));
 }
 
+function pluginOwnership(plugin: DesktopPluginRecord): DesktopManagedExtensionOwnership {
+  const normalizedSourcePath = normalizeStoredPath(plugin.sourcePath);
+  if (!plugin.installed) {
+    return "marketplace-installed";
+  }
+  if (normalizedSourcePath.includes("/codex-home/plugins/") && !normalizedSourcePath.includes("/codex-home/plugins/cache/")) {
+    return "profile-owned";
+  }
+  if (plugin.marketplacePath || normalizedSourcePath.includes("/codex-home/plugins/cache/")) {
+    return "marketplace-installed";
+  }
+  return "built-in";
+}
+
+function skillOwnership(skill: DesktopSkillRecord, ownerPluginIds: string[]): DesktopManagedExtensionOwnership {
+  if (ownerPluginIds.length > 0 || skill.scope === "plugin") {
+    return "plugin-owned";
+  }
+  if (normalizeStoredPath(skill.path).includes("/codex-home/skills/")) {
+    return "profile-owned";
+  }
+  return "built-in";
+}
+
+function appOwnership(ownerPluginIds: string[]): DesktopManagedExtensionOwnership {
+  return ownerPluginIds.length > 0 ? "plugin-owned" : "built-in";
+}
+
+function mcpOwnership(ownerPluginIds: string[]): DesktopManagedExtensionOwnership {
+  return ownerPluginIds.length > 0 ? "plugin-owned" : "profile-owned";
+}
+
+function appAuthState(app: DesktopAppRecord): DesktopManagedExtensionAuthState {
+  if (!app.installUrl) {
+    return "not-required";
+  }
+  return app.isAccessible ? "connected" : "required";
+}
+
+function pluginAuthState(plugin: DesktopPluginRecord, apps: DesktopAppRecord[]): DesktopManagedExtensionAuthState {
+  const relatedApps = apps.filter((app) => plugin.appIds.includes(app.id));
+  if (relatedApps.some((app) => app.installUrl && !app.isAccessible)) {
+    return "required";
+  }
+  if (relatedApps.some((app) => app.installUrl && app.isAccessible)) {
+    return "connected";
+  }
+  return "not-required";
+}
+
+function mcpAuthState(server: DesktopMcpServerRecord): DesktopManagedExtensionAuthState {
+  const normalized = firstString(server.authStatus)?.toLowerCase() ?? "";
+  if (!normalized) {
+    return "not-required";
+  }
+  if (
+    normalized.includes("connected")
+    || normalized.includes("authenticated")
+    || normalized.includes("authorized")
+    || normalized.includes("ready")
+    || normalized.includes("ok")
+  ) {
+    return "connected";
+  }
+  if (normalized.includes("failed") || normalized.includes("error")) {
+    return "failed";
+  }
+  return "required";
+}
+
+function healthStateForAuth(authState: DesktopManagedExtensionAuthState): DesktopManagedExtensionHealthState {
+  if (authState === "failed") {
+    return "error";
+  }
+  if (authState === "required") {
+    return "warning";
+  }
+  return "healthy";
+}
+
+function mcpHealthState(server: DesktopMcpServerRecord, authState: DesktopManagedExtensionAuthState): DesktopManagedExtensionHealthState {
+  const normalizedState = firstString(server.state)?.toLowerCase() ?? "";
+  if (normalizedState.includes("error") || normalizedState.includes("failed") || authState === "failed") {
+    return "error";
+  }
+  if (authState === "required") {
+    return "warning";
+  }
+  return "healthy";
+}
+
+function buildManagedExtensions({
+  plugins,
+  apps,
+  mcpServers,
+  skills,
+  metadataByPluginId,
+}: {
+  plugins: DesktopPluginRecord[];
+  apps: DesktopAppRecord[];
+  mcpServers: DesktopMcpServerRecord[];
+  skills: DesktopSkillRecord[];
+  metadataByPluginId: Map<string, LocalPluginMetadata>;
+}): DesktopManagedExtensionRecord[] {
+  const pluginById = new Map(plugins.map((plugin) => [plugin.id, plugin] as const));
+  const skillOwnersByPath = new Map<string, string[]>();
+  const appOwnersById = new Map<string, string[]>();
+  const mcpOwnersById = new Map<string, string[]>();
+
+  for (const [pluginId, metadata] of metadataByPluginId.entries()) {
+    for (const skill of metadata.skills) {
+      skillOwnersByPath.set(skill.path, uniqueStrings([...(skillOwnersByPath.get(skill.path) ?? []), pluginId]));
+    }
+    for (const appId of metadata.appIds) {
+      appOwnersById.set(appId, uniqueStrings([...(appOwnersById.get(appId) ?? []), pluginId]));
+    }
+    for (const mcpServerId of metadata.mcpServerIds) {
+      mcpOwnersById.set(mcpServerId, uniqueStrings([...(mcpOwnersById.get(mcpServerId) ?? []), pluginId]));
+    }
+  }
+
+  for (const app of apps) {
+    const matchedPluginIds = plugins
+      .filter((plugin) =>
+        plugin.installed
+        && (
+          plugin.appIds.includes(app.id)
+        || app.pluginDisplayNames.includes(plugin.displayName)
+        || app.pluginDisplayNames.includes(plugin.name)
+        || app.pluginDisplayNames.includes(plugin.id)))
+      .map((plugin) => plugin.id);
+    if (matchedPluginIds.length === 0) {
+      continue;
+    }
+    appOwnersById.set(app.id, uniqueStrings([...(appOwnersById.get(app.id) ?? []), ...matchedPluginIds]));
+  }
+
+  const managedExtensions: DesktopManagedExtensionRecord[] = [];
+
+  for (const plugin of plugins) {
+    const authState = pluginAuthState(plugin, apps);
+    const metadata = metadataByPluginId.get(plugin.id);
+    managedExtensions.push({
+      id: plugin.id,
+      kind: "plugin",
+      name: plugin.name,
+      displayName: plugin.displayName,
+      description: plugin.description,
+      installState: plugin.installed ? "installed" : "discoverable",
+      enablementState: plugin.enabled ? "enabled" : "disabled",
+      authState,
+      healthState: healthStateForAuth(authState),
+      ownership: pluginOwnership(plugin),
+      ownerPluginIds: [],
+      includedSkillIds: metadata?.skills.map((skill) => skill.path) ?? [],
+      includedAppIds: metadata?.appIds ?? [],
+      includedMcpServerIds: metadata?.mcpServerIds ?? [],
+      capabilities: plugin.capabilities,
+      sourcePath: plugin.sourcePath,
+      marketplaceName: plugin.marketplaceName,
+      marketplacePath: plugin.marketplacePath,
+      canOpen: Boolean(plugin.sourcePath),
+      canUninstall: pluginOwnership(plugin) === "profile-owned",
+      canDisable: plugin.installed,
+    });
+  }
+
+  for (const app of apps) {
+    const authState = appAuthState(app);
+    const ownerPluginIds = uniqueStrings(appOwnersById.get(app.id) ?? []);
+    managedExtensions.push({
+      id: app.id,
+      kind: "app",
+      name: app.name,
+      displayName: app.name,
+      description: app.description,
+      installState: app.isAccessible || app.isEnabled || ownerPluginIds.length > 0 ? "installed" : "discoverable",
+      enablementState: app.isEnabled ? "enabled" : "disabled",
+      authState,
+      healthState: healthStateForAuth(authState),
+      ownership: appOwnership(ownerPluginIds),
+      ownerPluginIds,
+      includedSkillIds: [],
+      includedAppIds: [],
+      includedMcpServerIds: [],
+      capabilities: [],
+      sourcePath: null,
+      marketplaceName: null,
+      marketplacePath: null,
+      canOpen: false,
+      canUninstall: false,
+      canDisable: app.isAccessible,
+    });
+  }
+
+  for (const skill of skills) {
+    const ownerPluginIds = uniqueStrings(skillOwnersByPath.get(skill.path) ?? []);
+    const ownership = skillOwnership(skill, ownerPluginIds);
+    managedExtensions.push({
+      id: skill.path,
+      kind: "skill",
+      name: skill.name,
+      displayName: skill.name,
+      description: skill.description,
+      installState: "installed",
+      enablementState: skill.enabled ? "enabled" : "disabled",
+      authState: "not-required",
+      healthState: "healthy",
+      ownership,
+      ownerPluginIds,
+      includedSkillIds: [],
+      includedAppIds: [],
+      includedMcpServerIds: [],
+      capabilities: [],
+      sourcePath: skill.path,
+      marketplaceName: ownerPluginIds.length === 1 ? pluginById.get(ownerPluginIds[0])?.marketplaceName ?? null : null,
+      marketplacePath: ownerPluginIds.length === 1 ? pluginById.get(ownerPluginIds[0])?.marketplacePath ?? null : null,
+      canOpen: true,
+      canUninstall: ownership === "profile-owned",
+      canDisable: true,
+    });
+  }
+
+  for (const server of mcpServers) {
+    const authState = mcpAuthState(server);
+    const ownerPluginIds = uniqueStrings(mcpOwnersById.get(server.id) ?? []);
+    const ownership = mcpOwnership(ownerPluginIds);
+    managedExtensions.push({
+      id: server.id,
+      kind: "mcp",
+      name: server.id,
+      displayName: server.id,
+      description: firstString(server.command, server.url),
+      installState: "installed",
+      enablementState: server.enabled ? "enabled" : "disabled",
+      authState,
+      healthState: mcpHealthState(server, authState),
+      ownership,
+      ownerPluginIds,
+      includedSkillIds: [],
+      includedAppIds: [],
+      includedMcpServerIds: [],
+      capabilities: [],
+      sourcePath: null,
+      marketplaceName: ownerPluginIds.length === 1 ? pluginById.get(ownerPluginIds[0])?.marketplaceName ?? null : null,
+      marketplacePath: ownerPluginIds.length === 1 ? pluginById.get(ownerPluginIds[0])?.marketplacePath ?? null : null,
+      canOpen: false,
+      canUninstall: false,
+      canDisable: true,
+    });
+  }
+
+  return managedExtensions.sort((left, right) => {
+    if (left.kind === right.kind) {
+      return left.displayName.localeCompare(right.displayName);
+    }
+    return left.kind.localeCompare(right.kind);
+  });
+}
+
 export class DesktopExtensionService {
   readonly #env: NodeJS.ProcessEnv;
   readonly #manager: AppServerProcessManager;
@@ -846,12 +1123,22 @@ export class DesktopExtensionService {
       plugins,
       metadataByPluginId,
     );
-
-    return {
-      provider,
+    const mcpServers = normalizeMcpServers(mcpResult, asRecord(config?.mcp_servers));
+    const managedExtensions = buildManagedExtensions({
       plugins,
       apps,
-      mcpServers: normalizeMcpServers(mcpResult, asRecord(config?.mcp_servers)),
+      mcpServers,
+      skills,
+      metadataByPluginId,
+    });
+
+    return {
+      contractVersion: 1,
+      provider,
+      managedExtensions,
+      plugins,
+      apps,
+      mcpServers,
       skills,
     };
   }

--- a/desktop/src/shared/contracts/management.ts
+++ b/desktop/src/shared/contracts/management.ts
@@ -37,6 +37,37 @@ export interface DesktopPluginRecord {
   readonly iconPath: string | null;
 }
 
+export type DesktopManagedExtensionKind = "plugin" | "skill" | "app" | "mcp";
+export type DesktopManagedExtensionInstallState = "discoverable" | "installed";
+export type DesktopManagedExtensionEnablementState = "enabled" | "disabled";
+export type DesktopManagedExtensionAuthState = "not-required" | "required" | "connected" | "failed";
+export type DesktopManagedExtensionHealthState = "healthy" | "warning" | "error";
+export type DesktopManagedExtensionOwnership = "built-in" | "profile-owned" | "plugin-owned" | "marketplace-installed";
+
+export interface DesktopManagedExtensionRecord {
+  readonly id: string;
+  readonly kind: DesktopManagedExtensionKind;
+  readonly name: string;
+  readonly displayName: string;
+  readonly description: string | null;
+  readonly installState: DesktopManagedExtensionInstallState;
+  readonly enablementState: DesktopManagedExtensionEnablementState;
+  readonly authState: DesktopManagedExtensionAuthState;
+  readonly healthState: DesktopManagedExtensionHealthState;
+  readonly ownership: DesktopManagedExtensionOwnership;
+  readonly ownerPluginIds: string[];
+  readonly includedSkillIds: string[];
+  readonly includedAppIds: string[];
+  readonly includedMcpServerIds: string[];
+  readonly capabilities: string[];
+  readonly sourcePath: string | null;
+  readonly marketplaceName: string | null;
+  readonly marketplacePath: string | null;
+  readonly canOpen: boolean;
+  readonly canUninstall: boolean;
+  readonly canDisable: boolean;
+}
+
 export interface DesktopAppRecord {
   readonly id: string;
   readonly name: string;
@@ -75,7 +106,9 @@ export interface DesktopExtensionOverviewRequest {
 }
 
 export interface DesktopExtensionOverviewResult {
+  readonly contractVersion: 1;
   readonly provider: DesktopProviderState;
+  readonly managedExtensions: DesktopManagedExtensionRecord[];
   readonly plugins: DesktopPluginRecord[];
   readonly apps: DesktopAppRecord[];
   readonly mcpServers: DesktopMcpServerRecord[];


### PR DESCRIPTION
Closes #44

## Summary
Sense-1's extension management layer currently exposes only tab-specific inventory arrays for plugins, apps, MCP servers, and skills. That is enough for the current flat management UI, but it is not enough to support a real lifecycle contract with explicit ownership, auth, health, and bundled-component semantics.

This PR establishes the first additive extension lifecycle contract without breaking the existing overview consumers. The backend now emits a normalized `managedExtensions` collection alongside the legacy `plugins`, `apps`, `mcpServers`, and `skills` arrays, and the repo now includes a contract note that documents the current upstream inputs and merge rules.

## Cause and effect
Before this change, later lifecycle work had to infer too much from ad hoc per-tab records:
- plugin-owned vs profile-owned items were not represented explicitly
- auth and health semantics were not normalized across entity types
- bundled plugin composition only existed indirectly through local metadata reads
- stale config merge behavior was tested for legacy fields only

That made the management layer harder to evolve and pushed lifecycle interpretation into renderer heuristics.

## Root cause
The shared management contract in `desktop/src/shared/contracts/management.ts` only modeled the current UI inventory slices. `DesktopExtensionService.getOverview()` normalized each slice independently, but there was no first-class, backend-owned domain model for extension lifecycle state.

## Fix
This PR:
- adds an additive normalized management contract with `contractVersion` and `managedExtensions`
- models install, enablement, auth, health, and ownership as separate axes
- enriches plugin-local metadata with bundled MCP server identifiers from `.mcp.json`
- derives normalized managed extension records in `DesktopExtensionService` while preserving the legacy overview arrays
- adds a repo-owned contract note describing the observed upstream inputs and merge rules
- adds focused tests for composition, ownership, auth, stale-config merging, and discoverable-plugin app handling

## Validation
- `node --test desktop/src/main/settings/desktop-extension-service.test.js`
- `pnpm --dir desktop typecheck`

## Notes
This is intentionally the contract foundation only. It does not replace the legacy overview arrays yet, and it does not attempt to finish the later lifecycle/UI issues in the milestone.
