### PR TITLE
[codex] Keep creator installs aligned with managed profile inventory

### DIFF
--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -7,6 +7,7 @@ import { resolveDesktopProfile } from "./bootstrap/desktop-bootstrap.js";
 import { resolveSignedInDesktopProfile } from "./bootstrap/bootstrap-profile.js";
 import {
   filterProfileCodexHomeRoots,
+  latestUserEntryRequestsManagedInventoryInstall,
   ManagementInventoryChangeTracker,
 } from "./settings/management-inventory-change.ts";
 import {
@@ -626,7 +627,10 @@ appServerManager.on("notification", (message) => {
       void persistInteractionState(threadId).catch(() => {});
     }
     runtimeFileChangeTracker.clear(threadId);
-    if (managementInventoryChangeTracker.consume(threadId)) {
+    if (
+      managementInventoryChangeTracker.consume(threadId)
+      || latestUserEntryRequestsManagedInventoryInstall(currentThreadState)
+    ) {
       emitDesktopRuntimeEvent({ kind: "managementInventoryChanged" });
     }
 

--- a/desktop/src/main/session/desktop-run-start-service.ts
+++ b/desktop/src/main/session/desktop-run-start-service.ts
@@ -174,6 +174,12 @@ function buildProfileExtensionRuntimeInstruction({
     instructions.push(
       `This run already has write access to ${profileCodexHome}. Do not claim sandbox, workspace-boundary, or permission blocking for profile skill installation when writing under that root.`,
     );
+    instructions.push(
+      `These managed skill tasks are an explicit exception to the normal workspace deliverable rule. The finished installed skill belongs in ${profileCodexHome}/skills, not in the selected workspace or session artifact folder, unless the user explicitly asked for a workspace-local draft.`,
+    );
+    instructions.push(
+      `Do not report success until the final installed skill exists under ${profileCodexHome} and you can reference that installed location. A workspace draft or scaffold does not satisfy a managed install request.`,
+    );
     if (shortcutNames.has("skill-creator")) {
       instructions.push(
         `When the user asks for a new Sense-1 skill, finish with a callable installed profile skill in ${profileCodexHome}/skills. Do not stop at a TODO-only template, placeholder scaffold, or a draft left in the selected workspace for later move/install unless the user explicitly asked for workspace-local scaffold output.`,
@@ -192,6 +198,9 @@ function buildProfileExtensionRuntimeInstruction({
     );
     instructions.push(
       `Do not leave the finished plugin scaffold in the selected workspace for later manual move/install when ${profileCodexHome} is writable in this run.`,
+    );
+    instructions.push(
+      `This managed plugin task is also an explicit exception to the normal workspace deliverable rule. The finished plugin belongs in ${profilePluginsDir} with any required marketplace metadata under ${profileMarketplacePath}; a workspace draft does not satisfy the request unless the user explicitly asked for one.`,
     );
     if (pluginCreatorSkillPath && pluginCreatorScriptPath) {
       instructions.push(

--- a/desktop/src/main/session/session-controller.test.js
+++ b/desktop/src/main/session/session-controller.test.js
@@ -6395,6 +6395,8 @@ test("runDesktopTask keeps folder-bound creator shortcuts inside the selected wo
   assert.match(developerInstructions, /profile CODEX_HOME/u);
   assert.match(developerInstructions, /already has write access/u);
   assert.match(developerInstructions, /Do not claim sandbox, workspace-boundary, or permission blocking/u);
+  assert.match(developerInstructions, /explicit exception to the normal workspace deliverable rule/u);
+  assert.match(developerInstructions, /does not satisfy a managed install request/u);
   assert.match(developerInstructions, /create_basic_plugin\.py/u);
   assert.match(developerInstructions, /Do not stop at a TODO-only template/u);
   assert.match(developerInstructions, /or a draft left in the selected workspace for later move\/install/u);

--- a/desktop/src/main/settings/management-inventory-change.test.js
+++ b/desktop/src/main/settings/management-inventory-change.test.js
@@ -5,6 +5,7 @@ import {
   collectManagementInventoryPathsFromRuntimeMessage,
   filterProfileCodexHomeRoots,
   isManagementInventoryPath,
+  latestUserEntryRequestsManagedInventoryInstall,
   ManagementInventoryChangeTracker,
 } from "./management-inventory-change.ts";
 
@@ -96,4 +97,44 @@ test("ManagementInventoryChangeTracker records runtime inventory changes once pe
 
   assert.equal(tracker.consume("thread-1"), true);
   assert.equal(tracker.consume("thread-1"), false);
+});
+
+test("latestUserEntryRequestsManagedInventoryInstall only matches the latest user turn shortcuts", () => {
+  assert.equal(
+    latestUserEntryRequestsManagedInventoryInstall({
+      entries: [
+        {
+          kind: "user",
+          promptShortcuts: [{ token: "skill-creator" }],
+        },
+        {
+          kind: "assistant",
+        },
+        {
+          kind: "user",
+          promptShortcuts: [{ token: "gmail:gmail" }],
+        },
+      ],
+    }),
+    false,
+  );
+
+  assert.equal(
+    latestUserEntryRequestsManagedInventoryInstall({
+      entries: [
+        {
+          kind: "user",
+          promptShortcuts: [{ token: "gmail:gmail" }],
+        },
+        {
+          kind: "assistant",
+        },
+        {
+          kind: "user",
+          promptShortcuts: [{ token: "plugin-creator" }, { token: "skill-installer" }],
+        },
+      ],
+    }),
+    true,
+  );
 });

--- a/desktop/src/main/settings/management-inventory-change.ts
+++ b/desktop/src/main/settings/management-inventory-change.ts
@@ -34,6 +34,21 @@ function uniquePaths(paths: string[]): string[] {
   return Array.from(new Set(paths.map((candidate) => path.resolve(candidate))));
 }
 
+const MANAGED_INVENTORY_SHORTCUTS = new Set([
+  "plugin-creator",
+  "skill-creator",
+  "skill-installer",
+]);
+
+function normalizeShortcutToken(token: unknown): string {
+  const resolved = firstString(token);
+  if (!resolved) {
+    return "";
+  }
+
+  return resolved.split(":").at(-1)?.trim().toLowerCase() ?? "";
+}
+
 export function filterProfileCodexHomeRoots(
   roots: Array<string | null | undefined>,
 ): string[] {
@@ -99,6 +114,23 @@ export function isManagementInventoryPath(
   }
 
   return isPathWithinAnyRoot(absolutePath, resolveInventoryRoots(codexHomeRoots));
+}
+
+export function latestUserEntryRequestsManagedInventoryInstall(
+  threadState: { entries?: Array<{ kind?: unknown; promptShortcuts?: Array<{ token?: unknown }> }> } | null | undefined,
+): boolean {
+  const entries = Array.isArray(threadState?.entries) ? threadState.entries : [];
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry?.kind !== "user") {
+      continue;
+    }
+
+    const shortcuts = Array.isArray(entry.promptShortcuts) ? entry.promptShortcuts : [];
+    return shortcuts.some((shortcut) => MANAGED_INVENTORY_SHORTCUTS.has(normalizeShortcutToken(shortcut?.token)));
+  }
+
+  return false;
 }
 
 export function collectManagementInventoryPathsFromRuntimeMessage(


### PR DESCRIPTION
Closes #48

This fixes the remaining backend gap where creator and installer turns could still finish as workspace drafts even after Sense-1 had granted profile `codex-home` write access.

The user-visible failure mode was twofold. First, `plugin-creator`, `skill-creator`, and `skill-installer` turns could still follow the generic desktop guidance that normal deliverables belong in the selected workspace or session folder, so the model would sometimes stop at a scaffold in the workspace instead of finishing the managed install in profile inventory. Second, the management surfaces only reloaded when runtime diff telemetry explicitly pointed at profile inventory paths, which misses some helper-script or indirect install flows even when the managed install actually happened.

The root cause was that the creator/install lane had write access and some destination hints, but it did not explicitly override the default workspace-deliverable rule. On top of that, management refresh was coupled too tightly to codex-home path diffs, so a successful managed install could still be invisible until a manual refresh.

This change makes the managed creator/install destination explicit. The creator shortcuts now state that these runs are an exception to the normal workspace deliverable rule, require the final installed artifact to exist under profile `codex-home`, and reject reporting a workspace draft or scaffold as a successful managed install. The runtime side also now triggers a management inventory refresh when the latest completed user turn invoked one of the managed inventory shortcuts, even if no qualifying inventory diff was emitted.

Validation:
- `node --test desktop/src/main/settings/management-inventory-change.test.js`
- `node --test desktop/src/main/session/session-controller.test.js --test-name-pattern 'runDesktopTask keeps folder-bound creator shortcuts inside the selected workspace while granting profile codex home writes'`
- `node scripts/check-public-boundary.mjs`
- `pnpm --dir desktop typecheck`
- `pnpm --dir desktop check:structure` (existing soft-limit warnings only)
- `pnpm --dir desktop test:unit`
- `pnpm --dir desktop build`
