### PR TITLE
[codex] close extension lifecycle parity with recovery coverage

### DIFF
--- a/EXTENSION_ACCEPTANCE_MATRIX.md
+++ b/EXTENSION_ACCEPTANCE_MATRIX.md
@@ -1,0 +1,44 @@
+# Extension Acceptance Matrix
+
+This matrix tracks the expected end-to-end extension lifecycle in Sense-1 and
+the current verification shape for each scenario.
+
+The goal is to keep automated coverage focused on durable backend and state
+contracts, then use one signed-in Electron smoke pass to validate the final
+surface behavior against real ChatGPT/App Server integrations.
+
+## Automated coverage legend
+
+- `Covered` means the behavior is directly asserted in automated tests.
+- `Partial` means the contract is covered indirectly, but the full user flow
+  still needs manual confirmation.
+- `Manual` means the scenario currently requires a signed-in Electron check.
+
+## Scenario matrix
+
+| Scenario | Expected result | Automated coverage | Manual verification |
+| --- | --- | --- | --- |
+| Plugin install discovery | Discoverable plugins appear as installable inventory without being treated as installed/plugin-owned until runtime confirms install. | Covered: `desktop/src/main/settings/desktop-extension-service.test.js` (`getOverview does not treat apps linked only to discoverable plugins as installed plugin-owned inventory`) | Confirm marketplace search/install in a signed-in session. |
+| Installed plugin lifecycle | Installed plugins surface ownership, uninstall capability, bundled apps/skills/MCPs, and stable metadata from runtime plus local plugin files. | Covered: `desktop/src/main/settings/desktop-extension-service.test.js` (`getOverview preserves marketplace metadata and uses the profile codex home for plugin discovery`, `getOverview emits normalized managed extensions with ownership, auth, and composition metadata`) | Confirm install, disable, uninstall, and reopen behavior from the management UI. |
+| Bundled skill visibility | Plugin-owned skills appear in `Skills`, keep plugin ownership, and remain manageable from the normalized inventory. | Covered: `desktop/src/main/settings/desktop-extension-service.test.js` (`getOverview emits normalized managed extensions with ownership, auth, and composition metadata`) | Confirm bundled skills render in the `Skills` tab and respond to UI actions. |
+| Standalone profile skill lifecycle | Legacy or manually installed profile skills remain visible, openable, and uninstallable after contract migration. | Covered: `desktop/src/main/settings/desktop-extension-service.test.js` (`getOverview marks legacy profile-owned skills as uninstallable profile inventory`) | Confirm `Open`, `Disable`, and `Uninstall` from the skill detail modal. |
+| Manually created profile plugin migration | Profile-local plugins created outside the marketplace remain visible as managed inventory and can be removed cleanly. | Covered: `desktop/src/main/settings/desktop-extension-service.test.js` (`getOverview marks manually created profile plugins as uninstallable profile inventory`) | Confirm a profile-owned plugin renders with the expected remove action. |
+| Stale config cleanup | Ghost app/plugin references in `config.toml` do not create fake installed inventory when runtime no longer reports them. | Covered: `desktop/src/main/settings/desktop-extension-service.test.js` (`getOverview ignores stale plugin and app config references without creating ghost inventory`) | Confirm management counts stay stable after removing config-only references. |
+| App connect/disconnect lifecycle | Installed apps show `required` vs `connected` auth state, support connect/disconnect actions, and update inventory state after auth changes. | Partial: app state normalization is covered by existing `desktop-extension-service` tests, but the real auth/connect flow still depends on signed-in Electron and ChatGPT/App Server. | Confirm `Connect`, `Disconnect`, and retry flows in a signed-in Sense-1 session. |
+| MCP enablement persistence | Local MCP enable/disable state survives restart even when runtime `config/read` is temporarily stale. | Covered: `desktop/src/main/settings/desktop-extension-service.test.js` (`getOverview preserves local mcp enablement when runtime config is stale after restart`) | Toggle an MCP, restart the app, and confirm the state persists in the management page. |
+| MCP auth/error recovery | Failed MCP auth surfaces as a recoverable error state with reconnect available. | Covered: `desktop/src/main/settings/desktop-extension-service.test.js` (`getOverview marks failed MCP auth as recoverable error state`) | Confirm `Connect`/`Reload` behavior against a real MCP requiring auth. |
+| Creator-installed managed inventory | `skill-creator`, `skill-installer`, and `plugin-creator` end in managed profile inventory instead of leaving workspace-only drafts when the user requested installable output. | Partial: runtime routing and management refresh are covered by the `session-controller` and `management-inventory-change` suites from issues `#48` and `#32`. | Run each creator/install flow in a folder-bound thread and confirm the new item appears in the correct management tab without manual refresh. |
+| Workspace draft exclusion | Workspace-local scaffolds do not appear as installed managed inventory until explicitly installed into the Sense-1 profile inventory. | Partial: inventory detection only tracks managed profile roots, not arbitrary workspace files. | Create a workspace-only draft skill/plugin and confirm it does not appear in management until installed. |
+| Try in chat | `Try in chat` launches a thread with the correct managed inventory reference instead of a loose file attachment or broken shortcut. | Manual: frontend behavior depends on live thread/runtime wiring. | Confirm each entity type opens a thread with a working mention/shortcut. |
+| Restart persistence | Counts, enablement, and ownership remain stable after full app restart for plugins, apps, skills, and MCPs. | Partial: backend merge rules are covered for stale config and MCP persistence, but the final signed-in restart pass remains manual. | Perform one signed-in restart smoke run after install/toggle/auth actions. |
+
+## Known limits
+
+- App payloads from the current runtime contract do not expose a trustworthy
+  app-auth failure detail equivalent to MCP `authStatus = failed`. Sense-1 can
+  reliably distinguish `required` versus `connected`, but a separate app
+  `failed` state should not be inferred until upstream payloads expose it.
+- Automated coverage here validates the backend merge rules and normalized
+  inventory contract. It does not replace the final signed-in Electron smoke
+  pass required for auth handoffs, external windows, and real ChatGPT/App
+  Server integration behavior.

--- a/EXTENSION_LIFECYCLE_CONTRACT.md
+++ b/EXTENSION_LIFECYCLE_CONTRACT.md
@@ -2,6 +2,9 @@
 
 This document defines the first normalized management contract for Sense-1 extensions. It is intentionally additive: the existing tab-specific records remain in `DesktopExtensionOverviewResult`, and the new normalized `managedExtensions` collection exists to stabilize downstream lifecycle, ownership, and management work.
 
+For the executable verification surface that sits on top of this contract, see
+`EXTENSION_ACCEPTANCE_MATRIX.md`.
+
 ## Why This Exists
 
 Sense-1 already aggregates extension data from multiple app-server and profile-local sources in `desktop/src/main/settings/desktop-extension-service.ts`, but the current public contract is only a set of tab-specific inventory arrays:

--- a/desktop/src/main/settings/desktop-extension-service.test.js
+++ b/desktop/src/main/settings/desktop-extension-service.test.js
@@ -632,6 +632,356 @@ test("getOverview does not treat apps linked only to discoverable plugins as ins
   }
 });
 
+test("getOverview preserves local mcp enablement when runtime config is stale after restart", async () => {
+  const runtimeStateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-runtime-state-"));
+  const env = {
+    ...process.env,
+    SENSE1_RUNTIME_STATE_ROOT: runtimeStateRoot,
+  };
+  const { codexHome } = await ensureProfileDirectories("default", env);
+
+  try {
+    await fs.writeFile(
+      path.join(codexHome, "config.toml"),
+      [
+        '[mcp_servers.docs]',
+        "enabled = false",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const service = new DesktopExtensionService({
+      env,
+      manager: createManager(async (method) => {
+        if (method === "config/read") {
+          return {
+            config: {
+              mcp_servers: {},
+            },
+          };
+        }
+
+        if (method === "plugin/list") {
+          return { marketplaces: [] };
+        }
+
+        if (method === "app/list") {
+          return { data: [] };
+        }
+
+        if (method === "mcpServerStatus/list") {
+          return {
+            data: [
+              {
+                id: "docs",
+                state: "ready",
+                authStatus: "connected",
+                tools: [],
+                resources: [],
+              },
+            ],
+          };
+        }
+
+        if (method === "skills/list") {
+          return { data: [] };
+        }
+
+        if (method === "account/read") {
+          return createAccountReadResult();
+        }
+
+        throw new Error(`Unexpected method: ${method}`);
+      }),
+      openExternal: async () => {},
+      resolveProfile: async () => ({ id: "default" }),
+    });
+
+    const overview = await service.getOverview({ forceRefetch: true });
+    assert.equal(overview.mcpServers[0]?.enabled, false);
+    assert.equal(findManagedExtension(overview, "mcp", "docs")?.enablementState, "disabled");
+  } finally {
+    await fs.rm(runtimeStateRoot, { force: true, recursive: true });
+  }
+});
+
+test("getOverview marks failed MCP auth as recoverable error state", async () => {
+  const service = new DesktopExtensionService({
+    manager: createManager(async (method) => {
+      if (method === "config/read") {
+        return {
+          config: {
+            mcp_servers: {
+              docs: {
+                enabled: true,
+              },
+            },
+          },
+        };
+      }
+
+      if (method === "plugin/list") {
+        return { marketplaces: [] };
+      }
+
+      if (method === "app/list") {
+        return { data: [] };
+      }
+
+      if (method === "mcpServerStatus/list") {
+        return {
+          data: [
+            {
+              id: "docs",
+              state: "error",
+              authStatus: "failed",
+              tools: [],
+              resources: [],
+            },
+          ],
+        };
+      }
+
+      if (method === "skills/list") {
+        return { data: [] };
+      }
+
+      if (method === "account/read") {
+        return createAccountReadResult();
+      }
+
+      throw new Error(`Unexpected method: ${method}`);
+    }),
+    openExternal: async () => {},
+    resolveProfile: async () => ({ id: "default" }),
+  });
+
+  const overview = await service.getOverview({ forceRefetch: true });
+  const managedMcp = findManagedExtension(overview, "mcp", "docs");
+  assert.equal(managedMcp?.authState, "failed");
+  assert.equal(managedMcp?.healthState, "error");
+  assert.equal(managedMcp?.canConnect, true);
+});
+
+test("getOverview marks legacy profile-owned skills as uninstallable profile inventory", async () => {
+  const runtimeStateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-runtime-state-"));
+  const env = {
+    ...process.env,
+    SENSE1_RUNTIME_STATE_ROOT: runtimeStateRoot,
+  };
+  const { codexHome } = await ensureProfileDirectories("default", env);
+  const skillRoot = path.join(codexHome, "skills", "legacy-skill");
+  const skillPath = path.join(skillRoot, "SKILL.md");
+
+  try {
+    await fs.mkdir(skillRoot, { recursive: true });
+    await fs.writeFile(skillPath, "# Legacy skill\n", "utf8");
+
+    const service = new DesktopExtensionService({
+      env,
+      manager: createManager(async (method) => {
+        if (method === "config/read") {
+          return { config: {} };
+        }
+
+        if (method === "plugin/list") {
+          return { marketplaces: [] };
+        }
+
+        if (method === "app/list") {
+          return { data: [] };
+        }
+
+        if (method === "mcpServerStatus/list") {
+          return { data: [] };
+        }
+
+        if (method === "skills/list") {
+          return {
+            data: [
+              {
+                cwd: codexHome,
+                skills: [
+                  {
+                    name: "legacy-skill",
+                    path: skillPath,
+                    description: "Legacy profile skill",
+                    enabled: true,
+                  },
+                ],
+              },
+            ],
+          };
+        }
+
+        if (method === "account/read") {
+          return createAccountReadResult();
+        }
+
+        throw new Error(`Unexpected method: ${method}`);
+      }),
+      openExternal: async () => {},
+      resolveProfile: async () => ({ id: "default" }),
+    });
+
+    const overview = await service.getOverview({ forceRefetch: true });
+    const managedSkill = findManagedExtension(overview, "skill", skillPath);
+    assert.equal(managedSkill?.ownership, "profile-owned");
+    assert.equal(managedSkill?.canUninstall, true);
+    assert.equal(managedSkill?.canOpen, true);
+  } finally {
+    await fs.rm(runtimeStateRoot, { force: true, recursive: true });
+  }
+});
+
+test("getOverview marks manually created profile plugins as uninstallable profile inventory", async () => {
+  const runtimeStateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-runtime-state-"));
+  const env = {
+    ...process.env,
+    SENSE1_RUNTIME_STATE_ROOT: runtimeStateRoot,
+  };
+  const { codexHome } = await ensureProfileDirectories("default", env);
+  const pluginRoot = path.join(codexHome, "plugins", "manual-plugin");
+
+  try {
+    await fs.mkdir(path.join(pluginRoot, ".codex-plugin"), { recursive: true });
+    await fs.writeFile(
+      path.join(pluginRoot, ".codex-plugin", "plugin.json"),
+      JSON.stringify({
+        interface: {
+          displayName: "Manual Plugin",
+          shortDescription: "Manual profile install",
+        },
+      }),
+      "utf8",
+    );
+
+    const service = new DesktopExtensionService({
+      env,
+      manager: createManager(async (method) => {
+        if (method === "config/read") {
+          return {
+            config: {
+              plugins: {
+                "manual-plugin": {
+                  enabled: true,
+                },
+              },
+            },
+          };
+        }
+
+        if (method === "plugin/list") {
+          return {
+            marketplaces: [
+              {
+                name: "Profile plugins",
+                path: path.join(codexHome, ".agents", "plugins", "marketplace.json"),
+                plugins: [
+                  {
+                    id: "manual-plugin",
+                    name: "manual-plugin",
+                    installed: true,
+                    enabled: true,
+                    source: {
+                      path: pluginRoot,
+                    },
+                    interface: {
+                      displayName: "Manual Plugin",
+                      shortDescription: "Manual profile install",
+                    },
+                  },
+                ],
+              },
+            ],
+          };
+        }
+
+        if (method === "app/list") {
+          return { data: [] };
+        }
+
+        if (method === "mcpServerStatus/list") {
+          return { data: [] };
+        }
+
+        if (method === "skills/list") {
+          return { data: [] };
+        }
+
+        if (method === "account/read") {
+          return createAccountReadResult();
+        }
+
+        throw new Error(`Unexpected method: ${method}`);
+      }),
+      openExternal: async () => {},
+      resolveProfile: async () => ({ id: "default" }),
+    });
+
+    const overview = await service.getOverview({ forceRefetch: true });
+    const managedPlugin = findManagedExtension(overview, "plugin", "manual-plugin");
+    assert.equal(managedPlugin?.ownership, "profile-owned");
+    assert.equal(managedPlugin?.canUninstall, true);
+    assert.equal(overview.plugins[0]?.sourcePath, pluginRoot);
+  } finally {
+    await fs.rm(runtimeStateRoot, { force: true, recursive: true });
+  }
+});
+
+test("getOverview ignores stale plugin and app config references without creating ghost inventory", async () => {
+  const service = new DesktopExtensionService({
+    manager: createManager(async (method) => {
+      if (method === "config/read") {
+        return {
+          config: {
+            apps: {
+              ghost_app: {
+                enabled: true,
+              },
+            },
+            plugins: {
+              ghost_plugin: {
+                enabled: true,
+              },
+            },
+          },
+        };
+      }
+
+      if (method === "plugin/list") {
+        return { marketplaces: [] };
+      }
+
+      if (method === "app/list") {
+        return { data: [] };
+      }
+
+      if (method === "mcpServerStatus/list") {
+        return { data: [] };
+      }
+
+      if (method === "skills/list") {
+        return { data: [] };
+      }
+
+      if (method === "account/read") {
+        return createAccountReadResult();
+      }
+
+      throw new Error(`Unexpected method: ${method}`);
+    }),
+    openExternal: async () => {},
+    resolveProfile: async () => ({ id: "default" }),
+  });
+
+  const overview = await service.getOverview({ forceRefetch: true });
+  assert.deepEqual(overview.plugins, []);
+  assert.deepEqual(overview.apps, []);
+  assert.deepEqual(overview.managedExtensions, []);
+});
+
 test("installPlugin enables manifest-backed apps even when plugin/install omits app ids", async () => {
   const pluginRoot = await createInstalledPluginFixture();
   const managerCalls = [];

--- a/desktop/src/main/settings/desktop-extension-service.ts
+++ b/desktop/src/main/settings/desktop-extension-service.ts
@@ -90,6 +90,7 @@ type LocalPluginMetadata = {
 type LocalConfigToggles = {
   readonly apps: Record<string, { enabled?: boolean }>;
   readonly features: Record<string, unknown>;
+  readonly mcp_servers: Record<string, { enabled?: boolean }>;
   readonly plugins: Record<string, { enabled?: boolean }>;
 };
 
@@ -232,10 +233,11 @@ function parseLocalConfigToggles(rawConfig: string): LocalConfigToggles {
   const toggles: LocalConfigToggles = {
     apps: {},
     features: {},
+    mcp_servers: {},
     plugins: {},
   };
 
-  let activeSection: "apps" | "features" | "plugins" | null = null;
+  let activeSection: "apps" | "features" | "mcp_servers" | "plugins" | null = null;
   let activeKey: string | null = null;
 
   for (const rawLine of rawConfig.split(/\r?\n/u)) {
@@ -244,9 +246,9 @@ function parseLocalConfigToggles(rawConfig: string): LocalConfigToggles {
       continue;
     }
 
-    const tableMatch = line.match(/^\[(plugins|apps)\.(?:"([^"]+)"|([A-Za-z0-9._@:-]+))\]$/u);
+    const tableMatch = line.match(/^\[(plugins|apps|mcp_servers)\.(?:"([^"]+)"|([A-Za-z0-9._@:-]+))\]$/u);
     if (tableMatch) {
-      activeSection = tableMatch[1] as "apps" | "plugins";
+      activeSection = tableMatch[1] as "apps" | "mcp_servers" | "plugins";
       activeKey = firstString(tableMatch[2], tableMatch[3]);
       continue;
     }
@@ -258,10 +260,10 @@ function parseLocalConfigToggles(rawConfig: string): LocalConfigToggles {
     }
 
     const dottedEnabledMatch = line.match(
-      /^(plugins|apps)\.(?:"([^"]+)"|([A-Za-z0-9._@:-]+))\.enabled\s*=\s*(true|false)$/iu,
+      /^(plugins|apps|mcp_servers)\.(?:"([^"]+)"|([A-Za-z0-9._@:-]+))\.enabled\s*=\s*(true|false)$/iu,
     );
     if (dottedEnabledMatch) {
-      const section = dottedEnabledMatch[1] as "apps" | "plugins";
+      const section = dottedEnabledMatch[1] as "apps" | "mcp_servers" | "plugins";
       const key = firstString(dottedEnabledMatch[2], dottedEnabledMatch[3]);
       const enabled = parseTomlBooleanToken(dottedEnabledMatch[4]);
       if (key && enabled !== null) {
@@ -322,6 +324,7 @@ async function readLocalConfigToggles(profileCodexHome: string): Promise<LocalCo
     return {
       apps: {},
       features: {},
+      mcp_servers: {},
       plugins: {},
     };
   }
@@ -338,7 +341,7 @@ function mergeConfigWithLocalToggles(
       ...asRecord(config?.features),
       ...localToggles.features,
     },
-    mcp_servers: asRecord(config?.mcp_servers),
+    mcp_servers: mergeToggleSections(asRecord(config?.mcp_servers), localToggles.mcp_servers),
     plugins: mergeToggleSections(asRecord(config?.plugins), localToggles.plugins),
   };
 }


### PR DESCRIPTION
Closes #49

## Summary
This closes the extension lifecycle parity milestone by tightening the remaining backend recovery rules and by documenting the acceptance surface that still requires signed-in Electron verification.

The main logic fix is restart persistence for MCP inventory. Before this change, Sense-1 only trusted the runtime `config/read` payload for MCP enablement. If the app server came back with stale or incomplete MCP config after a restart, the management inventory could show the wrong enabled state even though the profile `config.toml` already held the user's intended toggle. This PR folds `mcp_servers` into the same local-config recovery path already used for apps and plugins.

This PR also hardens migration and failure-recovery coverage around the normalized management contract. It adds tests for legacy profile-owned skills, manually created profile plugins, stale config references that should not reappear as ghost inventory, and recoverable MCP auth failure state. Finally, it adds an explicit acceptance matrix so the remaining manual smoke scenarios are documented rather than implicit.

## User impact
After this lands:
- MCP enable/disable state is preserved more reliably across restart even when runtime config is temporarily stale.
- Legacy profile-owned skills and profile-local plugins remain visible as managed inventory with the right ownership and uninstall affordances.
- Stale config references no longer masquerade as installed plugins or apps.
- The extension lifecycle milestone has a concrete acceptance matrix for the final signed-in Electron parity run.

## Review notes
I ran a code-review pass against `main` before packaging. No new blocking defects were found in the restart-recovery change itself. The only review-driven adjustment was to link the new acceptance matrix from `EXTENSION_LIFECYCLE_CONTRACT.md` so the artifact is discoverable from the main contract doc.

## Validation
- `node --test desktop/src/main/settings/desktop-extension-service.test.js`
- `node scripts/check-public-boundary.mjs`
- `pnpm --dir desktop typecheck`
- `pnpm --dir desktop check:structure`
- `pnpm --dir desktop test:unit`
- `pnpm --dir desktop build`

## Remaining gap
This PR does not replace the final signed-in Electron smoke pass for extension auth handoffs and live marketplace/runtime integration. That gap is now documented explicitly in `EXTENSION_ACCEPTANCE_MATRIX.md`.
