### PR TITLE
Keep Sense-1 extension backend alive when a plugin ships bad MCP config

### DIFF
--- a/desktop/src/main/settings/desktop-extension-service.test.js
+++ b/desktop/src/main/settings/desktop-extension-service.test.js
@@ -2406,6 +2406,7 @@ async function createInstalledPluginFixtureWithInvalidMcp() {
       mcpServers: {
         "cloudflare-api": {
           type: "http",
+          url: "https://example.com/cloudflare-mcp",
         },
         "good-server": {
           url: "https://example.com/mcp",
@@ -2506,7 +2507,7 @@ test("getOverview surfaces invalid plugin MCP entries without dropping valid one
     assert.equal(invalid.length, 1);
     assert.equal(invalid[0].serverId, "cloudflare-api");
     assert.equal(invalid[0].pluginName, "cloudflare");
-    assert.match(invalid[0].reason, /missing both `command`.*`url`/);
+    assert.match(invalid[0].reason, /unsupported transport `http`/);
 
     const managedPlugin = findManagedExtension(overview, "plugin", "cloudflare");
     assert.ok(managedPlugin, "plugin record still present");

--- a/desktop/src/main/settings/desktop-extension-service.test.js
+++ b/desktop/src/main/settings/desktop-extension-service.test.js
@@ -2392,3 +2392,267 @@ test("uninstallSkill also accepts a profile-owned skill root directory", async (
     await fs.rm(runtimeStateRoot, { force: true, recursive: true });
   }
 });
+
+async function createInstalledPluginFixtureWithInvalidMcp() {
+  const pluginRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-plugin-bad-mcp-"));
+  await fs.writeFile(
+    path.join(pluginRoot, ".app.json"),
+    JSON.stringify({ apps: {} }),
+    "utf8",
+  );
+  await fs.writeFile(
+    path.join(pluginRoot, ".mcp.json"),
+    JSON.stringify({
+      mcpServers: {
+        "cloudflare-api": {
+          type: "http",
+        },
+        "good-server": {
+          url: "https://example.com/mcp",
+        },
+      },
+    }),
+    "utf8",
+  );
+  return pluginRoot;
+}
+
+test("getOverview surfaces failed backend reads in health.backend.failedReads without throwing", async () => {
+  const runtimeStateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-runtime-state-"));
+  const env = {
+    ...process.env,
+    SENSE1_RUNTIME_STATE_ROOT: runtimeStateRoot,
+  };
+  try {
+    const service = new DesktopExtensionService({
+      env,
+      manager: createManager(async (method) => {
+        if (method === "app/list") {
+          throw new Error("App Server transport closed before response.");
+        }
+        if (method === "config/read") return { config: {} };
+        if (method === "plugin/list") return { marketplaces: [] };
+        if (method === "mcpServerStatus/list") return { data: [] };
+        if (method === "skills/list") return { data: [] };
+        if (method === "account/read") return createAccountReadResult();
+        throw new Error(`Unexpected method: ${method}`);
+      }),
+      openExternal: async () => {},
+      resolveProfile: async () => ({ id: "default" }),
+    });
+
+    const overview = await service.getOverview({ forceRefetch: true });
+
+    assert.ok(overview.health, "overview should include a health block");
+    assert.equal(overview.health.backend.failedReads.length, 1);
+    assert.equal(overview.health.backend.failedReads[0].method, "app/list");
+    assert.match(
+      overview.health.backend.failedReads[0].message,
+      /App Server transport closed/,
+    );
+    assert.equal(overview.health.backend.lastRuntimeError, null);
+    assert.deepEqual(overview.health.backend.suspectedMcpServerIds, []);
+    assert.deepEqual(overview.apps, []);
+  } finally {
+    await fs.rm(runtimeStateRoot, { force: true, recursive: true });
+  }
+});
+
+test("getOverview surfaces invalid plugin MCP entries without dropping valid ones", async () => {
+  const runtimeStateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-runtime-state-"));
+  const env = {
+    ...process.env,
+    SENSE1_RUNTIME_STATE_ROOT: runtimeStateRoot,
+  };
+  const pluginRoot = await createInstalledPluginFixtureWithInvalidMcp();
+  try {
+    const service = new DesktopExtensionService({
+      env,
+      manager: createManager(async (method) => {
+        if (method === "config/read") return { config: {} };
+        if (method === "plugin/list") {
+          return {
+            marketplaces: [
+              {
+                name: "OpenAI Curated",
+                path: "/tmp/curated.json",
+                plugins: [
+                  {
+                    id: "cloudflare",
+                    name: "cloudflare",
+                    installed: true,
+                    enabled: true,
+                    source: { path: pluginRoot },
+                    interface: { displayName: "Cloudflare" },
+                  },
+                ],
+              },
+            ],
+          };
+        }
+        if (method === "app/list") return { data: [] };
+        if (method === "mcpServerStatus/list") return { data: [] };
+        if (method === "skills/list") return { data: [] };
+        if (method === "account/read") return createAccountReadResult();
+        throw new Error(`Unexpected method: ${method}`);
+      }),
+      openExternal: async () => {},
+      resolveProfile: async () => ({ id: "default" }),
+    });
+
+    const overview = await service.getOverview({ forceRefetch: true });
+
+    const invalid = overview.health.pluginMcp.invalidEntries;
+    assert.equal(invalid.length, 1);
+    assert.equal(invalid[0].serverId, "cloudflare-api");
+    assert.equal(invalid[0].pluginName, "cloudflare");
+    assert.match(invalid[0].reason, /missing both `command`.*`url`/);
+
+    const managedPlugin = findManagedExtension(overview, "plugin", "cloudflare");
+    assert.ok(managedPlugin, "plugin record still present");
+    assert.deepEqual(
+      [...managedPlugin.includedMcpServerIds].sort(),
+      ["cloudflare-api", "good-server"],
+      "plugin still reports both MCP ids it composes, even the invalid one",
+    );
+  } finally {
+    await fs.rm(runtimeStateRoot, { force: true, recursive: true });
+    await fs.rm(pluginRoot, { force: true, recursive: true });
+  }
+});
+
+test("setPluginEnabled returns health with runtime error when restart rejects", async () => {
+  const runtimeStateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-runtime-state-"));
+  const env = {
+    ...process.env,
+    SENSE1_RUNTIME_STATE_ROOT: runtimeStateRoot,
+  };
+  const pluginRoot = await createInstalledPluginFixture();
+  const restartReasons = [];
+  try {
+    const manager = {
+      request: async (method) => {
+        if (method === "config/read") return { config: {} };
+        if (method === "plugin/list") {
+          return {
+            marketplaces: [
+              {
+                name: "OpenAI Curated",
+                path: "/tmp/curated.json",
+                plugins: [
+                  {
+                    id: "gmail",
+                    name: "gmail",
+                    installed: true,
+                    enabled: true,
+                    source: { path: pluginRoot },
+                    interface: { displayName: "Gmail" },
+                  },
+                ],
+              },
+            ],
+          };
+        }
+        if (method === "app/list") return { data: [] };
+        if (method === "mcpServerStatus/list") return { data: [] };
+        if (method === "skills/list") return { data: [] };
+        if (method === "account/read") return createAccountReadResult();
+        if (method === "config/batchWrite") return {};
+        if (method === "config/mcpServer/reload") return {};
+        throw new Error(`Unexpected method: ${method}`);
+      },
+      restart: async (reason) => {
+        restartReasons.push(reason);
+        throw new Error("Invalid configuration: invalid transport in `mcp_servers.cloudflare-api`");
+      },
+    };
+
+    const service = new DesktopExtensionService({
+      env,
+      manager,
+      openExternal: async () => {},
+      resolveProfile: async () => ({ id: "default" }),
+    });
+
+    const overview = await service.setPluginEnabled({ pluginId: "gmail", enabled: true });
+
+    assert.ok(restartReasons.includes("plugin-enabled"), "expected restart attempt");
+    assert.match(
+      overview.health.backend.lastRuntimeError ?? "",
+      /invalid transport in `mcp_servers.cloudflare-api`/,
+    );
+    assert.deepEqual(overview.health.backend.suspectedMcpServerIds, ["cloudflare-api"]);
+  } finally {
+    await fs.rm(runtimeStateRoot, { force: true, recursive: true });
+    await fs.rm(pluginRoot, { force: true, recursive: true });
+  }
+});
+
+test("installPlugin surfaces runtime error in health when restart rejects post-install", async () => {
+  const runtimeStateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-runtime-state-"));
+  const env = {
+    ...process.env,
+    SENSE1_RUNTIME_STATE_ROOT: runtimeStateRoot,
+  };
+  const pluginRoot = await createInstalledPluginFixture();
+  try {
+    const manager = {
+      request: async (method) => {
+        if (method === "plugin/install") return { appsNeedingAuth: [] };
+        if (method === "config/read") return { config: {} };
+        if (method === "plugin/list") {
+          return {
+            marketplaces: [
+              {
+                name: "OpenAI Curated",
+                path: "/tmp/curated.json",
+                plugins: [
+                  {
+                    id: "gmail",
+                    name: "gmail",
+                    installed: true,
+                    enabled: true,
+                    source: { path: pluginRoot },
+                    interface: { displayName: "Gmail" },
+                  },
+                ],
+              },
+            ],
+          };
+        }
+        if (method === "app/list") return { data: [] };
+        if (method === "mcpServerStatus/list") return { data: [] };
+        if (method === "skills/list") return { data: [] };
+        if (method === "account/read") return createAccountReadResult();
+        if (method === "config/batchWrite") return {};
+        if (method === "config/mcpServer/reload") return {};
+        throw new Error(`Unexpected method: ${method}`);
+      },
+      restart: async () => {
+        throw new Error("Invalid configuration: invalid transport in `mcp_servers.cloudflare-api`");
+      },
+    };
+
+    const service = new DesktopExtensionService({
+      env,
+      manager,
+      openExternal: async () => {},
+      resolveProfile: async () => ({ id: "default" }),
+    });
+
+    const overview = await service.installPlugin({
+      marketplacePath: "/tmp/curated.json",
+      pluginId: "gmail",
+      pluginName: "gmail",
+    });
+
+    assert.match(
+      overview.health.backend.lastRuntimeError ?? "",
+      /invalid transport in `mcp_servers.cloudflare-api`/,
+    );
+    assert.deepEqual(overview.health.backend.suspectedMcpServerIds, ["cloudflare-api"]);
+  } finally {
+    await fs.rm(runtimeStateRoot, { force: true, recursive: true });
+    await fs.rm(pluginRoot, { force: true, recursive: true });
+  }
+});

--- a/desktop/src/main/settings/desktop-extension-service.ts
+++ b/desktop/src/main/settings/desktop-extension-service.ts
@@ -9,8 +9,11 @@ import type {
   DesktopAppInstallRequest,
   DesktopAppEnabledRequest,
   DesktopAppRecord,
+  DesktopExtensionBackendFailure,
+  DesktopExtensionHealth,
   DesktopExtensionOverviewRequest,
   DesktopExtensionOverviewResult,
+  DesktopExtensionPluginMcpIssue,
   DesktopManagedExtensionAuthState,
   DesktopManagedExtensionHealthState,
   DesktopManagedExtensionOwnership,
@@ -85,6 +88,7 @@ type LocalPluginMetadata = {
   readonly mcpServerIds: string[];
   readonly sourcePath: string | null;
   readonly skills: DesktopSkillRecord[];
+  readonly invalidMcpEntries: DesktopExtensionPluginMcpIssue[];
 };
 
 type LocalConfigToggles = {
@@ -350,6 +354,39 @@ function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function classifyMcpServerEntry(entry: unknown): { ok: true } | { ok: false; reason: string } {
+  const record = asRecord(entry);
+  if (Object.keys(record).length === 0) {
+    return { ok: false, reason: "Plugin MCP entry is not an object." };
+  }
+  if (firstString(record.command)) {
+    return { ok: true };
+  }
+  if (firstString(record.url)) {
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    reason: "Plugin MCP entry is missing both `command` (stdio) and `url` (remote); codex cannot infer a transport.",
+  };
+}
+
+const MCP_SERVER_ERROR_PATTERN = /mcp_servers[.\[]"?([A-Za-z0-9._@:-]+)"?\]?/gu;
+
+function extractSuspectedMcpServerIds(errorMessage: string | null): string[] {
+  if (!errorMessage) {
+    return [];
+  }
+  const seen = new Set<string>();
+  for (const match of errorMessage.matchAll(MCP_SERVER_ERROR_PATTERN)) {
+    const id = firstString(match[1]);
+    if (id) {
+      seen.add(id);
+    }
+  }
+  return [...seen];
+}
+
 function commandExists(command: string): boolean {
   const result = spawnSync("which", [command], { stdio: "ignore" });
   return result.status === 0;
@@ -596,6 +633,7 @@ async function readPluginLocalMetadata(
       mcpServerIds: [],
       sourcePath: null,
       skills: [],
+      invalidMcpEntries: [],
     };
   }
 
@@ -609,9 +647,22 @@ async function readPluginLocalMetadata(
   } catch {}
 
   let mcpServerIds: string[] = [];
+  const invalidMcpEntries: DesktopExtensionPluginMcpIssue[] = [];
   try {
     const mcpJson = JSON.parse(await fs.readFile(path.join(sourcePath, ".mcp.json"), "utf8")) as { mcpServers?: Record<string, unknown> };
-    mcpServerIds = uniqueStrings(Object.keys(mcpJson?.mcpServers ?? {}));
+    const serverEntries = Object.entries(asRecord(mcpJson?.mcpServers));
+    mcpServerIds = uniqueStrings(serverEntries.map(([id]) => id));
+    for (const [serverId, serverConfig] of serverEntries) {
+      const classification = classifyMcpServerEntry(serverConfig);
+      if (!classification.ok) {
+        invalidMcpEntries.push({
+          pluginName: plugin.name,
+          sourcePath,
+          serverId,
+          reason: classification.reason,
+        });
+      }
+    }
   } catch {}
 
   const skillsRoot = path.join(sourcePath, "skills");
@@ -646,6 +697,7 @@ async function readPluginLocalMetadata(
     mcpServerIds,
     sourcePath,
     skills,
+    invalidMcpEntries,
   };
 }
 
@@ -1198,11 +1250,18 @@ export class DesktopExtensionService {
     this.#resolveProfile = options.resolveProfile;
   }
 
-  async #requestOrFallback<T>(method: string, params: unknown, fallback: T): Promise<T> {
+  async #requestOrFallback<T>(
+    method: string,
+    params: unknown,
+    fallback: T,
+    failures?: DesktopExtensionBackendFailure[],
+  ): Promise<T> {
     try {
       return await this.#manager.request(method, params) as T;
     } catch (error) {
-      console.warn(`[desktop:extensions] ${method} failed; continuing with fallback. ${formatError(error)}`);
+      const message = formatError(error);
+      console.warn(`[desktop:extensions] ${method} failed; continuing with fallback. ${message}`);
+      failures?.push({ method, message });
       return fallback;
     }
   }
@@ -1226,31 +1285,62 @@ export class DesktopExtensionService {
     await manager.restart(reason);
   }
 
+  async #safeRuntimeRefresh(
+    reason: string,
+    opts: { reloadMcpServers: boolean },
+  ): Promise<string | null> {
+    try {
+      await this.#restartRuntimeIfSupported(reason);
+    } catch (error) {
+      const message = formatError(error);
+      console.warn(`[desktop:extensions] runtime refresh for "${reason}" failed. ${message}`);
+      return message;
+    }
+    if (opts.reloadMcpServers) {
+      try {
+        await this.#manager.request("config/mcpServer/reload", {});
+      } catch (error) {
+        const message = formatError(error);
+        console.warn(`[desktop:extensions] config/mcpServer/reload for "${reason}" failed. ${message}`);
+        return message;
+      }
+    }
+    return null;
+  }
+
   async getOverview(
     request: DesktopExtensionOverviewRequest = {},
   ): Promise<DesktopExtensionOverviewResult> {
+    return this.#buildOverview(request, null);
+  }
+
+  async #buildOverview(
+    request: DesktopExtensionOverviewRequest,
+    runtimeError: string | null,
+  ): Promise<DesktopExtensionOverviewResult> {
     const profile = await this.#resolveProfile();
     const profileCodexHome = resolveProfileCodexHome(profile.id, this.#env);
+    const failedReads: DesktopExtensionBackendFailure[] = [];
     const [configResult, pluginResult, appResult, mcpResult, skillResult, accountResult] = await Promise.all([
-      this.#requestOrFallback<ConfigReadResult>("config/read", { includeLayers: false }, { config: null }),
+      this.#requestOrFallback<ConfigReadResult>("config/read", { includeLayers: false }, { config: null }, failedReads),
       this.#requestOrFallback<unknown>("plugin/list", {
         cwds: [profileCodexHome],
         forceRemoteSync: Boolean(request.forceRefetch),
-      }, { marketplaces: [] }),
+      }, { marketplaces: [] }, failedReads),
       this.#requestOrFallback<unknown>("app/list", {
         cursor: null,
         forceRefetch: Boolean(request.forceRefetch),
         limit: 100,
-      }, { data: [] }),
+      }, { data: [] }, failedReads),
       this.#requestOrFallback<unknown>("mcpServerStatus/list", {
         cursor: null,
         limit: 100,
-      }, { data: [] }),
+      }, { data: [] }, failedReads),
       this.#requestOrFallback<unknown>("skills/list", {
         cwds: [profileCodexHome],
         forceReload: Boolean(request.forceRefetch),
-      }, { data: [] }),
-      this.#requestOrFallback<AccountReadResult>("account/read", { refreshToken: false }, {}),
+      }, { data: [] }, failedReads),
+      this.#requestOrFallback<AccountReadResult>("account/read", { refreshToken: false }, {}, failedReads),
     ]);
 
     const localConfigToggles = await readLocalConfigToggles(profileCodexHome);
@@ -1299,6 +1389,22 @@ export class DesktopExtensionService {
       metadataByPluginId,
     });
 
+    const invalidMcpEntries: DesktopExtensionPluginMcpIssue[] = [];
+    for (const metadata of metadataByPluginId.values()) {
+      invalidMcpEntries.push(...metadata.invalidMcpEntries);
+    }
+
+    const health: DesktopExtensionHealth = {
+      backend: {
+        failedReads,
+        lastRuntimeError: runtimeError,
+        suspectedMcpServerIds: extractSuspectedMcpServerIds(runtimeError),
+      },
+      pluginMcp: {
+        invalidEntries: invalidMcpEntries,
+      },
+    };
+
     return {
       contractVersion: 1,
       provider,
@@ -1307,6 +1413,7 @@ export class DesktopExtensionService {
       apps,
       mcpServers,
       skills,
+      health,
     };
   }
 
@@ -1438,12 +1545,11 @@ export class DesktopExtensionService {
     await this.#manager.request("config/batchWrite", {
       edits: batchEdits,
     });
-    await this.#restartRuntimeIfSupported("plugin-install");
-    if (mcpServerIdsToEnable.size > 0) {
-      await this.#manager.request("config/mcpServer/reload", {});
-    }
+    const runtimeError = await this.#safeRuntimeRefresh("plugin-install", {
+      reloadMcpServers: mcpServerIdsToEnable.size > 0,
+    });
 
-    const finalOverview = await this.getOverview({ forceRefetch: true });
+    const finalOverview = await this.#buildOverview({ forceRefetch: true }, runtimeError);
     if (authUrls.size === 0 && appIdsToEnable.size > 0) {
       for (const app of finalOverview.apps) {
         if (!appIdsToEnable.has(app.id)) {
@@ -1517,11 +1623,10 @@ export class DesktopExtensionService {
         ),
       ],
     });
-    if ((managedPlugin?.includedMcpServerIds.length ?? 0) > 0) {
-      await this.#manager.request("config/mcpServer/reload", {});
-    }
-    await this.#restartRuntimeIfSupported("plugin-uninstall");
-    return await this.getOverview({ forceRefetch: true });
+    const runtimeError = await this.#safeRuntimeRefresh("plugin-uninstall", {
+      reloadMcpServers: (managedPlugin?.includedMcpServerIds.length ?? 0) > 0,
+    });
+    return await this.#buildOverview({ forceRefetch: true }, runtimeError);
   }
 
   async setPluginEnabled(request: DesktopPluginEnabledRequest): Promise<DesktopExtensionOverviewResult> {
@@ -1577,11 +1682,10 @@ export class DesktopExtensionService {
     await this.#manager.request("config/batchWrite", {
       edits,
     });
-    if (includedMcpServerIds.length > 0) {
-      await this.#manager.request("config/mcpServer/reload", {});
-    }
-    await this.#restartRuntimeIfSupported("plugin-enabled");
-    return await this.getOverview({ forceRefetch: true });
+    const runtimeError = await this.#safeRuntimeRefresh("plugin-enabled", {
+      reloadMcpServers: includedMcpServerIds.length > 0,
+    });
+    return await this.#buildOverview({ forceRefetch: true }, runtimeError);
   }
 
   async openAppInstall(request: DesktopAppInstallRequest): Promise<DesktopExtensionOverviewResult> {
@@ -1599,9 +1703,9 @@ export class DesktopExtensionService {
         },
       ],
     });
-    await this.#restartRuntimeIfSupported("app-install");
+    const runtimeError = await this.#safeRuntimeRefresh("app-install", { reloadMcpServers: false });
     await this.#openManagedAuth(request.installUrl);
-    return await this.getOverview({ forceRefetch: true });
+    return await this.#buildOverview({ forceRefetch: true }, runtimeError);
   }
 
   async removeApp(request: DesktopAppRemoveRequest): Promise<DesktopExtensionOverviewResult> {
@@ -1614,8 +1718,8 @@ export class DesktopExtensionService {
         },
       ],
     });
-    await this.#restartRuntimeIfSupported("app-remove");
-    return await this.getOverview({ forceRefetch: true });
+    const runtimeError = await this.#safeRuntimeRefresh("app-remove", { reloadMcpServers: false });
+    return await this.#buildOverview({ forceRefetch: true }, runtimeError);
   }
 
   async setAppEnabled(request: DesktopAppEnabledRequest): Promise<DesktopExtensionOverviewResult> {
@@ -1633,8 +1737,8 @@ export class DesktopExtensionService {
         },
       ],
     });
-    await this.#restartRuntimeIfSupported("app-enabled");
-    return await this.getOverview({ forceRefetch: true });
+    const runtimeError = await this.#safeRuntimeRefresh("app-enabled", { reloadMcpServers: false });
+    return await this.#buildOverview({ forceRefetch: true }, runtimeError);
   }
 
   async startMcpServerAuth(request: DesktopMcpServerAuthRequest): Promise<DesktopMcpServerAuthResult> {
@@ -1660,8 +1764,14 @@ export class DesktopExtensionService {
       mergeStrategy: "upsert",
       value: request.enabled,
     });
-    await this.#manager.request("config/mcpServer/reload", {});
-    return await this.getOverview({ forceRefetch: true });
+    let runtimeError: string | null = null;
+    try {
+      await this.#manager.request("config/mcpServer/reload", {});
+    } catch (error) {
+      runtimeError = formatError(error);
+      console.warn(`[desktop:extensions] config/mcpServer/reload for "mcp-enabled" failed. ${runtimeError}`);
+    }
+    return await this.#buildOverview({ forceRefetch: true }, runtimeError);
   }
 
   async readSkillDetail(request: DesktopSkillDetailRequest): Promise<DesktopSkillDetailResult> {
@@ -1707,7 +1817,7 @@ export class DesktopExtensionService {
     }
 
     await fs.rm(skillDirectory, { force: true, recursive: true });
-    await this.#restartRuntimeIfSupported("skill-uninstall");
-    return await this.getOverview({ forceRefetch: true });
+    const runtimeError = await this.#safeRuntimeRefresh("skill-uninstall", { reloadMcpServers: false });
+    return await this.#buildOverview({ forceRefetch: true }, runtimeError);
   }
 }

--- a/desktop/src/main/settings/desktop-extension-service.ts
+++ b/desktop/src/main/settings/desktop-extension-service.ts
@@ -354,15 +354,48 @@ function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+const MCP_STDIO_TRANSPORTS = new Set(["stdio"]);
+const MCP_REMOTE_TRANSPORTS = new Set(["sse", "streamable_http", "streamable-http"]);
+
 function classifyMcpServerEntry(entry: unknown): { ok: true } | { ok: false; reason: string } {
   const record = asRecord(entry);
   if (Object.keys(record).length === 0) {
     return { ok: false, reason: "Plugin MCP entry is not an object." };
   }
-  if (firstString(record.command)) {
+  const command = firstString(record.command);
+  const url = firstString(record.url);
+  const declaredType = firstString(record.type, record.transport);
+  const declaredTypeLower = declaredType ? declaredType.toLowerCase() : null;
+
+  if (declaredTypeLower) {
+    if (MCP_STDIO_TRANSPORTS.has(declaredTypeLower)) {
+      if (!command) {
+        return {
+          ok: false,
+          reason: `Plugin MCP entry declares transport \`${declaredType}\` but is missing \`command\`.`,
+        };
+      }
+      return { ok: true };
+    }
+    if (MCP_REMOTE_TRANSPORTS.has(declaredTypeLower)) {
+      if (!url) {
+        return {
+          ok: false,
+          reason: `Plugin MCP entry declares transport \`${declaredType}\` but is missing \`url\`.`,
+        };
+      }
+      return { ok: true };
+    }
+    return {
+      ok: false,
+      reason: `Plugin MCP entry declares unsupported transport \`${declaredType}\`; codex accepts \`stdio\`, \`sse\`, or \`streamable_http\`.`,
+    };
+  }
+
+  if (command) {
     return { ok: true };
   }
-  if (firstString(record.url)) {
+  if (url) {
     return { ok: true };
   }
   return {

--- a/desktop/src/shared/contracts/management.ts
+++ b/desktop/src/shared/contracts/management.ts
@@ -107,6 +107,29 @@ export interface DesktopExtensionOverviewRequest {
   readonly forceRefetch?: boolean;
 }
 
+export interface DesktopExtensionBackendFailure {
+  readonly method: string;
+  readonly message: string;
+}
+
+export interface DesktopExtensionPluginMcpIssue {
+  readonly pluginName: string | null;
+  readonly sourcePath: string | null;
+  readonly serverId: string;
+  readonly reason: string;
+}
+
+export interface DesktopExtensionHealth {
+  readonly backend: {
+    readonly failedReads: DesktopExtensionBackendFailure[];
+    readonly lastRuntimeError: string | null;
+    readonly suspectedMcpServerIds: string[];
+  };
+  readonly pluginMcp: {
+    readonly invalidEntries: DesktopExtensionPluginMcpIssue[];
+  };
+}
+
 export interface DesktopExtensionOverviewResult {
   readonly contractVersion: 1;
   readonly provider: DesktopProviderState;
@@ -115,6 +138,7 @@ export interface DesktopExtensionOverviewResult {
   readonly apps: DesktopAppRecord[];
   readonly mcpServers: DesktopMcpServerRecord[];
   readonly skills: DesktopSkillRecord[];
+  readonly health: DesktopExtensionHealth;
 }
 
 export interface DesktopPluginEnabledRequest {


### PR DESCRIPTION
## Summary

- Adds an additive `health` block to `DesktopExtensionOverviewResult` carrying failed backend reads, last runtime-restart error, suspected MCP server ids, and malformed plugin `.mcp.json` entries.
- New `#safeRuntimeRefresh` wraps `#restartRuntimeIfSupported` + `config/mcpServer/reload` in every mutation path — a failing codex restart no longer throws out to the IPC handler, so one bad plugin no longer crashes `installPlugin`, `setPluginEnabled`, `uninstallPlugin`, app toggles, skill uninstall, or mcp toggles.
- Plugin `.mcp.json` entries missing both `command` and `url` are classified and reported via `health.pluginMcp.invalidEntries` while still appearing in the managed graph.
- `#requestOrFallback` now collects each failed read into `health.backend.failedReads` instead of silently returning empty — renderer can distinguish "nothing installed" from "backend refused to answer".

## Context

One stale Cloudflare plugin clone under `.../codex-home/.tmp/plugins/plugins/cloudflare/.mcp.json` was shipping `{ "type": "http", "url": ... }`, which the codex app-server rejected as `invalid transport in \`mcp_servers.cloudflare-api\``. Result: `app/list` / `mcpServerStatus/list` collapsed into empty fallbacks (Extensions page looked dead) and every mutation path threw the codex error up to the renderer.

This PR is **Pass 1 (resilience)** of a planned four-pass fix:
1. **Resilience** — this PR.
2. **Protocol** — kill the `connectors://` `ERR_UNKNOWN_URL_SCHEME` noise.
3. **Lifecycle** — wire the remaining detail-view actions and keep app auth inside Sense-1.
4. **Signed-in smoke** — one regression gate exercising plugin/app/MCP/skill lifecycle with restart persistence.

Still to come in Pass 1 follow-ups: disk-level quarantine of invalid plugin MCP entries and a renderer banner that surfaces `overview.health`. This PR is intentionally backend-only and additive so it can land fast.

## Test plan

- [x] `node --test src/main/settings/desktop-extension-service.test.js` — 26/26 pass (22 existing + 4 new).
- [x] `pnpm test:main` — 462/462 pass, no regressions.
- [x] `pnpm typecheck` — clean.
- [ ] Manual signed-in Electron pass: Extensions page populates with real plugins/apps/MCPs (not empty fallbacks), no `invalid transport in mcp_servers.*` on startup, enable/disable a plugin still returns an overview even if codex is unhappy.