### PR TITLE
Add extension detail views for plugin, app, MCP, and skill entities

### DIFF
--- a/desktop/src/renderer/components/PluginsPage.tsx
+++ b/desktop/src/renderer/components/PluginsPage.tsx
@@ -1,8 +1,12 @@
-import { useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { Blocks, Cable, ChevronDown, EllipsisVertical, Filter, Plus, PlugZap, RefreshCw, Search, Sparkles, Trash2 } from "lucide-react";
 
 import { Button } from "./ui/button";
-import type { DesktopAppRecord, DesktopExtensionOverviewResult, DesktopPluginRecord, DesktopSkillRecord } from "../../main/contracts";
+import type { DesktopAppRecord, DesktopExtensionOverviewResult, DesktopManagedExtensionKind, DesktopPluginRecord, DesktopSkillRecord } from "../../main/contracts";
+import { PluginDetailView } from "./extensions/PluginDetailView";
+import { SkillDetailModal } from "./extensions/SkillDetailModal";
+import { AppDetailView } from "./extensions/AppDetailView";
+import { McpDetailView } from "./extensions/McpDetailView";
 
 type ExtensionIconKind = "plugin" | "app" | "mcp" | "skill";
 
@@ -360,7 +364,6 @@ export function PluginsPage({
   uninstallPlugin,
   uninstallSkill,
 }: PluginsPageProps) {
-  void removeApp;
   const [activeTab, setActiveTab] = useState<PluginsTabId>("plugins");
   const [inventoryFilter, setInventoryFilter] = useState<InventoryFilter>("all");
   const [sourceFilter, setSourceFilter] = useState<SourceFilter>("all");
@@ -368,6 +371,28 @@ export function PluginsPage({
   const [actionError, setActionError] = useState<string | null>(null);
   const [actionFeedback, setActionFeedback] = useState<string | null>(null);
   const [pendingActionKey, setPendingActionKey] = useState<string | null>(null);
+
+  // Entity detail navigation state
+  const [selectedEntityId, setSelectedEntityId] = useState<string | null>(null);
+  const [selectedEntityKind, setSelectedEntityKind] = useState<DesktopManagedExtensionKind | null>(null);
+
+  const selectEntity = useCallback((id: string, kind: DesktopManagedExtensionKind) => {
+    setSelectedEntityId(id);
+    setSelectedEntityKind(kind);
+  }, []);
+
+  const clearSelection = useCallback(() => {
+    setSelectedEntityId(null);
+    setSelectedEntityKind(null);
+  }, []);
+
+  // Look up the managed record for the selected entity
+  const selectedManagedRecord = useMemo(() => {
+    if (!selectedEntityId || !selectedEntityKind || !overview) return null;
+    return overview.managedExtensions.find(
+      (e) => e.id === selectedEntityId && e.kind === selectedEntityKind,
+    ) ?? null;
+  }, [overview, selectedEntityId, selectedEntityKind]);
 
   const pluginAppsByDisplayName = useMemo(() => {
     const byDisplayName = new Map<string, DesktopAppRecord[]>();
@@ -462,7 +487,7 @@ export function PluginsPage({
             <button
               className={`rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors ${tab.id === activeTab ? "bg-ink text-white" : "text-ink-muted hover:bg-surface-soft hover:text-ink"}`}
               key={tab.id}
-              onClick={() => setActiveTab(tab.id)}
+              onClick={() => { setActiveTab(tab.id); clearSelection(); }}
               type="button"
             >
               {tab.label}
@@ -516,193 +541,273 @@ export function PluginsPage({
       ) : null}
 
       {/* ---- Content ---- */}
-      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
-        {loading && !overview ? <EmptyState message="Loading..." /> : null}
+      {/* Show detail view for plugin/app/mcp (replaces card grid) */}
+      {selectedManagedRecord && selectedEntityKind === "plugin" && overview ? (
+        <PluginDetailView
+          managedRecord={selectedManagedRecord}
+          overview={overview}
+          onBack={clearSelection}
+          onToggleEnabled={(next) => void runAction(`plugin-enable:${selectedManagedRecord.id}`, async () => await setPluginEnabled({ pluginId: selectedManagedRecord.id, enabled: next }))}
+          onUninstall={() => void runAction(`plugin-uninstall:${selectedManagedRecord.id}`, async () => { await uninstallPlugin({ pluginId: selectedManagedRecord.id }); clearSelection(); }, `Removed ${selectedManagedRecord.displayName}.`)}
+          onNavigateToEntity={(id, kind) => {
+            const tabMap = { skill: "skills", app: "apps", mcp: "mcps" } as const;
+            setActiveTab(tabMap[kind]);
+            selectEntity(id, kind);
+          }}
+          pendingActionKey={pendingActionKey}
+          Toggle={Toggle}
+        />
+      ) : selectedManagedRecord && selectedEntityKind === "app" && overview ? (
+        <AppDetailView
+          managedRecord={selectedManagedRecord}
+          legacyApp={overview.apps.find((a) => a.id === selectedManagedRecord.id)}
+          onBack={clearSelection}
+          onToggleEnabled={(next) => void runAction(`app-enable:${selectedManagedRecord.id}`, async () => await setAppEnabled({ appId: selectedManagedRecord.id, enabled: next }))}
+          onConnect={() => {
+            const legacyApp = overview.apps.find((a) => a.id === selectedManagedRecord.id);
+            if (legacyApp?.installUrl) {
+              void runAction(`app-connect:${selectedManagedRecord.id}`, async () => await openAppInstall({ appId: selectedManagedRecord.id, installUrl: legacyApp.installUrl ?? "" }), `Opened auth flow for ${selectedManagedRecord.displayName}.`);
+            }
+          }}
+          onRemove={() => void runAction(`app-remove:${selectedManagedRecord.id}`, async () => { await removeApp({ appId: selectedManagedRecord.id }); clearSelection(); }, `Removed ${selectedManagedRecord.displayName}.`)}
+          pendingActionKey={pendingActionKey}
+          Toggle={Toggle}
+        />
+      ) : selectedManagedRecord && selectedEntityKind === "mcp" && overview ? (
+        <McpDetailView
+          managedRecord={selectedManagedRecord}
+          legacyMcp={overview.mcpServers.find((m) => m.id === selectedManagedRecord.id)}
+          onBack={clearSelection}
+          onToggleEnabled={(next) => void runAction(`mcp-enable:${selectedManagedRecord.id}`, async () => await setMcpServerEnabled({ serverId: selectedManagedRecord.id, enabled: next }))}
+          pendingActionKey={pendingActionKey}
+          Toggle={Toggle}
+        />
+      ) : (
+        /* Default: show card grids */
+        <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
+          {loading && !overview ? <EmptyState message="Loading..." /> : null}
 
-        {/* ---------- Plugins ---------- */}
-        {activeTab === "plugins" && overview ? (
-          filteredPlugins.length > 0 ? (
-            <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
-              {filteredPlugins.map((plugin) => {
-                const authApp = resolvePluginAuth(plugin);
-                const canInstall = !plugin.installed && plugin.installPolicy !== "NOT_AVAILABLE" && Boolean(plugin.marketplacePath);
-                const canUninstall = pluginSource(plugin) === "profile";
-                const installKey = `plugin-install:${plugin.id}`;
-                const enableKey = `plugin-enable:${plugin.id}`;
-                const uninstallKey = `plugin-uninstall:${plugin.id}`;
-                const connectKey = authApp ? `app-connect:${authApp.id}` : null;
-                const needsConnect = plugin.installed && Boolean(authApp?.installUrl);
+          {/* ---------- Plugins ---------- */}
+          {activeTab === "plugins" && overview ? (
+            filteredPlugins.length > 0 ? (
+              <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+                {filteredPlugins.map((plugin) => {
+                  const authApp = resolvePluginAuth(plugin);
+                  const canInstall = !plugin.installed && plugin.installPolicy !== "NOT_AVAILABLE" && Boolean(plugin.marketplacePath);
+                  const canUninstall = pluginSource(plugin) === "profile";
+                  const installKey = `plugin-install:${plugin.id}`;
+                  const enableKey = `plugin-enable:${plugin.id}`;
+                  const uninstallKey = `plugin-uninstall:${plugin.id}`;
+                  const connectKey = authApp ? `app-connect:${authApp.id}` : null;
+                  const needsConnect = plugin.installed && Boolean(authApp?.installUrl);
 
-                return (
-                  <article
-                    className={`group flex items-start gap-3 rounded-xl px-3 py-2.5 transition-colors ${plugin.enabled ? "bg-surface-soft" : "bg-surface-soft/50"}`}
-                    key={plugin.id}
-                  >
-                    <ExtensionIcon kind="plugin" src={plugin.iconPath} />
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-2">
-                        <h3 className="truncate text-[13px] font-medium text-ink">{plugin.displayName}</h3>
-                        {!plugin.installed ? <span className="shrink-0 rounded bg-surface-strong px-1.5 py-0.5 text-[10px] text-muted">Available</span> : null}
-                        {needsConnect ? <span className="shrink-0 rounded bg-amber-50 px-1.5 py-0.5 text-[10px] text-amber-600">Auth</span> : null}
+                  return (
+                    <article
+                      className={`group flex cursor-pointer items-start gap-3 rounded-xl px-3 py-2.5 transition-colors hover:ring-1 hover:ring-accent/30 ${plugin.enabled ? "bg-surface-soft" : "bg-surface-soft/50"}`}
+                      key={plugin.id}
+                      onClick={() => selectEntity(plugin.id, "plugin")}
+                    >
+                      <ExtensionIcon kind="plugin" src={plugin.iconPath} />
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <h3 className="truncate text-[13px] font-medium text-ink">{plugin.displayName}</h3>
+                          {!plugin.installed ? <span className="shrink-0 rounded bg-surface-strong px-1.5 py-0.5 text-[10px] text-muted">Available</span> : null}
+                          {needsConnect ? <span className="shrink-0 rounded bg-amber-50 px-1.5 py-0.5 text-[10px] text-amber-600">Auth</span> : null}
+                        </div>
+                        <p className="mt-0.5 truncate text-[11px] leading-4 text-muted">{plugin.description ?? "No description"}</p>
                       </div>
-                      <p className="mt-0.5 truncate text-[11px] leading-4 text-muted">{plugin.description ?? "No description"}</p>
+                      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+                      <div className="flex shrink-0 items-center gap-1.5" onClick={(e) => e.stopPropagation()}>
+                        {!plugin.installed && canInstall ? (
+                          <Button
+                            className="h-6 rounded-md px-2 text-[11px]"
+                            disabled={pendingActionKey === installKey}
+                            onClick={() => {
+                              const marketplacePath = plugin.marketplacePath;
+                              if (!marketplacePath) return;
+                              void runAction(installKey, async () => await installPlugin({ marketplacePath, pluginId: plugin.id, pluginName: plugin.name }), `Installed ${plugin.displayName}.`);
+                            }}
+                            variant="default"
+                          >
+                            Install
+                          </Button>
+                        ) : null}
+                        {needsConnect ? (
+                          <Button
+                            className="h-6 rounded-md px-2 text-[11px]"
+                            disabled={pendingActionKey === connectKey}
+                            onClick={() => {
+                              if (!authApp) return;
+                              void runAction(connectKey ?? `app-connect:${plugin.id}`, async () => await openAppInstall({ appId: authApp.id, installUrl: authApp.installUrl ?? "" }), `Opened auth flow for ${authApp.name}.`);
+                            }}
+                            variant="secondary"
+                          >
+                            Connect
+                          </Button>
+                        ) : null}
+                        {plugin.installed ? (
+                          <Toggle checked={plugin.enabled} disabled={pendingActionKey === enableKey} onChange={(next) => void runAction(enableKey, async () => await setPluginEnabled({ pluginId: plugin.id, enabled: next }))} />
+                        ) : null}
+                        {(canUninstall || plugin.category) ? (
+                          <OverflowMenu>
+                            {plugin.category ? <OverflowItem onClick={() => {}}>{plugin.category}</OverflowItem> : null}
+                            {canUninstall ? <OverflowItem destructive disabled={pendingActionKey === uninstallKey} onClick={() => void runAction(uninstallKey, async () => await uninstallPlugin({ pluginId: plugin.id }), `Removed ${plugin.displayName}.`)}><Trash2 className="size-3" /> Uninstall</OverflowItem> : null}
+                          </OverflowMenu>
+                        ) : null}
+                      </div>
+                    </article>
+                  );
+                })}
+              </div>
+            ) : <EmptyState message="No plugins match the current filters." />
+          ) : null}
+
+          {/* ---------- Apps ---------- */}
+          {activeTab === "apps" && overview ? (
+            filteredApps.length > 0 ? (
+              <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+                {filteredApps.map((app) => {
+                  const enableKey = `app-enable:${app.id}`;
+                  const connectKey = `app-connect:${app.id}`;
+                  const needsConnect = !app.isAccessible && Boolean(app.installUrl);
+
+                  return (
+                    <article
+                      className={`group flex cursor-pointer items-start gap-3 rounded-xl px-3 py-2.5 transition-colors hover:ring-1 hover:ring-accent/30 ${app.isEnabled ? "bg-surface-soft" : "bg-surface-soft/50"}`}
+                      key={app.id}
+                      onClick={() => selectEntity(app.id, "app")}
+                    >
+                      <ExtensionIcon kind="app" src={app.logoUrl} />
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <h3 className="truncate text-[13px] font-medium text-ink">{app.name}</h3>
+                          {needsConnect ? <span className="shrink-0 rounded bg-amber-50 px-1.5 py-0.5 text-[10px] text-amber-600">Auth</span> : null}
+                        </div>
+                        <p className="mt-0.5 truncate text-[11px] leading-4 text-muted">{app.description ?? "App connector"}</p>
+                      </div>
+                      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+                      <div className="flex shrink-0 items-center gap-1.5" onClick={(e) => e.stopPropagation()}>
+                        {needsConnect ? (
+                          <Button
+                            className="h-6 rounded-md px-2 text-[11px]"
+                            disabled={pendingActionKey === connectKey}
+                            onClick={() => void runAction(connectKey, async () => await openAppInstall({ appId: app.id, installUrl: app.installUrl ?? "" }), `Opened auth flow for ${app.name}.`)}
+                            variant="secondary"
+                          >
+                            Connect
+                          </Button>
+                        ) : null}
+                        {app.isAccessible ? (
+                          <Toggle checked={app.isEnabled} disabled={pendingActionKey === enableKey} onChange={(next) => void runAction(enableKey, async () => await setAppEnabled({ appId: app.id, enabled: next }))} />
+                        ) : !needsConnect ? (
+                          <Toggle checked={false} disabled />
+                        ) : null}
+                      </div>
+                    </article>
+                  );
+                })}
+              </div>
+            ) : <EmptyState message="No apps match the current filters." />
+          ) : null}
+
+          {/* ---------- MCPs ---------- */}
+          {activeTab === "mcps" && overview ? (
+            filteredMcps.length > 0 ? (
+              <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+                {filteredMcps.map((server) => (
+                  <article
+                    className={`group flex cursor-pointer items-start gap-3 rounded-xl px-3 py-2.5 transition-colors hover:ring-1 hover:ring-accent/30 ${server.enabled ? "bg-surface-soft" : "bg-surface-soft/50"}`}
+                    key={server.id}
+                    onClick={() => selectEntity(server.id, "mcp")}
+                  >
+                    <ExtensionIcon kind="mcp" />
+                    <div className="min-w-0 flex-1">
+                      <h3 className="truncate text-[13px] font-medium text-ink">{server.id}</h3>
+                      <p className="mt-0.5 truncate text-[11px] leading-4 text-muted">
+                        {server.transport?.toUpperCase() ?? "MCP"}
+                        {server.state ? ` · ${server.state}` : ""}
+                        {` · ${server.toolsCount} tools`}
+                        {server.resourcesCount > 0 ? ` · ${server.resourcesCount} res.` : ""}
+                      </p>
                     </div>
-                    <div className="flex shrink-0 items-center gap-1.5">
-                      {!plugin.installed && canInstall ? (
-                        <Button
-                          className="h-6 rounded-md px-2 text-[11px]"
-                          disabled={pendingActionKey === installKey}
-                          onClick={() => {
-                            const marketplacePath = plugin.marketplacePath;
-                            if (!marketplacePath) return;
-                            void runAction(installKey, async () => await installPlugin({ marketplacePath, pluginId: plugin.id, pluginName: plugin.name }), `Installed ${plugin.displayName}.`);
-                          }}
-                          variant="default"
-                        >
-                          Install
-                        </Button>
-                      ) : null}
-                      {needsConnect ? (
-                        <Button
-                          className="h-6 rounded-md px-2 text-[11px]"
-                          disabled={pendingActionKey === connectKey}
-                          onClick={() => {
-                            if (!authApp) return;
-                            void runAction(connectKey ?? `app-connect:${plugin.id}`, async () => await openAppInstall({ appId: authApp.id, installUrl: authApp.installUrl ?? "" }), `Opened auth flow for ${authApp.name}.`);
-                          }}
-                          variant="secondary"
-                        >
-                          Connect
-                        </Button>
-                      ) : null}
-                      {plugin.installed ? (
-                        <Toggle checked={plugin.enabled} disabled={pendingActionKey === enableKey} onChange={(next) => void runAction(enableKey, async () => await setPluginEnabled({ pluginId: plugin.id, enabled: next }))} />
-                      ) : null}
-                      {(canUninstall || plugin.category) ? (
-                        <OverflowMenu>
-                          {plugin.category ? <OverflowItem onClick={() => {}}>{plugin.category}</OverflowItem> : null}
-                          {canUninstall ? <OverflowItem destructive disabled={pendingActionKey === uninstallKey} onClick={() => void runAction(uninstallKey, async () => await uninstallPlugin({ pluginId: plugin.id }), `Removed ${plugin.displayName}.`)}><Trash2 className="size-3" /> Uninstall</OverflowItem> : null}
-                        </OverflowMenu>
-                      ) : null}
+                    {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+                    <div className="flex shrink-0 items-center gap-1.5" onClick={(e) => e.stopPropagation()}>
+                      {server.authStatus ? <span className="rounded bg-amber-50 px-1.5 py-0.5 text-[10px] text-amber-600">{server.authStatus}</span> : null}
+                      <Toggle checked={server.enabled} onChange={(next) => void setMcpServerEnabled({ serverId: server.id, enabled: next })} />
                     </div>
                   </article>
-                );
-              })}
-            </div>
-          ) : <EmptyState message="No plugins match the current filters." />
-        ) : null}
+                ))}
+              </div>
+            ) : <EmptyState message="No MCP servers configured." />
+          ) : null}
 
-        {/* ---------- Apps ---------- */}
-        {activeTab === "apps" && overview ? (
-          filteredApps.length > 0 ? (
-            <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
-              {filteredApps.map((app) => {
-                const enableKey = `app-enable:${app.id}`;
-                const connectKey = `app-connect:${app.id}`;
-                const needsConnect = !app.isAccessible && Boolean(app.installUrl);
+          {/* ---------- Skills ---------- */}
+          {activeTab === "skills" && overview ? (
+            filteredSkills.length > 0 ? (
+              <div className="grid gap-px sm:grid-cols-2 xl:grid-cols-3">
+                {filteredSkills.map((skill) => {
+                  const canUninstall = skillSource(skill) === "profile";
+                  const uninstallKey = `skill-uninstall:${skill.path}`;
 
-                return (
-                  <article
-                    className={`group flex items-start gap-3 rounded-xl px-3 py-2.5 transition-colors ${app.isEnabled ? "bg-surface-soft" : "bg-surface-soft/50"}`}
-                    key={app.id}
-                  >
-                    <ExtensionIcon kind="app" src={app.logoUrl} />
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-2">
-                        <h3 className="truncate text-[13px] font-medium text-ink">{app.name}</h3>
-                        {needsConnect ? <span className="shrink-0 rounded bg-amber-50 px-1.5 py-0.5 text-[10px] text-amber-600">Auth</span> : null}
+                  return (
+                    <article
+                      className={`group flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2 transition-colors hover:ring-1 hover:ring-accent/30 ${skill.enabled ? "bg-surface-soft" : "bg-surface-soft/30 opacity-70"}`}
+                      key={skill.path}
+                      onClick={() => selectEntity(skill.path, "skill")}
+                    >
+                      <ExtensionIcon kind="skill" />
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <h3 className="truncate text-[13px] font-medium text-ink">{skill.name}</h3>
+                          {skill.scope ? <span className="shrink-0 text-[10px] text-muted">{skill.scope}</span> : null}
+                        </div>
+                        <p className="truncate text-[11px] leading-4 text-muted">{skill.description ?? "No description"}</p>
                       </div>
-                      <p className="mt-0.5 truncate text-[11px] leading-4 text-muted">{app.description ?? "App connector"}</p>
-                    </div>
-                    <div className="flex shrink-0 items-center gap-1.5">
-                      {needsConnect ? (
-                        <Button
-                          className="h-6 rounded-md px-2 text-[11px]"
-                          disabled={pendingActionKey === connectKey}
-                          onClick={() => void runAction(connectKey, async () => await openAppInstall({ appId: app.id, installUrl: app.installUrl ?? "" }), `Opened auth flow for ${app.name}.`)}
-                          variant="secondary"
-                        >
-                          Connect
-                        </Button>
-                      ) : null}
-                      {app.isAccessible ? (
-                        <Toggle checked={app.isEnabled} disabled={pendingActionKey === enableKey} onChange={(next) => void runAction(enableKey, async () => await setAppEnabled({ appId: app.id, enabled: next }))} />
-                      ) : !needsConnect ? (
-                        <Toggle checked={false} disabled />
-                      ) : null}
-                    </div>
-                  </article>
-                );
-              })}
-            </div>
-          ) : <EmptyState message="No apps match the current filters." />
-        ) : null}
-
-        {/* ---------- MCPs ---------- */}
-        {activeTab === "mcps" && overview ? (
-          filteredMcps.length > 0 ? (
-            <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
-              {filteredMcps.map((server) => (
-                <article
-                  className={`group flex items-start gap-3 rounded-xl px-3 py-2.5 transition-colors ${server.enabled ? "bg-surface-soft" : "bg-surface-soft/50"}`}
-                  key={server.id}
-                >
-                  <ExtensionIcon kind="mcp" />
-                  <div className="min-w-0 flex-1">
-                    <h3 className="truncate text-[13px] font-medium text-ink">{server.id}</h3>
-                    <p className="mt-0.5 truncate text-[11px] leading-4 text-muted">
-                      {server.transport?.toUpperCase() ?? "MCP"}
-                      {server.state ? ` · ${server.state}` : ""}
-                      {` · ${server.toolsCount} tools`}
-                      {server.resourcesCount > 0 ? ` · ${server.resourcesCount} res.` : ""}
-                    </p>
-                  </div>
-                  <div className="flex shrink-0 items-center gap-1.5">
-                    {server.authStatus ? <span className="rounded bg-amber-50 px-1.5 py-0.5 text-[10px] text-amber-600">{server.authStatus}</span> : null}
-                    <Toggle checked={server.enabled} onChange={(next) => void setMcpServerEnabled({ serverId: server.id, enabled: next })} />
-                  </div>
-                </article>
-              ))}
-            </div>
-          ) : <EmptyState message="No MCP servers configured." />
-        ) : null}
-
-        {/* ---------- Skills ---------- */}
-        {activeTab === "skills" && overview ? (
-          filteredSkills.length > 0 ? (
-            <div className="grid gap-px sm:grid-cols-2 xl:grid-cols-3">
-              {filteredSkills.map((skill) => {
-                const canUninstall = skillSource(skill) === "profile";
-                const uninstallKey = `skill-uninstall:${skill.path}`;
-
-                return (
-                  <article
-                    className={`group flex items-center gap-3 rounded-lg px-3 py-2 transition-colors ${skill.enabled ? "bg-surface-soft" : "bg-surface-soft/30 opacity-70"}`}
-                    key={skill.path}
-                  >
-                    <ExtensionIcon kind="skill" />
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-2">
-                        <h3 className="truncate text-[13px] font-medium text-ink">{skill.name}</h3>
-                        {skill.scope ? <span className="shrink-0 text-[10px] text-muted">{skill.scope}</span> : null}
+                      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+                      <div className="flex shrink-0 items-center gap-1.5" onClick={(e) => e.stopPropagation()}>
+                        <Toggle checked={skill.enabled} onChange={(next) => void setSkillEnabled({ path: skill.path, enabled: next })} />
+                        {canUninstall ? (
+                          <OverflowMenu>
+                            <OverflowItem destructive disabled={pendingActionKey === uninstallKey} onClick={() => void runAction(uninstallKey, async () => await uninstallSkill({ path: skill.path }), `Removed ${skill.name}.`)}><Trash2 className="size-3" /> Uninstall</OverflowItem>
+                          </OverflowMenu>
+                        ) : null}
                       </div>
-                      <p className="truncate text-[11px] leading-4 text-muted">{skill.description ?? "No description"}</p>
-                    </div>
-                    <div className="flex shrink-0 items-center gap-1.5">
-                      <Toggle checked={skill.enabled} onChange={(next) => void setSkillEnabled({ path: skill.path, enabled: next })} />
-                      {canUninstall ? (
-                        <OverflowMenu>
-                          <OverflowItem destructive disabled={pendingActionKey === uninstallKey} onClick={() => void runAction(uninstallKey, async () => await uninstallSkill({ path: skill.path }), `Removed ${skill.name}.`)}><Trash2 className="size-3" /> Uninstall</OverflowItem>
-                        </OverflowMenu>
-                      ) : null}
-                    </div>
-                  </article>
-                );
-              })}
-            </div>
-          ) : <EmptyState message="No skills match the current filters." />
-        ) : null}
-      </div>
+                    </article>
+                  );
+                })}
+              </div>
+            ) : <EmptyState message="No skills match the current filters." />
+          ) : null}
+        </div>
+      )}
+
+      {/* ---- Skill detail modal (overlay) ---- */}
+      {selectedManagedRecord && selectedEntityKind === "skill" ? (
+        <SkillDetailModal
+          managedRecord={selectedManagedRecord}
+          legacySkill={overview?.skills.find((s) => s.path === selectedManagedRecord.id)}
+          onClose={clearSelection}
+          onToggleEnabled={(next) => {
+            const legacySkill = overview?.skills.find((s) => s.path === selectedManagedRecord.id);
+            if (legacySkill) {
+              void runAction(`skill-enable:${selectedManagedRecord.id}`, async () => await setSkillEnabled({ path: legacySkill.path, enabled: next }));
+            }
+          }}
+          onUninstall={() => {
+            const legacySkill = overview?.skills.find((s) => s.path === selectedManagedRecord.id);
+            if (legacySkill) {
+              void runAction(`skill-uninstall:${selectedManagedRecord.id}`, async () => { await uninstallSkill({ path: legacySkill.path }); clearSelection(); }, `Removed ${selectedManagedRecord.displayName}.`);
+            }
+          }}
+          onOpen={() => {
+            if (selectedManagedRecord.sourcePath) {
+              void window.sense1Desktop.workspace.openFilePath(selectedManagedRecord.sourcePath);
+            }
+          }}
+          pendingActionKey={pendingActionKey}
+          Toggle={Toggle}
+        />
+      ) : null}
     </div>
   );
 }

--- a/desktop/src/renderer/components/extensions/AppDetailView.tsx
+++ b/desktop/src/renderer/components/extensions/AppDetailView.tsx
@@ -1,0 +1,164 @@
+import { ArrowLeft, Blocks, Check, Trash2 } from "lucide-react";
+
+import type {
+  DesktopAppRecord,
+  DesktopManagedExtensionRecord,
+} from "../../../main/contracts";
+import { Button } from "../ui/button";
+
+type AppDetailViewProps = {
+  managedRecord: DesktopManagedExtensionRecord;
+  legacyApp: DesktopAppRecord | undefined;
+  onBack: () => void;
+  onToggleEnabled: (next: boolean) => void;
+  onConnect: () => void;
+  onRemove: () => void;
+  pendingActionKey: string | null;
+  Toggle: React.ComponentType<{ checked: boolean; disabled?: boolean; onChange?: (next: boolean) => void }>;
+};
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return <h4 className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-muted">{children}</h4>;
+}
+
+export function AppDetailView({
+  managedRecord,
+  legacyApp,
+  onBack,
+  onToggleEnabled,
+  onConnect,
+  onRemove,
+  pendingActionKey,
+  Toggle,
+}: AppDetailViewProps) {
+  const isEnabled = managedRecord.enablementState === "enabled";
+  const enableKey = `app-enable:${managedRecord.id}`;
+  const connectKey = `app-connect:${managedRecord.id}`;
+  const removeKey = `app-remove:${managedRecord.id}`;
+
+  const authState = managedRecord.authState;
+  const needsConnect = authState === "required" || authState === "failed";
+  const isConnected = authState === "connected";
+  const pluginNames = legacyApp?.pluginDisplayNames ?? [];
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      {/* Header */}
+      <div className="flex items-center gap-3 border-b border-line/40 px-4 py-3">
+        <button
+          className="flex size-7 items-center justify-center rounded-lg text-ink-muted transition-colors hover:bg-surface-soft hover:text-ink"
+          onClick={onBack}
+          title="Back to list"
+          type="button"
+        >
+          <ArrowLeft className="size-4" />
+        </button>
+        {legacyApp?.logoUrl ? (
+          <img alt="" className="size-8 shrink-0 rounded-lg object-contain" src={legacyApp.logoUrl} />
+        ) : (
+          <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-surface-strong">
+            <Blocks className="size-4 text-muted" />
+          </div>
+        )}
+        <div className="min-w-0 flex-1">
+          <h2 className="truncate text-sm font-semibold text-ink">{managedRecord.displayName}</h2>
+          {managedRecord.description ? (
+            <p className="mt-0.5 truncate text-[11px] leading-4 text-muted">{managedRecord.description}</p>
+          ) : null}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {managedRecord.canDisable ? (
+            <Toggle
+              checked={isEnabled}
+              disabled={pendingActionKey === enableKey}
+              onChange={onToggleEnabled}
+            />
+          ) : null}
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+        <div className="mx-auto max-w-xl space-y-6">
+          {/* Auth state */}
+          <section>
+            <SectionHeading>Authentication</SectionHeading>
+            <div className="rounded-xl bg-surface-soft px-3 py-3">
+              {isConnected ? (
+                <div className="flex items-center gap-2">
+                  <span className="flex items-center gap-1 rounded-md bg-green-50 px-2 py-1 text-[11px] font-medium text-green-700">
+                    <Check className="size-3" />
+                    Connected
+                  </span>
+                </div>
+              ) : needsConnect ? (
+                <div className="flex items-center gap-3">
+                  <span className="rounded bg-amber-50 px-2 py-1 text-[11px] text-amber-600">Auth required</span>
+                  <Button
+                    className="h-7 rounded-lg px-3 text-[11px]"
+                    disabled={pendingActionKey === connectKey}
+                    onClick={onConnect}
+                    variant="default"
+                  >
+                    Connect
+                  </Button>
+                </div>
+              ) : (
+                <p className="text-[11px] text-muted">No authentication required.</p>
+              )}
+            </div>
+          </section>
+
+          {/* Plugin ownership */}
+          {pluginNames.length > 0 ? (
+            <section>
+              <SectionHeading>Used by plugins</SectionHeading>
+              <div className="flex flex-wrap gap-1.5">
+                {pluginNames.map((name) => (
+                  <span
+                    className="rounded-lg bg-surface-soft px-2.5 py-1.5 text-[11px] text-ink"
+                    key={name}
+                  >
+                    {name}
+                  </span>
+                ))}
+              </div>
+            </section>
+          ) : null}
+
+          {/* Details */}
+          <section>
+            <SectionHeading>Details</SectionHeading>
+            <div className="rounded-xl bg-surface-soft px-3 py-2">
+              <div className="flex items-baseline gap-2 py-1">
+                <span className="shrink-0 text-[11px] text-muted">Ownership</span>
+                <span className="text-[11px] text-ink">{managedRecord.ownership}</span>
+              </div>
+              {managedRecord.healthState !== "healthy" ? (
+                <div className="flex items-baseline gap-2 py-1">
+                  <span className="shrink-0 text-[11px] text-muted">Health</span>
+                  <span className="text-[11px] text-ink">{managedRecord.healthState}</span>
+                </div>
+              ) : null}
+            </div>
+          </section>
+
+          {/* Remove */}
+          {managedRecord.canUninstall ? (
+            <section>
+              <Button
+                className="h-8 gap-1.5 rounded-lg px-3 text-xs"
+                disabled={pendingActionKey === removeKey}
+                onClick={onRemove}
+                variant="destructive"
+              >
+                <Trash2 className="size-3.5" />
+                Remove app
+              </Button>
+            </section>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/renderer/components/extensions/AppDetailView.tsx
+++ b/desktop/src/renderer/components/extensions/AppDetailView.tsx
@@ -144,7 +144,7 @@ export function AppDetailView({
           </section>
 
           {/* Remove */}
-          {managedRecord.canUninstall ? (
+          {legacyApp?.isAccessible || managedRecord.enablementState === "enabled" ? (
             <section>
               <Button
                 className="h-8 gap-1.5 rounded-lg px-3 text-xs"

--- a/desktop/src/renderer/components/extensions/McpDetailView.tsx
+++ b/desktop/src/renderer/components/extensions/McpDetailView.tsx
@@ -1,0 +1,127 @@
+import { ArrowLeft, Cable } from "lucide-react";
+
+import type {
+  DesktopManagedExtensionRecord,
+  DesktopMcpServerRecord,
+} from "../../../main/contracts";
+
+type McpDetailViewProps = {
+  managedRecord: DesktopManagedExtensionRecord;
+  legacyMcp: DesktopMcpServerRecord | undefined;
+  onBack: () => void;
+  onToggleEnabled: (next: boolean) => void;
+  pendingActionKey: string | null;
+  Toggle: React.ComponentType<{ checked: boolean; disabled?: boolean; onChange?: (next: boolean) => void }>;
+};
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return <h4 className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-muted">{children}</h4>;
+}
+
+function MetadataRow({ label, value }: { label: string; value: string | number | null | undefined }) {
+  if (value == null) return null;
+  return (
+    <div className="flex items-baseline gap-2 py-1">
+      <span className="shrink-0 text-[11px] text-muted">{label}</span>
+      <span className="text-[11px] text-ink">{String(value)}</span>
+    </div>
+  );
+}
+
+function HealthBadge({ state }: { state: string }) {
+  const color =
+    state === "healthy"
+      ? "bg-green-50 text-green-700"
+      : state === "warning"
+        ? "bg-amber-50 text-amber-600"
+        : "bg-red-50 text-red-600";
+  return <span className={`rounded-md px-2 py-0.5 text-[11px] font-medium ${color}`}>{state}</span>;
+}
+
+export function McpDetailView({
+  managedRecord,
+  legacyMcp,
+  onBack,
+  onToggleEnabled,
+  pendingActionKey,
+  Toggle,
+}: McpDetailViewProps) {
+  const isEnabled = managedRecord.enablementState === "enabled";
+  const enableKey = `mcp-enable:${managedRecord.id}`;
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      {/* Header */}
+      <div className="flex items-center gap-3 border-b border-line/40 px-4 py-3">
+        <button
+          className="flex size-7 items-center justify-center rounded-lg text-ink-muted transition-colors hover:bg-surface-soft hover:text-ink"
+          onClick={onBack}
+          title="Back to list"
+          type="button"
+        >
+          <ArrowLeft className="size-4" />
+        </button>
+        <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-surface-strong">
+          <Cable className="size-4 text-muted" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h2 className="truncate text-sm font-semibold text-ink">{managedRecord.displayName}</h2>
+          {legacyMcp?.transport ? (
+            <p className="mt-0.5 text-[11px] text-muted">{legacyMcp.transport.toUpperCase()}</p>
+          ) : null}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {managedRecord.canDisable ? (
+            <Toggle
+              checked={isEnabled}
+              disabled={pendingActionKey === enableKey}
+              onChange={onToggleEnabled}
+            />
+          ) : null}
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+        <div className="mx-auto max-w-xl space-y-6">
+          {/* Status */}
+          <section>
+            <SectionHeading>Status</SectionHeading>
+            <div className="flex items-center gap-3 rounded-xl bg-surface-soft px-3 py-3">
+              <HealthBadge state={managedRecord.healthState} />
+              {managedRecord.authState !== "not-required" ? (
+                <span className="rounded bg-amber-50 px-2 py-0.5 text-[11px] text-amber-600">
+                  Auth: {managedRecord.authState}
+                </span>
+              ) : null}
+            </div>
+          </section>
+
+          {/* Capabilities */}
+          {legacyMcp ? (
+            <section>
+              <SectionHeading>Capabilities</SectionHeading>
+              <div className="rounded-xl bg-surface-soft px-3 py-2">
+                <MetadataRow label="Tools" value={legacyMcp.toolsCount} />
+                <MetadataRow label="Resources" value={legacyMcp.resourcesCount > 0 ? legacyMcp.resourcesCount : null} />
+                <MetadataRow label="Transport" value={legacyMcp.transport} />
+                <MetadataRow label="State" value={legacyMcp.state} />
+                <MetadataRow label="Command" value={legacyMcp.command} />
+                <MetadataRow label="URL" value={legacyMcp.url} />
+              </div>
+            </section>
+          ) : null}
+
+          {/* Details */}
+          <section>
+            <SectionHeading>Details</SectionHeading>
+            <div className="rounded-xl bg-surface-soft px-3 py-2">
+              <MetadataRow label="Server ID" value={managedRecord.id} />
+              <MetadataRow label="Ownership" value={managedRecord.ownership} />
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/renderer/components/extensions/PluginDetailView.tsx
+++ b/desktop/src/renderer/components/extensions/PluginDetailView.tsx
@@ -1,0 +1,206 @@
+import { ArrowLeft, Blocks, Cable, ExternalLink, Sparkles, Trash2 } from "lucide-react";
+
+import type {
+  DesktopAppRecord,
+  DesktopExtensionOverviewResult,
+  DesktopManagedExtensionRecord,
+  DesktopPluginRecord,
+} from "../../../main/contracts";
+import { Button } from "../ui/button";
+
+type PluginDetailViewProps = {
+  managedRecord: DesktopManagedExtensionRecord;
+  overview: DesktopExtensionOverviewResult;
+  onBack: () => void;
+  onToggleEnabled: (next: boolean) => void;
+  onUninstall: () => void;
+  onNavigateToEntity: (id: string, kind: "skill" | "app" | "mcp") => void;
+  pendingActionKey: string | null;
+  Toggle: React.ComponentType<{ checked: boolean; disabled?: boolean; onChange?: (next: boolean) => void }>;
+};
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return <h4 className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-muted">{children}</h4>;
+}
+
+function MetadataRow({ label, value }: { label: string; value: string | null | undefined }) {
+  if (!value) return null;
+  return (
+    <div className="flex items-baseline gap-2 py-1">
+      <span className="shrink-0 text-[11px] text-muted">{label}</span>
+      <span className="text-[11px] text-ink">{value}</span>
+    </div>
+  );
+}
+
+function IncludedEntityChip({
+  icon: Icon,
+  label,
+  onClick,
+}: {
+  icon: typeof Sparkles;
+  label: string;
+  onClick?: () => void;
+}) {
+  return (
+    <button
+      className="inline-flex items-center gap-1.5 rounded-lg bg-surface-soft px-2.5 py-1.5 text-[11px] text-ink transition-colors hover:bg-surface-strong"
+      onClick={onClick}
+      type="button"
+    >
+      <Icon className="size-3 text-muted" />
+      {label}
+    </button>
+  );
+}
+
+export function PluginDetailView({
+  managedRecord,
+  overview,
+  onBack,
+  onToggleEnabled,
+  onUninstall,
+  onNavigateToEntity,
+  pendingActionKey,
+  Toggle,
+}: PluginDetailViewProps) {
+  const legacyPlugin: DesktopPluginRecord | undefined = overview.plugins.find((p) => p.id === managedRecord.id);
+  const enableKey = `plugin-enable:${managedRecord.id}`;
+  const uninstallKey = `plugin-uninstall:${managedRecord.id}`;
+
+  // Resolve included entities from managed extensions
+  const includedSkills = overview.managedExtensions.filter(
+    (e) => e.kind === "skill" && managedRecord.includedSkillIds.includes(e.id),
+  );
+  const includedApps = overview.managedExtensions.filter(
+    (e) => e.kind === "app" && managedRecord.includedAppIds.includes(e.id),
+  );
+  const includedMcps = overview.managedExtensions.filter(
+    (e) => e.kind === "mcp" && managedRecord.includedMcpServerIds.includes(e.id),
+  );
+
+  // Fallback: also look up apps from legacy records
+  const legacyAppRecords: DesktopAppRecord[] = managedRecord.includedAppIds
+    .map((appId) => overview.apps.find((a) => a.id === appId))
+    .filter((a): a is DesktopAppRecord => a != null);
+
+  const hasIncludes = includedSkills.length > 0 || includedApps.length > 0 || includedMcps.length > 0 || legacyAppRecords.length > 0;
+  const isEnabled = managedRecord.enablementState === "enabled";
+  const websiteUrl = legacyPlugin?.websiteUrl ?? null;
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      {/* Header */}
+      <div className="flex items-center gap-3 border-b border-line/40 px-4 py-3">
+        <button
+          className="flex size-7 items-center justify-center rounded-lg text-ink-muted transition-colors hover:bg-surface-soft hover:text-ink"
+          onClick={onBack}
+          title="Back to list"
+          type="button"
+        >
+          <ArrowLeft className="size-4" />
+        </button>
+        <div className="min-w-0 flex-1">
+          <h2 className="truncate text-sm font-semibold text-ink">{managedRecord.displayName}</h2>
+          {managedRecord.description ? (
+            <p className="mt-0.5 truncate text-[11px] leading-4 text-muted">{managedRecord.description}</p>
+          ) : null}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {managedRecord.canDisable ? (
+            <Toggle
+              checked={isEnabled}
+              disabled={pendingActionKey === enableKey}
+              onChange={onToggleEnabled}
+            />
+          ) : null}
+          {managedRecord.canUninstall ? (
+            <Button
+              className="h-7 gap-1.5 rounded-lg px-2.5 text-[11px]"
+              disabled={pendingActionKey === uninstallKey}
+              onClick={onUninstall}
+              variant="destructive"
+            >
+              <Trash2 className="size-3" />
+              Uninstall
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+        <div className="mx-auto max-w-xl space-y-6">
+          {/* Metadata */}
+          <section>
+            <SectionHeading>Details</SectionHeading>
+            <div className="rounded-xl bg-surface-soft px-3 py-2">
+              <MetadataRow label="Category" value={managedRecord.capabilities.length > 0 ? managedRecord.capabilities.join(", ") : legacyPlugin?.category} />
+              <MetadataRow label="Marketplace" value={managedRecord.marketplaceName} />
+              <MetadataRow label="Ownership" value={managedRecord.ownership} />
+              <MetadataRow label="Install state" value={managedRecord.installState} />
+              <MetadataRow label="Health" value={managedRecord.healthState !== "healthy" ? managedRecord.healthState : null} />
+              <MetadataRow label="Auth" value={managedRecord.authState !== "not-required" ? managedRecord.authState : null} />
+              {websiteUrl ? (
+                <div className="flex items-center gap-2 py-1">
+                  <span className="shrink-0 text-[11px] text-muted">Website</span>
+                  <a
+                    className="inline-flex items-center gap-1 text-[11px] text-accent hover:underline"
+                    href={websiteUrl}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    {websiteUrl}
+                    <ExternalLink className="size-2.5" />
+                  </a>
+                </div>
+              ) : null}
+            </div>
+          </section>
+
+          {/* Includes */}
+          {hasIncludes ? (
+            <section>
+              <SectionHeading>Includes</SectionHeading>
+              <div className="flex flex-wrap gap-1.5">
+                {includedSkills.map((skill) => (
+                  <IncludedEntityChip
+                    icon={Sparkles}
+                    key={skill.id}
+                    label={skill.displayName}
+                    onClick={() => onNavigateToEntity(skill.id, "skill")}
+                  />
+                ))}
+                {includedApps.length > 0
+                  ? includedApps.map((app) => (
+                      <IncludedEntityChip
+                        icon={Blocks}
+                        key={app.id}
+                        label={app.displayName}
+                        onClick={() => onNavigateToEntity(app.id, "app")}
+                      />
+                    ))
+                  : legacyAppRecords.map((app) => (
+                      <IncludedEntityChip
+                        icon={Blocks}
+                        key={app.id}
+                        label={app.name}
+                        onClick={() => onNavigateToEntity(app.id, "app")}
+                      />
+                    ))}
+                {includedMcps.map((mcp) => (
+                  <IncludedEntityChip
+                    icon={Cable}
+                    key={mcp.id}
+                    label={mcp.displayName}
+                    onClick={() => onNavigateToEntity(mcp.id, "mcp")}
+                  />
+                ))}
+              </div>
+            </section>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/renderer/components/extensions/SkillDetailModal.tsx
+++ b/desktop/src/renderer/components/extensions/SkillDetailModal.tsx
@@ -1,0 +1,116 @@
+import { ExternalLink, Sparkles, Trash2, X } from "lucide-react";
+
+import type { DesktopManagedExtensionRecord, DesktopSkillRecord } from "../../../main/contracts";
+import { Button } from "../ui/button";
+
+type SkillDetailModalProps = {
+  managedRecord: DesktopManagedExtensionRecord;
+  legacySkill: DesktopSkillRecord | undefined;
+  onClose: () => void;
+  onToggleEnabled: (next: boolean) => void;
+  onUninstall: () => void;
+  onOpen: () => void;
+  pendingActionKey: string | null;
+  Toggle: React.ComponentType<{ checked: boolean; disabled?: boolean; onChange?: (next: boolean) => void }>;
+};
+
+export function SkillDetailModal({
+  managedRecord,
+  legacySkill,
+  onClose,
+  onToggleEnabled,
+  onUninstall,
+  onOpen,
+  pendingActionKey,
+  Toggle,
+}: SkillDetailModalProps) {
+  const isEnabled = managedRecord.enablementState === "enabled";
+  const enableKey = `skill-enable:${managedRecord.id}`;
+  const uninstallKey = `skill-uninstall:${managedRecord.id}`;
+  const scope = legacySkill?.scope ?? (managedRecord.ownership === "plugin-owned" ? "plugin" : null);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-ink/20"
+        onClick={onClose}
+        role="presentation"
+      />
+
+      {/* Modal */}
+      <div className="relative z-10 w-full max-w-md rounded-2xl border border-line/40 bg-white shadow-xl">
+        {/* Header */}
+        <div className="flex items-start gap-3 border-b border-line/30 px-5 py-4">
+          <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-surface-strong">
+            <Sparkles className="size-4 text-muted" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <h3 className="truncate text-sm font-semibold text-ink">{managedRecord.displayName}</h3>
+              <span className="shrink-0 rounded bg-surface-strong px-1.5 py-0.5 text-[10px] font-medium text-muted">
+                Skill
+              </span>
+              {scope ? (
+                <span className="shrink-0 text-[10px] text-muted">{scope}</span>
+              ) : null}
+            </div>
+          </div>
+          <button
+            className="flex size-6 items-center justify-center rounded-md text-ink-muted transition-colors hover:bg-surface-soft hover:text-ink"
+            onClick={onClose}
+            type="button"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-5 py-4">
+          <p className="text-[12px] leading-5 text-ink">
+            {managedRecord.description ?? "No description available."}
+          </p>
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center justify-between border-t border-line/30 px-5 py-3">
+          <div className="flex items-center gap-3">
+            {managedRecord.canDisable ? (
+              <div className="flex items-center gap-2">
+                <span className="text-[11px] text-muted">{isEnabled ? "Enabled" : "Disabled"}</span>
+                <Toggle
+                  checked={isEnabled}
+                  disabled={pendingActionKey === enableKey}
+                  onChange={onToggleEnabled}
+                />
+              </div>
+            ) : null}
+          </div>
+          <div className="flex items-center gap-2">
+            {managedRecord.canOpen ? (
+              <Button
+                className="h-7 gap-1.5 rounded-lg px-2.5 text-[11px]"
+                onClick={onOpen}
+                variant="secondary"
+              >
+                <ExternalLink className="size-3" />
+                Open
+              </Button>
+            ) : null}
+            {managedRecord.canUninstall ? (
+              <Button
+                className="h-7 gap-1.5 rounded-lg px-2.5 text-[11px]"
+                disabled={pendingActionKey === uninstallKey}
+                onClick={onUninstall}
+                variant="destructive"
+              >
+                <Trash2 className="size-3" />
+                Uninstall
+              </Button>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Plugin detail view**: In-place view with metadata (category, marketplace, ownership), includes section listing contained skills/apps/MCPs, and enable/disable + uninstall actions gated by `canDisable`/`canUninstall`
- **Skill detail modal**: Overlay with name, scope badge, description, enable/disable toggle, Open button (via `openFilePath`), and uninstall -- all gated by capability flags
- **App detail view**: In-place view with auth state (connect/connected), plugin ownership info, enable/disable toggle, and remove action
- **MCP detail view**: In-place view with health badge, auth status, tools/resources counts, transport details, and enable/disable toggle
- Cards in all four tabs are now clickable to open their detail surface; interactive controls (toggles, buttons, menus) use `stopPropagation` to avoid accidental navigation
- Tab switching clears any open detail view

Closes #46

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test:renderer` passes (143/143)
- [ ] Manual: click a plugin card -> detail view replaces grid with back button, metadata, includes section, and actions
- [ ] Manual: click a skill card -> modal overlay appears with skill info and actions
- [ ] Manual: click an app card -> detail view shows auth state and plugin ownership
- [ ] Manual: click an MCP card -> detail view shows health, tools count, transport
- [ ] Manual: toggles and overflow menus on cards still work without navigating to detail
- [ ] Manual: switching tabs clears the selected entity