### PR TITLE
[codex] keep app connect flows inside Sense-1

### DIFF
--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -13,6 +13,7 @@ import {
 import {
   createMainWindow,
   focusMainWindow,
+  openDesktopAuthWindow,
 } from "./window";
 import { resolveDesktopIconPath } from "./desktop-icon.js";
 import { emitDesktopRuntimeEvent, emitDesktopThreadDelta, registerDesktopIpcHandlers, unregisterDesktopIpcHandlers } from "./ipc";
@@ -449,6 +450,9 @@ const desktopSessionController = new DesktopSessionController(appServerManager, 
   env: process.env,
   openExternal: async (url) => {
     await shell.openExternal(url);
+  },
+  openManagedAuth: async (url) => {
+    await openDesktopAuthWindow(url);
   },
   onRuntimeEvent: async (event) => {
     emitDesktopRuntimeEvent(event);

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -14,6 +14,7 @@ import {
   createMainWindow,
   focusMainWindow,
   openDesktopAuthWindow,
+  openDesktopManagedAuthWindow,
 } from "./window";
 import { resolveDesktopIconPath } from "./desktop-icon.js";
 import { emitDesktopRuntimeEvent, emitDesktopThreadDelta, registerDesktopIpcHandlers, unregisterDesktopIpcHandlers } from "./ipc";
@@ -452,7 +453,7 @@ const desktopSessionController = new DesktopSessionController(appServerManager, 
     await shell.openExternal(url);
   },
   openManagedAuth: async (url) => {
-    await openDesktopAuthWindow(url);
+    await openDesktopManagedAuthWindow(url);
   },
   onRuntimeEvent: async (event) => {
     emitDesktopRuntimeEvent(event);

--- a/desktop/src/main/session-controller.ts
+++ b/desktop/src/main/session-controller.ts
@@ -124,6 +124,7 @@ export type DesktopSessionControllerOptions = {
   readonly desktopVoiceClient?: DesktopVoiceClient;
   readonly env?: NodeJS.ProcessEnv;
   readonly openExternal: (url: string) => Promise<void>;
+  readonly openManagedAuth?: (url: string) => Promise<void>;
   readonly onDesktopRunStarted?: (result: DesktopTaskRunResult) => void | Promise<void>;
   readonly onDesktopTaskResult?: (result: DesktopTaskRunResult) => void | Promise<void>;
   readonly onThreadTitleChanged?: (threadId: string, title: string) => void | Promise<void>;
@@ -175,6 +176,7 @@ export class DesktopSessionController {
   readonly #appStartedAt: string;
   readonly #env: NodeJS.ProcessEnv;
   readonly #openExternal: (url: string) => Promise<void>;
+  readonly #openManagedAuth: (url: string) => Promise<void>;
   readonly #onDesktopRunStarted: ((result: DesktopTaskRunResult) => void | Promise<void>) | null;
   readonly #onDesktopTaskResult: ((result: DesktopTaskRunResult) => void | Promise<void>) | null;
   readonly #onThreadTitleChanged: ((threadId: string, title: string) => void | Promise<void>) | null;
@@ -208,6 +210,7 @@ export class DesktopSessionController {
     this.#appStartedAt = options.appStartedAt;
     this.#env = options.env ?? process.env;
     this.#openExternal = options.openExternal;
+    this.#openManagedAuth = options.openManagedAuth ?? options.openExternal;
     this.#resolveProfile = async () => await this.#resolveCurrentProfile();
     this.#onRuntimeEvent = options.onRuntimeEvent ?? null;
     this.#onDesktopRunStarted = options.onDesktopRunStarted ?? null;
@@ -241,6 +244,7 @@ export class DesktopSessionController {
       env: this.#env,
       manager: this.#manager,
       openExternal: this.#openExternal,
+      openManagedAuth: this.#openManagedAuth,
       resolveProfile: this.#resolveProfile,
     });
     this.#desktopTenant = new DesktopTenantService({

--- a/desktop/src/main/settings/desktop-extension-service.test.js
+++ b/desktop/src/main/settings/desktop-extension-service.test.js
@@ -635,7 +635,8 @@ test("getOverview does not treat apps linked only to discoverable plugins as ins
 test("installPlugin enables manifest-backed apps even when plugin/install omits app ids", async () => {
   const pluginRoot = await createInstalledPluginFixture();
   const managerCalls = [];
-  const opened = [];
+  const managedAuthOpened = [];
+  const externallyOpened = [];
   let installed = false;
 
   const service = new DesktopExtensionService({
@@ -732,7 +733,10 @@ test("installPlugin enables manifest-backed apps even when plugin/install omits 
       throw new Error(`Unexpected method: ${method}`);
     }),
     openExternal: async (url) => {
-      opened.push(url);
+      externallyOpened.push(url);
+    },
+    openManagedAuth: async (url) => {
+      managedAuthOpened.push(url);
     },
     resolveProfile: async () => ({ id: "default" }),
   });
@@ -769,7 +773,8 @@ test("installPlugin enables manifest-backed apps even when plugin/install omits 
     ],
   });
   assert.ok(managerCalls.some((entry) => entry.method === "config/mcpServer/reload"));
-  assert.deepEqual(opened, ["https://chatgpt.com/gmail/install"]);
+  assert.deepEqual(managedAuthOpened, ["https://chatgpt.com/gmail/install"]);
+  assert.deepEqual(externallyOpened, []);
   assert.equal(overview.plugins[0]?.installed, true);
   assert.deepEqual(overview.apps[0]?.pluginDisplayNames, ["Gmail", "gmail"]);
 });
@@ -1156,9 +1161,10 @@ test("setPluginEnabled disables manifest-backed apps when no other plugin still 
   assert.ok(managerCalls.some((entry) => entry.method === "config/mcpServer/reload"));
 });
 
-test("openAppInstall enables the app and opens its install URL", async () => {
+test("openAppInstall enables the app and opens its install URL in the managed auth window", async () => {
   const managerCalls = [];
-  const opened = [];
+  const managedAuthOpened = [];
+  const externallyOpened = [];
 
   const service = new DesktopExtensionService({
     manager: createManager(async (method, params) => {
@@ -1214,7 +1220,10 @@ test("openAppInstall enables the app and opens its install URL", async () => {
       throw new Error(`Unexpected method: ${method}`);
     }),
     openExternal: async (url) => {
-      opened.push(url);
+      externallyOpened.push(url);
+    },
+    openManagedAuth: async (url) => {
+      managedAuthOpened.push(url);
     },
     resolveProfile: async () => ({ id: "default" }),
   });
@@ -1239,7 +1248,8 @@ test("openAppInstall enables the app and opens its install URL", async () => {
       },
     ],
   });
-  assert.deepEqual(opened, ["https://chatgpt.com/gmail/install"]);
+  assert.deepEqual(managedAuthOpened, ["https://chatgpt.com/gmail/install"]);
+  assert.deepEqual(externallyOpened, []);
 });
 
 test("uninstallPlugin removes a profile-owned plugin directory and disables its profile entries", async () => {
@@ -1791,7 +1801,8 @@ test("readPluginDetail prefers plugin/read and falls back to local metadata", as
 });
 
 test("startMcpServerAuth opens the returned authorization URL", async () => {
-  const opened = [];
+  const externallyOpened = [];
+  const managedAuthOpened = [];
 
   const service = new DesktopExtensionService({
     manager: createManager(async (method) => {
@@ -1846,14 +1857,18 @@ test("startMcpServerAuth opens the returned authorization URL", async () => {
       throw new Error(`Unexpected method: ${method}`);
     }),
     openExternal: async (url) => {
-      opened.push(url);
+      externallyOpened.push(url);
+    },
+    openManagedAuth: async (url) => {
+      managedAuthOpened.push(url);
     },
     resolveProfile: async () => ({ id: "default" }),
   });
 
   const result = await service.startMcpServerAuth({ serverId: "docs" });
   assert.equal(result.authorizationUrl, "https://example.com/oauth/start");
-  assert.deepEqual(opened, ["https://example.com/oauth/start"]);
+  assert.deepEqual(externallyOpened, ["https://example.com/oauth/start"]);
+  assert.deepEqual(managedAuthOpened, []);
 });
 
 test("readSkillDetail returns the skill markdown body", async () => {

--- a/desktop/src/main/settings/desktop-extension-service.ts
+++ b/desktop/src/main/settings/desktop-extension-service.ts
@@ -40,6 +40,7 @@ type DesktopExtensionServiceOptions = {
   env?: NodeJS.ProcessEnv;
   manager: AppServerProcessManager;
   openExternal: (url: string) => Promise<void>;
+  openManagedAuth?: (url: string) => Promise<void>;
   resolveProfile: () => Promise<{ id: string }>;
 };
 
@@ -1183,12 +1184,14 @@ export class DesktopExtensionService {
   readonly #env: NodeJS.ProcessEnv;
   readonly #manager: AppServerProcessManager;
   readonly #openExternal: (url: string) => Promise<void>;
+  readonly #openManagedAuth: (url: string) => Promise<void>;
   readonly #resolveProfile: () => Promise<{ id: string }>;
 
   constructor(options: DesktopExtensionServiceOptions) {
     this.#env = options.env ?? process.env;
     this.#manager = options.manager;
     this.#openExternal = options.openExternal;
+    this.#openManagedAuth = options.openManagedAuth ?? options.openExternal;
     this.#resolveProfile = options.resolveProfile;
   }
 
@@ -1451,7 +1454,7 @@ export class DesktopExtensionService {
     }
 
     for (const installUrl of authUrls) {
-      await this.#openExternal(installUrl);
+      await this.#openManagedAuth(installUrl);
     }
 
     return finalOverview;
@@ -1594,7 +1597,7 @@ export class DesktopExtensionService {
       ],
     });
     await this.#restartRuntimeIfSupported("app-install");
-    await this.#openExternal(request.installUrl);
+    await this.#openManagedAuth(request.installUrl);
     return await this.getOverview({ forceRefetch: true });
   }
 

--- a/desktop/src/main/window.ts
+++ b/desktop/src/main/window.ts
@@ -12,6 +12,7 @@ const DESKTOP_AUTH_CALLBACK_PATH = "/auth/callback";
 let mainWindow: BrowserWindow | null = null;
 let authWindow: BrowserWindow | null = null;
 let authWindowCloseTimer: NodeJS.Timeout | null = null;
+const managedAuthWindows = new Set<BrowserWindow>();
 
 export function getMainWindow(): BrowserWindow | null {
   return mainWindow;
@@ -115,6 +116,15 @@ export async function openDesktopAuthWindow(authUrl: string): Promise<void> {
   window.focus();
 }
 
+export async function openDesktopManagedAuthWindow(authUrl: string): Promise<void> {
+  const window = createManagedAuthWindow();
+  await window.loadURL(authUrl);
+  if (!window.isVisible()) {
+    window.show();
+  }
+  window.focus();
+}
+
 export function markDesktopAuthCallbackSeen(targetUrl: string): void {
   if (!authWindow || authWindow.isDestroyed() || !isDesktopAuthCallbackUrl(targetUrl)) {
     return;
@@ -156,18 +166,7 @@ function getOrCreateAuthWindow(): BrowserWindow {
     return authWindow;
   }
 
-  const window = new BrowserWindow({
-    show: false,
-    width: 520,
-    height: 760,
-    minWidth: 420,
-    minHeight: 620,
-    title: "Sign in to sense-1",
-    autoHideMenuBar: true,
-    parent: mainWindow ?? undefined,
-    modal: false,
-    icon: resolveDesktopIconPath() ?? undefined,
-  });
+  const window = createAuthWindow("Sign in to sense-1");
 
   authWindow = window;
 
@@ -205,6 +204,30 @@ function getOrCreateAuthWindow(): BrowserWindow {
   });
 
   return window;
+}
+
+function createManagedAuthWindow(): BrowserWindow {
+  const window = createAuthWindow("Connect app in sense-1");
+  managedAuthWindows.add(window);
+  window.on("closed", () => {
+    managedAuthWindows.delete(window);
+  });
+  return window;
+}
+
+function createAuthWindow(title: string): BrowserWindow {
+  return new BrowserWindow({
+    show: false,
+    width: 520,
+    height: 760,
+    minWidth: 420,
+    minHeight: 620,
+    title,
+    autoHideMenuBar: true,
+    parent: mainWindow ?? undefined,
+    modal: false,
+    icon: resolveDesktopIconPath() ?? undefined,
+  });
 }
 
 function uniqueTargets(targets: Array<string | undefined>): string[] {


### PR DESCRIPTION
Closes #53

## Summary
Sense-1 app connect/install flows were still using the generic external-open path. On macOS that let the ChatGPT desktop app claim some ChatGPT install URLs, so clicking `Connect` from the Sense-1 Apps surface could jump into ChatGPT desktop instead of staying inside Sense-1.

## User impact
For auth-required apps like Canva, Sense-1 showed a `Connect` action but did not complete a usable in-app flow. The wrong desktop app could open, the connect attempt could fail there, and Sense-1 remained stuck on the detail view with no real state transition.

## Root cause
`DesktopExtensionService` treated app install/connect URLs the same as any other external URL and routed them through `shell.openExternal(...)` via the session controller's `openExternal` callback. That was too generic for Sense-1-owned app auth handoff.

## Fix
This PR adds a dedicated managed-auth callback for extension lifecycle work and uses it only for app install/connect URLs:
- plugin install follow-up auth URLs now open in the existing Sense-1 auth window
- direct app `Connect` / install URLs now open in the existing Sense-1 auth window
- MCP/provider OAuth still uses the generic external-open path

That keeps the change narrow: Sense-1 owns the app connect window, but unrelated external URLs and MCP auth are not forced into the same flow.

## Validation
- `node --test desktop/src/main/settings/desktop-extension-service.test.js`
- `node scripts/check-public-boundary.mjs`
- `pnpm --dir desktop typecheck`
- `pnpm --dir desktop check:structure`
- `pnpm --dir desktop test:unit`
- `pnpm --dir desktop build`

## Notes
- `check:structure` still reports the repo's existing soft-limit warnings; this PR does not change that baseline.
- I did not rerun the signed-in Electron app manually after the patch, so the remaining gap is live end-to-end confirmation rather than backend coverage.
