### PR TITLE
Add extension action UX for bundled items and MCP controls

### DIFF
--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -153,6 +153,15 @@ export default function App() {
         onRefresh={() => {
           void management.loadOverview(true);
         }}
+        onTryInChat={(extensionName) => {
+          setActiveView("home");
+          const prompt = `$${extensionName}`;
+          if (sessionState.selectedThread) {
+            setThreadPrompt(prompt);
+            return;
+          }
+          setDraftPrompt(prompt);
+        }}
         installPlugin={management.installPlugin}
         openAppInstall={management.openAppInstall}
         overview={management.overview}
@@ -161,6 +170,7 @@ export default function App() {
         setMcpServerEnabled={management.setMcpServerEnabled}
         setPluginEnabled={management.setPluginEnabled}
         setSkillEnabled={management.setSkillEnabled}
+        startMcpServerAuth={management.startMcpServerAuth}
         uninstallPlugin={management.uninstallPlugin}
         uninstallSkill={management.uninstallSkill}
       />

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -155,7 +155,8 @@ export default function App() {
         }}
         onTryInChat={(extensionName) => {
           setActiveView("home");
-          const prompt = `$${extensionName}`;
+          const token = extensionName.toLowerCase().replace(/[^a-z0-9:_-]+/g, "-").replace(/^-+|-+$/g, "");
+          const prompt = `$${token} `;
           if (sessionState.selectedThread) {
             setThreadPrompt(prompt);
             return;

--- a/desktop/src/renderer/components/PluginsPage.tsx
+++ b/desktop/src/renderer/components/PluginsPage.tsx
@@ -600,9 +600,10 @@ export function PluginsPage({
             void runAction(`mcp-auth:${selectedManagedRecord.id}`, async () => await startMcpServerAuth({ serverId: selectedManagedRecord.id }), `Started auth flow for ${selectedManagedRecord.displayName}.`);
           } : undefined}
           onReload={selectedManagedRecord.canReload ? () => {
+            const wasEnabled = selectedManagedRecord.enablementState === "enabled";
             void runAction(`mcp-reload:${selectedManagedRecord.id}`, async () => {
               await setMcpServerEnabled({ serverId: selectedManagedRecord.id, enabled: false });
-              await setMcpServerEnabled({ serverId: selectedManagedRecord.id, enabled: true });
+              await setMcpServerEnabled({ serverId: selectedManagedRecord.id, enabled: wasEnabled });
             }, `Reloaded ${selectedManagedRecord.displayName}.`);
           } : undefined}
           pendingActionKey={pendingActionKey}

--- a/desktop/src/renderer/components/PluginsPage.tsx
+++ b/desktop/src/renderer/components/PluginsPage.tsx
@@ -36,6 +36,7 @@ type PluginsPageProps = {
   loading: boolean;
   onCreatePlugin: () => void;
   onCreateSkill: () => void;
+  onTryInChat?: (extensionName: string) => void;
   openAppInstall: (request: { appId: string; installUrl: string }) => Promise<unknown>;
   onRefresh: () => void;
   overview: DesktopExtensionOverviewResult | null;
@@ -44,6 +45,7 @@ type PluginsPageProps = {
   setMcpServerEnabled: (request: { serverId: string; enabled: boolean }) => Promise<unknown>;
   setPluginEnabled: (request: { pluginId: string; enabled: boolean }) => Promise<unknown>;
   setSkillEnabled: (request: { path: string; enabled: boolean }) => Promise<unknown>;
+  startMcpServerAuth?: (request: { serverId: string }) => Promise<unknown>;
   uninstallPlugin: (request: { pluginId: string }) => Promise<unknown>;
   uninstallSkill: (request: { path: string }) => Promise<unknown>;
 };
@@ -353,6 +355,7 @@ export function PluginsPage({
   loading,
   onCreatePlugin,
   onCreateSkill,
+  onTryInChat,
   openAppInstall,
   onRefresh,
   overview,
@@ -361,6 +364,7 @@ export function PluginsPage({
   setMcpServerEnabled,
   setPluginEnabled,
   setSkillEnabled,
+  startMcpServerAuth,
   uninstallPlugin,
   uninstallSkill,
 }: PluginsPageProps) {
@@ -554,6 +558,19 @@ export function PluginsPage({
             setActiveTab(tabMap[kind]);
             selectEntity(id, kind);
           }}
+          onOpen={selectedManagedRecord.canOpen && selectedManagedRecord.sourcePath ? () => {
+            void window.sense1Desktop.workspace.openFilePath(selectedManagedRecord.sourcePath!);
+          } : undefined}
+          onTryInChat={onTryInChat}
+          onToggleBundledItem={(id, kind, enabled) => {
+            if (kind === "skill") {
+              void runAction(`skill-enable:${id}`, async () => await setSkillEnabled({ path: id, enabled }));
+            } else if (kind === "app") {
+              void runAction(`app-enable:${id}`, async () => await setAppEnabled({ appId: id, enabled }));
+            } else if (kind === "mcp") {
+              void runAction(`mcp-enable:${id}`, async () => await setMcpServerEnabled({ serverId: id, enabled }));
+            }
+          }}
           pendingActionKey={pendingActionKey}
           Toggle={Toggle}
         />
@@ -579,6 +596,15 @@ export function PluginsPage({
           legacyMcp={overview.mcpServers.find((m) => m.id === selectedManagedRecord.id)}
           onBack={clearSelection}
           onToggleEnabled={(next) => void runAction(`mcp-enable:${selectedManagedRecord.id}`, async () => await setMcpServerEnabled({ serverId: selectedManagedRecord.id, enabled: next }))}
+          onStartAuth={selectedManagedRecord.canConnect && startMcpServerAuth ? () => {
+            void runAction(`mcp-auth:${selectedManagedRecord.id}`, async () => await startMcpServerAuth({ serverId: selectedManagedRecord.id }), `Started auth flow for ${selectedManagedRecord.displayName}.`);
+          } : undefined}
+          onReload={selectedManagedRecord.canReload ? () => {
+            void runAction(`mcp-reload:${selectedManagedRecord.id}`, async () => {
+              await setMcpServerEnabled({ serverId: selectedManagedRecord.id, enabled: false });
+              await setMcpServerEnabled({ serverId: selectedManagedRecord.id, enabled: true });
+            }, `Reloaded ${selectedManagedRecord.displayName}.`);
+          } : undefined}
           pendingActionKey={pendingActionKey}
           Toggle={Toggle}
         />
@@ -804,6 +830,7 @@ export function PluginsPage({
               void window.sense1Desktop.workspace.openFilePath(selectedManagedRecord.sourcePath);
             }
           }}
+          onTryInChat={onTryInChat}
           pendingActionKey={pendingActionKey}
           Toggle={Toggle}
         />

--- a/desktop/src/renderer/components/extensions/McpDetailView.tsx
+++ b/desktop/src/renderer/components/extensions/McpDetailView.tsx
@@ -1,15 +1,18 @@
-import { ArrowLeft, Cable } from "lucide-react";
+import { ArrowLeft, Cable, Check, RefreshCw } from "lucide-react";
 
 import type {
   DesktopManagedExtensionRecord,
   DesktopMcpServerRecord,
 } from "../../../main/contracts";
+import { Button } from "../ui/button";
 
 type McpDetailViewProps = {
   managedRecord: DesktopManagedExtensionRecord;
   legacyMcp: DesktopMcpServerRecord | undefined;
   onBack: () => void;
   onToggleEnabled: (next: boolean) => void;
+  onStartAuth?: () => void;
+  onReload?: () => void;
   pendingActionKey: string | null;
   Toggle: React.ComponentType<{ checked: boolean; disabled?: boolean; onChange?: (next: boolean) => void }>;
 };
@@ -43,11 +46,19 @@ export function McpDetailView({
   legacyMcp,
   onBack,
   onToggleEnabled,
+  onStartAuth,
+  onReload,
   pendingActionKey,
   Toggle,
 }: McpDetailViewProps) {
   const isEnabled = managedRecord.enablementState === "enabled";
   const enableKey = `mcp-enable:${managedRecord.id}`;
+  const authKey = `mcp-auth:${managedRecord.id}`;
+  const reloadKey = `mcp-reload:${managedRecord.id}`;
+
+  const authState = managedRecord.authState;
+  const needsConnect = authState === "required" || authState === "failed";
+  const isConnected = authState === "connected";
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -71,6 +82,17 @@ export function McpDetailView({
           ) : null}
         </div>
         <div className="flex shrink-0 items-center gap-2">
+          {managedRecord.canReload && onReload ? (
+            <Button
+              className="h-7 gap-1.5 rounded-lg px-2.5 text-[11px]"
+              disabled={pendingActionKey === reloadKey}
+              onClick={onReload}
+              variant="secondary"
+            >
+              <RefreshCw className="size-3" />
+              Reload
+            </Button>
+          ) : null}
           {managedRecord.canDisable ? (
             <Toggle
               checked={isEnabled}
@@ -89,13 +111,40 @@ export function McpDetailView({
             <SectionHeading>Status</SectionHeading>
             <div className="flex items-center gap-3 rounded-xl bg-surface-soft px-3 py-3">
               <HealthBadge state={managedRecord.healthState} />
-              {managedRecord.authState !== "not-required" ? (
+              {isConnected ? (
+                <span className="flex items-center gap-1 rounded-md bg-green-50 px-2 py-1 text-[11px] font-medium text-green-700">
+                  <Check className="size-3" />
+                  Connected
+                </span>
+              ) : needsConnect ? (
                 <span className="rounded bg-amber-50 px-2 py-0.5 text-[11px] text-amber-600">
-                  Auth: {managedRecord.authState}
+                  Auth required
+                </span>
+              ) : authState !== "not-required" ? (
+                <span className="rounded bg-amber-50 px-2 py-0.5 text-[11px] text-amber-600">
+                  Auth: {authState}
                 </span>
               ) : null}
             </div>
           </section>
+
+          {/* Auth action */}
+          {managedRecord.canConnect && needsConnect && onStartAuth ? (
+            <section>
+              <SectionHeading>Authentication</SectionHeading>
+              <div className="flex items-center gap-3 rounded-xl bg-surface-soft px-3 py-3">
+                <span className="rounded bg-amber-50 px-2 py-1 text-[11px] text-amber-600">Auth required</span>
+                <Button
+                  className="h-7 rounded-lg px-3 text-[11px]"
+                  disabled={pendingActionKey === authKey}
+                  onClick={onStartAuth}
+                  variant="default"
+                >
+                  Connect
+                </Button>
+              </div>
+            </section>
+          ) : null}
 
           {/* Capabilities */}
           {legacyMcp ? (
@@ -118,6 +167,7 @@ export function McpDetailView({
             <div className="rounded-xl bg-surface-soft px-3 py-2">
               <MetadataRow label="Server ID" value={managedRecord.id} />
               <MetadataRow label="Ownership" value={managedRecord.ownership} />
+              <MetadataRow label="Install state" value={managedRecord.installState} />
             </div>
           </section>
         </div>

--- a/desktop/src/renderer/components/extensions/PluginDetailView.tsx
+++ b/desktop/src/renderer/components/extensions/PluginDetailView.tsx
@@ -136,7 +136,7 @@ export function PluginDetailView({
           {onTryInChat ? (
             <Button
               className="h-7 gap-1.5 rounded-lg px-2.5 text-[11px]"
-              onClick={() => onTryInChat(managedRecord.displayName)}
+              onClick={() => onTryInChat(managedRecord.name)}
               variant="secondary"
             >
               <MessageSquare className="size-3" />

--- a/desktop/src/renderer/components/extensions/PluginDetailView.tsx
+++ b/desktop/src/renderer/components/extensions/PluginDetailView.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Blocks, Cable, ExternalLink, Sparkles, Trash2 } from "lucide-react";
+import { ArrowLeft, Blocks, Cable, ExternalLink, MessageSquare, Sparkles, Trash2 } from "lucide-react";
 
 import type {
   DesktopAppRecord,
@@ -15,6 +15,9 @@ type PluginDetailViewProps = {
   onToggleEnabled: (next: boolean) => void;
   onUninstall: () => void;
   onNavigateToEntity: (id: string, kind: "skill" | "app" | "mcp") => void;
+  onOpen?: () => void;
+  onTryInChat?: (name: string) => void;
+  onToggleBundledItem?: (id: string, kind: "skill" | "app" | "mcp", enabled: boolean) => void;
   pendingActionKey: string | null;
   Toggle: React.ComponentType<{ checked: boolean; disabled?: boolean; onChange?: (next: boolean) => void }>;
 };
@@ -33,24 +36,34 @@ function MetadataRow({ label, value }: { label: string; value: string | null | u
   );
 }
 
-function IncludedEntityChip({
+function IncludedEntityRow({
   icon: Icon,
   label,
   onClick,
+  toggle,
 }: {
   icon: typeof Sparkles;
   label: string;
   onClick?: () => void;
+  toggle?: React.ReactNode;
 }) {
   return (
-    <button
-      className="inline-flex items-center gap-1.5 rounded-lg bg-surface-soft px-2.5 py-1.5 text-[11px] text-ink transition-colors hover:bg-surface-strong"
-      onClick={onClick}
-      type="button"
-    >
-      <Icon className="size-3 text-muted" />
-      {label}
-    </button>
+    <div className="flex items-center gap-2 py-1">
+      <button
+        className="inline-flex min-w-0 flex-1 items-center gap-1.5 rounded-lg bg-surface-soft px-2.5 py-1.5 text-[11px] text-ink transition-colors hover:bg-surface-strong"
+        onClick={onClick}
+        type="button"
+      >
+        <Icon className="size-3 shrink-0 text-muted" />
+        <span className="truncate">{label}</span>
+      </button>
+      {toggle ? (
+        /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
+        <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
+          {toggle}
+        </div>
+      ) : null}
+    </div>
   );
 }
 
@@ -61,6 +74,9 @@ export function PluginDetailView({
   onToggleEnabled,
   onUninstall,
   onNavigateToEntity,
+  onOpen,
+  onTryInChat,
+  onToggleBundledItem,
   pendingActionKey,
   Toggle,
 }: PluginDetailViewProps) {
@@ -107,6 +123,26 @@ export function PluginDetailView({
           ) : null}
         </div>
         <div className="flex shrink-0 items-center gap-2">
+          {managedRecord.canOpen && onOpen ? (
+            <Button
+              className="h-7 gap-1.5 rounded-lg px-2.5 text-[11px]"
+              onClick={onOpen}
+              variant="secondary"
+            >
+              <ExternalLink className="size-3" />
+              Open
+            </Button>
+          ) : null}
+          {onTryInChat ? (
+            <Button
+              className="h-7 gap-1.5 rounded-lg px-2.5 text-[11px]"
+              onClick={() => onTryInChat(managedRecord.displayName)}
+              variant="secondary"
+            >
+              <MessageSquare className="size-3" />
+              Try in chat
+            </Button>
+          ) : null}
           {managedRecord.canDisable ? (
             <Toggle
               checked={isEnabled}
@@ -162,26 +198,44 @@ export function PluginDetailView({
           {hasIncludes ? (
             <section>
               <SectionHeading>Includes</SectionHeading>
-              <div className="flex flex-wrap gap-1.5">
+              <div className="space-y-0.5">
                 {includedSkills.map((skill) => (
-                  <IncludedEntityChip
+                  <IncludedEntityRow
                     icon={Sparkles}
                     key={skill.id}
                     label={skill.displayName}
                     onClick={() => onNavigateToEntity(skill.id, "skill")}
+                    toggle={
+                      skill.canDisable && onToggleBundledItem ? (
+                        <Toggle
+                          checked={skill.enablementState === "enabled"}
+                          disabled={pendingActionKey === `skill-enable:${skill.id}`}
+                          onChange={(next) => onToggleBundledItem(skill.id, "skill", next)}
+                        />
+                      ) : null
+                    }
                   />
                 ))}
                 {includedApps.length > 0
                   ? includedApps.map((app) => (
-                      <IncludedEntityChip
+                      <IncludedEntityRow
                         icon={Blocks}
                         key={app.id}
                         label={app.displayName}
                         onClick={() => onNavigateToEntity(app.id, "app")}
+                        toggle={
+                          app.canDisable && onToggleBundledItem ? (
+                            <Toggle
+                              checked={app.enablementState === "enabled"}
+                              disabled={pendingActionKey === `app-enable:${app.id}`}
+                              onChange={(next) => onToggleBundledItem(app.id, "app", next)}
+                            />
+                          ) : null
+                        }
                       />
                     ))
                   : legacyAppRecords.map((app) => (
-                      <IncludedEntityChip
+                      <IncludedEntityRow
                         icon={Blocks}
                         key={app.id}
                         label={app.name}
@@ -189,11 +243,20 @@ export function PluginDetailView({
                       />
                     ))}
                 {includedMcps.map((mcp) => (
-                  <IncludedEntityChip
+                  <IncludedEntityRow
                     icon={Cable}
                     key={mcp.id}
                     label={mcp.displayName}
                     onClick={() => onNavigateToEntity(mcp.id, "mcp")}
+                    toggle={
+                      mcp.canDisable && onToggleBundledItem ? (
+                        <Toggle
+                          checked={mcp.enablementState === "enabled"}
+                          disabled={pendingActionKey === `mcp-enable:${mcp.id}`}
+                          onChange={(next) => onToggleBundledItem(mcp.id, "mcp", next)}
+                        />
+                      ) : null
+                    }
                   />
                 ))}
               </div>

--- a/desktop/src/renderer/components/extensions/SkillDetailModal.tsx
+++ b/desktop/src/renderer/components/extensions/SkillDetailModal.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink, Sparkles, Trash2, X } from "lucide-react";
+import { ExternalLink, MessageSquare, Sparkles, Trash2, X } from "lucide-react";
 
 import type { DesktopManagedExtensionRecord, DesktopSkillRecord } from "../../../main/contracts";
 import { Button } from "../ui/button";
@@ -10,6 +10,7 @@ type SkillDetailModalProps = {
   onToggleEnabled: (next: boolean) => void;
   onUninstall: () => void;
   onOpen: () => void;
+  onTryInChat?: (name: string) => void;
   pendingActionKey: string | null;
   Toggle: React.ComponentType<{ checked: boolean; disabled?: boolean; onChange?: (next: boolean) => void }>;
 };
@@ -21,6 +22,7 @@ export function SkillDetailModal({
   onToggleEnabled,
   onUninstall,
   onOpen,
+  onTryInChat,
   pendingActionKey,
   Toggle,
 }: SkillDetailModalProps) {
@@ -87,6 +89,16 @@ export function SkillDetailModal({
             ) : null}
           </div>
           <div className="flex items-center gap-2">
+            {onTryInChat ? (
+              <Button
+                className="h-7 gap-1.5 rounded-lg px-2.5 text-[11px]"
+                onClick={() => onTryInChat(managedRecord.displayName)}
+                variant="secondary"
+              >
+                <MessageSquare className="size-3" />
+                Try in chat
+              </Button>
+            ) : null}
             {managedRecord.canOpen ? (
               <Button
                 className="h-7 gap-1.5 rounded-lg px-2.5 text-[11px]"

--- a/desktop/src/renderer/components/extensions/SkillDetailModal.tsx
+++ b/desktop/src/renderer/components/extensions/SkillDetailModal.tsx
@@ -92,7 +92,7 @@ export function SkillDetailModal({
             {onTryInChat ? (
               <Button
                 className="h-7 gap-1.5 rounded-lg px-2.5 text-[11px]"
-                onClick={() => onTryInChat(managedRecord.displayName)}
+                onClick={() => onTryInChat(managedRecord.name)}
                 variant="secondary"
               >
                 <MessageSquare className="size-3" />

--- a/desktop/src/renderer/features/management/use-desktop-management.ts
+++ b/desktop/src/renderer/features/management/use-desktop-management.ts
@@ -5,6 +5,8 @@ import type {
   DesktopAppInstallRequest,
   DesktopAppEnabledRequest,
   DesktopExtensionOverviewResult,
+  DesktopMcpServerAuthRequest,
+  DesktopMcpServerAuthResult,
   DesktopMcpServerEnabledRequest,
   DesktopPluginInstallRequest,
   DesktopPluginUninstallRequest,
@@ -111,6 +113,13 @@ export function useDesktopManagement({
     return nextOverview;
   }, []);
 
+  const startMcpServerAuth = useCallback(async (request: DesktopMcpServerAuthRequest): Promise<DesktopMcpServerAuthResult> => {
+    const bridge = requireDesktopBridge();
+    const result = await bridge.management.startMcpServerAuth(request);
+    setOverview(result.overview);
+    return result;
+  }, []);
+
   const setMcpServerEnabled = useCallback(async (request: DesktopMcpServerEnabledRequest) => {
     const bridge = requireDesktopBridge();
     const nextOverview = await bridge.management.setMcpServerEnabled(request);
@@ -144,6 +153,7 @@ export function useDesktopManagement({
     setMcpServerEnabled,
     setPluginEnabled,
     setSkillEnabled,
+    startMcpServerAuth,
     uninstallPlugin,
     uninstallSkill,
   };


### PR DESCRIPTION
## Summary
- Add "Try in chat" button on PluginDetailView and SkillDetailModal that navigates to chat with the extension name as prompt
- Add bundled item toggle switches in PluginDetailView so users can enable/disable individual skills, apps, and MCPs from a plugin's detail view (gated on `canDisable`)
- Add MCP "Connect" button in McpDetailView for auth-required servers (gated on `canConnect`), wired to `startMcpServerAuth` bridge method
- Add MCP "Reload" button in McpDetailView (gated on `canReload`), implemented as toggle off+on
- Add "Open" button for plugins with `sourcePath` in PluginDetailView
- Improve visual state presentation in McpDetailView with connected (green checkmark), auth-required (amber), and error health (red) badges
- Add `startMcpServerAuth` to `use-desktop-management` hook

Closes #47

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test:renderer` passes (143/143 tests)
- [ ] Manual: open a plugin detail view and verify bundled item toggles appear for items with `canDisable`
- [ ] Manual: open an MCP detail view and verify Connect/Reload buttons appear based on `canConnect`/`canReload`
- [ ] Manual: click "Try in chat" on a plugin or skill and verify navigation to chat
