### PR TITLE
Quarantine invalid plugin MCP entries + surface extension health in UI

### DIFF
--- a/desktop/src/main/settings/desktop-extension-service.test.js
+++ b/desktop/src/main/settings/desktop-extension-service.test.js
@@ -2512,8 +2512,8 @@ test("getOverview surfaces invalid plugin MCP entries without dropping valid one
     assert.ok(managedPlugin, "plugin record still present");
     assert.deepEqual(
       [...managedPlugin.includedMcpServerIds].sort(),
-      ["cloudflare-api", "good-server"],
-      "plugin still reports both MCP ids it composes, even the invalid one",
+      ["good-server"],
+      "invalid MCP entry is quarantined off the composed list; valid entry survives",
     );
   } finally {
     await fs.rm(runtimeStateRoot, { force: true, recursive: true });

--- a/desktop/src/main/settings/desktop-extension-service.ts
+++ b/desktop/src/main/settings/desktop-extension-service.ts
@@ -4,6 +4,10 @@ import { spawnSync } from "node:child_process";
 
 import type { AppServerProcessManager } from "../runtime/app-server-process-manager.js";
 import { resolveProfileCodexHome } from "../profile/profile-state.js";
+import {
+  quarantineInvalidPluginMcpEntries,
+  readQuarantinedPluginMcpEntries,
+} from "./plugin-mcp-quarantine.ts";
 import type {
   DesktopAppRemoveRequest,
   DesktopAppInstallRequest,
@@ -1321,6 +1325,12 @@ export class DesktopExtensionService {
     const profile = await this.#resolveProfile();
     const profileCodexHome = resolveProfileCodexHome(profile.id, this.#env);
     const failedReads: DesktopExtensionBackendFailure[] = [];
+
+    try {
+      await quarantineInvalidPluginMcpEntries(profileCodexHome);
+    } catch (error) {
+      console.warn(`[desktop:extensions] plugin MCP quarantine (canonical sweep) failed. ${formatError(error)}`);
+    }
     const [configResult, pluginResult, appResult, mcpResult, skillResult, accountResult] = await Promise.all([
       this.#requestOrFallback<ConfigReadResult>("config/read", { includeLayers: false }, { config: null }, failedReads),
       this.#requestOrFallback<unknown>("plugin/list", {
@@ -1365,10 +1375,16 @@ export class DesktopExtensionService {
       }),
     };
 
-    const enriched = await enrichPluginsWithLocalMetadata(
-      normalizePlugins(pluginResult, asRecord(config?.plugins)),
-      profileCodexHome,
-    );
+    const normalizedPlugins = normalizePlugins(pluginResult, asRecord(config?.plugins));
+    const pluginSourcePaths = uniqueStrings(normalizedPlugins.map((plugin) => plugin.sourcePath));
+    if (pluginSourcePaths.length > 0) {
+      try {
+        await quarantineInvalidPluginMcpEntries(profileCodexHome, pluginSourcePaths);
+      } catch (error) {
+        console.warn(`[desktop:extensions] plugin MCP quarantine (per-plugin sweep) failed. ${formatError(error)}`);
+      }
+    }
+    const enriched = await enrichPluginsWithLocalMetadata(normalizedPlugins, profileCodexHome);
     const plugins = await resolvePluginIcons(enriched.plugins);
     const metadataByPluginId = enriched.metadataByPluginId;
     const apps = backfillAppPluginDisplayNames(
@@ -1390,8 +1406,35 @@ export class DesktopExtensionService {
     });
 
     const invalidMcpEntries: DesktopExtensionPluginMcpIssue[] = [];
+    const seenInvalidKeys = new Set<string>();
+    const addInvalidEntry = (entry: DesktopExtensionPluginMcpIssue) => {
+      const key = `${entry.sourcePath ?? ""}\u0000${entry.serverId}`;
+      if (seenInvalidKeys.has(key)) {
+        return;
+      }
+      seenInvalidKeys.add(key);
+      invalidMcpEntries.push(entry);
+    };
+    const pluginNameBySourcePath = new Map<string, string>();
+    for (const plugin of normalizedPlugins) {
+      const resolved = plugin.sourcePath ? path.resolve(plugin.sourcePath) : null;
+      if (resolved) {
+        pluginNameBySourcePath.set(resolved, plugin.name);
+      }
+    }
+    try {
+      for (const entry of await readQuarantinedPluginMcpEntries(profileCodexHome, pluginSourcePaths)) {
+        const resolved = entry.sourcePath ? path.resolve(entry.sourcePath) : null;
+        const friendlyName = resolved ? pluginNameBySourcePath.get(resolved) ?? null : null;
+        addInvalidEntry(friendlyName ? { ...entry, pluginName: friendlyName } : entry);
+      }
+    } catch (error) {
+      console.warn(`[desktop:extensions] reading quarantine manifests failed. ${formatError(error)}`);
+    }
     for (const metadata of metadataByPluginId.values()) {
-      invalidMcpEntries.push(...metadata.invalidMcpEntries);
+      for (const entry of metadata.invalidMcpEntries) {
+        addInvalidEntry(entry);
+      }
     }
 
     const health: DesktopExtensionHealth = {

--- a/desktop/src/main/settings/plugin-mcp-quarantine.test.js
+++ b/desktop/src/main/settings/plugin-mcp-quarantine.test.js
@@ -1,0 +1,163 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  classifyPluginMcpEntry,
+  quarantineInvalidPluginMcpEntries,
+  readQuarantinedPluginMcpEntries,
+} from "./plugin-mcp-quarantine.ts";
+
+async function makeProfile() {
+  const codexHome = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-quarantine-"));
+  const clonesRoot = path.join(codexHome, ".tmp", "plugins", "plugins");
+  await fs.mkdir(clonesRoot, { recursive: true });
+  return { codexHome, clonesRoot };
+}
+
+async function writePluginMcp(clonesRoot, pluginName, contents) {
+  const sourcePath = path.join(clonesRoot, pluginName);
+  await fs.mkdir(sourcePath, { recursive: true });
+  const mcpJsonPath = path.join(sourcePath, ".mcp.json");
+  await fs.writeFile(mcpJsonPath, JSON.stringify(contents, null, 2), "utf8");
+  return { sourcePath, mcpJsonPath };
+}
+
+test("classifyPluginMcpEntry accepts stdio command entries and rejects transportless ones", () => {
+  assert.equal(classifyPluginMcpEntry({ command: "node", args: ["server.js"] }).ok, true);
+  assert.equal(classifyPluginMcpEntry({ url: "https://example.com/mcp" }).ok, true);
+  assert.equal(classifyPluginMcpEntry({ type: "http" }).ok, false);
+  assert.equal(classifyPluginMcpEntry({}).ok, false);
+  assert.equal(classifyPluginMcpEntry(null).ok, false);
+});
+
+test("quarantine leaves plugins with only valid entries untouched", async () => {
+  const { codexHome, clonesRoot } = await makeProfile();
+  try {
+    const { mcpJsonPath } = await writePluginMcp(clonesRoot, "gmail", {
+      mcpServers: {
+        "gmail-mcp": { url: "https://example.com/mcp" },
+      },
+    });
+
+    const summary = await quarantineInvalidPluginMcpEntries(codexHome);
+    assert.equal(summary.scannedFiles, 1);
+    assert.equal(summary.rewrittenFiles, 0);
+    assert.deepEqual(summary.removedEntries, []);
+
+    const onDisk = JSON.parse(await fs.readFile(mcpJsonPath, "utf8"));
+    assert.deepEqual(onDisk.mcpServers, {
+      "gmail-mcp": { url: "https://example.com/mcp" },
+    });
+
+    const manifestPath = path.join(path.dirname(mcpJsonPath), ".mcp.json.quarantine-manifest.json");
+    await assert.rejects(fs.access(manifestPath), "no manifest created when nothing quarantined");
+  } finally {
+    await fs.rm(codexHome, { force: true, recursive: true });
+  }
+});
+
+test("quarantine strips invalid entries, preserves valid ones, and records a manifest", async () => {
+  const { codexHome, clonesRoot } = await makeProfile();
+  try {
+    const { sourcePath, mcpJsonPath } = await writePluginMcp(clonesRoot, "cloudflare", {
+      mcpServers: {
+        "cloudflare-api": { type: "http" },
+        "good-server": { url: "https://example.com/mcp" },
+      },
+    });
+
+    const summary = await quarantineInvalidPluginMcpEntries(codexHome);
+    assert.equal(summary.scannedFiles, 1);
+    assert.equal(summary.rewrittenFiles, 1);
+    assert.equal(summary.removedEntries.length, 1);
+    assert.equal(summary.removedEntries[0].serverId, "cloudflare-api");
+    assert.equal(summary.removedEntries[0].pluginName, "cloudflare");
+    assert.equal(summary.removedEntries[0].sourcePath, sourcePath);
+
+    const onDisk = JSON.parse(await fs.readFile(mcpJsonPath, "utf8"));
+    assert.deepEqual(onDisk.mcpServers, {
+      "good-server": { url: "https://example.com/mcp" },
+    });
+
+    const manifest = JSON.parse(await fs.readFile(path.join(sourcePath, ".mcp.json.quarantine-manifest.json"), "utf8"));
+    assert.equal(manifest.entries.length, 1);
+    assert.equal(manifest.entries[0].serverId, "cloudflare-api");
+    assert.deepEqual(manifest.entries[0].originalValue, { type: "http" });
+    assert.ok(manifest.entries[0].removedAt);
+  } finally {
+    await fs.rm(codexHome, { force: true, recursive: true });
+  }
+});
+
+test("quarantine is idempotent across repeated runs", async () => {
+  const { codexHome, clonesRoot } = await makeProfile();
+  try {
+    const { sourcePath } = await writePluginMcp(clonesRoot, "cloudflare", {
+      mcpServers: {
+        "cloudflare-api": { type: "http" },
+        "good-server": { url: "https://example.com/mcp" },
+      },
+    });
+
+    const first = await quarantineInvalidPluginMcpEntries(codexHome);
+    assert.equal(first.rewrittenFiles, 1);
+
+    const second = await quarantineInvalidPluginMcpEntries(codexHome);
+    assert.equal(second.rewrittenFiles, 0);
+    assert.deepEqual(second.removedEntries, []);
+
+    const manifest = JSON.parse(await fs.readFile(path.join(sourcePath, ".mcp.json.quarantine-manifest.json"), "utf8"));
+    assert.equal(manifest.entries.length, 1);
+  } finally {
+    await fs.rm(codexHome, { force: true, recursive: true });
+  }
+});
+
+test("readQuarantinedPluginMcpEntries reports past quarantined entries", async () => {
+  const { codexHome, clonesRoot } = await makeProfile();
+  try {
+    await writePluginMcp(clonesRoot, "cloudflare", {
+      mcpServers: {
+        "cloudflare-api": { type: "http" },
+      },
+    });
+
+    await quarantineInvalidPluginMcpEntries(codexHome);
+    const issues = await readQuarantinedPluginMcpEntries(codexHome);
+    assert.equal(issues.length, 1);
+    assert.equal(issues[0].serverId, "cloudflare-api");
+    assert.equal(issues[0].pluginName, "cloudflare");
+  } finally {
+    await fs.rm(codexHome, { force: true, recursive: true });
+  }
+});
+
+test("quarantine tolerates a missing clones directory", async () => {
+  const codexHome = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-quarantine-empty-"));
+  try {
+    const summary = await quarantineInvalidPluginMcpEntries(codexHome);
+    assert.equal(summary.scannedFiles, 0);
+    assert.equal(summary.rewrittenFiles, 0);
+    assert.deepEqual(summary.removedEntries, []);
+  } finally {
+    await fs.rm(codexHome, { force: true, recursive: true });
+  }
+});
+
+test("quarantine tolerates unparseable .mcp.json files without throwing", async () => {
+  const { codexHome, clonesRoot } = await makeProfile();
+  try {
+    const pluginDir = path.join(clonesRoot, "broken");
+    await fs.mkdir(pluginDir, { recursive: true });
+    await fs.writeFile(path.join(pluginDir, ".mcp.json"), "{ not-json", "utf8");
+
+    const summary = await quarantineInvalidPluginMcpEntries(codexHome);
+    assert.equal(summary.scannedFiles, 1);
+    assert.equal(summary.rewrittenFiles, 0);
+  } finally {
+    await fs.rm(codexHome, { force: true, recursive: true });
+  }
+});

--- a/desktop/src/main/settings/plugin-mcp-quarantine.ts
+++ b/desktop/src/main/settings/plugin-mcp-quarantine.ts
@@ -1,0 +1,245 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import type { DesktopExtensionPluginMcpIssue } from "../contracts";
+
+const PLUGIN_CLONE_ROOT_SEGMENTS = [".tmp", "plugins", "plugins"] as const;
+const MANIFEST_FILENAME = ".mcp.json.quarantine-manifest.json";
+
+export type QuarantineSummary = {
+  readonly scannedFiles: number;
+  readonly rewrittenFiles: number;
+  readonly removedEntries: DesktopExtensionPluginMcpIssue[];
+};
+
+type ClassifyResult = { ok: true } | { ok: false; reason: string };
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function classifyPluginMcpEntry(entry: unknown): ClassifyResult {
+  const record = asRecord(entry);
+  if (Object.keys(record).length === 0) {
+    return { ok: false, reason: "Plugin MCP entry is not an object." };
+  }
+  if (nonEmptyString(record.command)) {
+    return { ok: true };
+  }
+  if (nonEmptyString(record.url)) {
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    reason: "Plugin MCP entry is missing both `command` (stdio) and `url` (remote); codex cannot infer a transport.",
+  };
+}
+
+function pluginCloneRoot(profileCodexHome: string): string {
+  return path.join(profileCodexHome, ...PLUGIN_CLONE_ROOT_SEGMENTS);
+}
+
+async function listPluginCloneMcpFiles(
+  profileCodexHome: string,
+  extraSourcePaths: readonly string[] = [],
+): Promise<Array<{ pluginName: string; mcpJsonPath: string; sourcePath: string }>> {
+  const root = pluginCloneRoot(profileCodexHome);
+  const candidates: Array<{ pluginName: string; sourcePath: string }> = [];
+
+  try {
+    const entries = await fs.readdir(root, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      candidates.push({ pluginName: entry.name, sourcePath: path.join(root, entry.name) });
+    }
+  } catch {}
+
+  for (const extra of extraSourcePaths) {
+    if (!extra) {
+      continue;
+    }
+    const resolved = path.resolve(extra);
+    candidates.push({ pluginName: path.basename(resolved), sourcePath: resolved });
+  }
+
+  const seenSourcePaths = new Set<string>();
+  const results: Array<{ pluginName: string; mcpJsonPath: string; sourcePath: string }> = [];
+  for (const candidate of candidates) {
+    const resolved = path.resolve(candidate.sourcePath);
+    if (seenSourcePaths.has(resolved)) {
+      continue;
+    }
+    seenSourcePaths.add(resolved);
+
+    const mcpJsonPath = path.join(resolved, ".mcp.json");
+    try {
+      await fs.access(mcpJsonPath);
+    } catch {
+      continue;
+    }
+    results.push({ pluginName: candidate.pluginName, mcpJsonPath, sourcePath: resolved });
+  }
+  return results;
+}
+
+type ManifestRecord = {
+  readonly serverId: string;
+  readonly reason: string;
+  readonly removedAt: string;
+  readonly originalValue: unknown;
+};
+
+type ManifestFile = {
+  readonly entries: ManifestRecord[];
+};
+
+function sanitizeManifest(raw: unknown): ManifestFile {
+  const record = asRecord(raw);
+  const entries = Array.isArray(record.entries) ? record.entries : [];
+  const sanitized: ManifestRecord[] = [];
+  for (const item of entries) {
+    const entry = asRecord(item);
+    const serverId = nonEmptyString(entry.serverId);
+    const reason = nonEmptyString(entry.reason);
+    const removedAt = nonEmptyString(entry.removedAt);
+    if (!serverId || !reason || !removedAt) {
+      continue;
+    }
+    sanitized.push({
+      serverId,
+      reason,
+      removedAt,
+      originalValue: entry.originalValue ?? null,
+    });
+  }
+  return { entries: sanitized };
+}
+
+async function readManifest(manifestPath: string): Promise<ManifestFile> {
+  try {
+    const raw = await fs.readFile(manifestPath, "utf8");
+    return sanitizeManifest(JSON.parse(raw));
+  } catch {
+    return { entries: [] };
+  }
+}
+
+function mergeManifest(existing: ManifestFile, additions: ManifestRecord[]): ManifestFile {
+  const byServerId = new Map<string, ManifestRecord>();
+  for (const entry of existing.entries) {
+    byServerId.set(entry.serverId, entry);
+  }
+  for (const addition of additions) {
+    byServerId.set(addition.serverId, addition);
+  }
+  return { entries: [...byServerId.values()] };
+}
+
+async function writeAtomic(targetPath: string, contents: string): Promise<void> {
+  const tempPath = `${targetPath}.quarantine-tmp-${process.pid}-${Date.now()}`;
+  await fs.writeFile(tempPath, contents, "utf8");
+  await fs.rename(tempPath, targetPath);
+}
+
+export async function readQuarantinedPluginMcpEntries(
+  profileCodexHome: string,
+  extraSourcePaths: readonly string[] = [],
+): Promise<DesktopExtensionPluginMcpIssue[]> {
+  const issues: DesktopExtensionPluginMcpIssue[] = [];
+  const clones = await listPluginCloneMcpFiles(profileCodexHome, extraSourcePaths);
+  for (const clone of clones) {
+    const manifestPath = path.join(clone.sourcePath, MANIFEST_FILENAME);
+    const manifest = await readManifest(manifestPath);
+    for (const entry of manifest.entries) {
+      issues.push({
+        pluginName: clone.pluginName,
+        sourcePath: clone.sourcePath,
+        serverId: entry.serverId,
+        reason: entry.reason,
+      });
+    }
+  }
+  return issues;
+}
+
+export async function quarantineInvalidPluginMcpEntries(
+  profileCodexHome: string,
+  extraSourcePaths: readonly string[] = [],
+): Promise<QuarantineSummary> {
+  const clones = await listPluginCloneMcpFiles(profileCodexHome, extraSourcePaths);
+  const removedEntries: DesktopExtensionPluginMcpIssue[] = [];
+  let scannedFiles = 0;
+  let rewrittenFiles = 0;
+
+  for (const clone of clones) {
+    scannedFiles += 1;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await fs.readFile(clone.mcpJsonPath, "utf8"));
+    } catch {
+      continue;
+    }
+
+    const root = asRecord(parsed);
+    const mcpServers = asRecord(root.mcpServers);
+    const serverIds = Object.keys(mcpServers);
+    if (serverIds.length === 0) {
+      continue;
+    }
+
+    const surviving: Record<string, unknown> = {};
+    const removals: ManifestRecord[] = [];
+    const nowIso = new Date().toISOString();
+
+    for (const serverId of serverIds) {
+      const value = mcpServers[serverId];
+      const classification = classifyPluginMcpEntry(value);
+      if (classification.ok) {
+        surviving[serverId] = value;
+        continue;
+      }
+      removals.push({
+        serverId,
+        reason: classification.reason,
+        removedAt: nowIso,
+        originalValue: value ?? null,
+      });
+      removedEntries.push({
+        pluginName: clone.pluginName,
+        sourcePath: clone.sourcePath,
+        serverId,
+        reason: classification.reason,
+      });
+    }
+
+    if (removals.length === 0) {
+      continue;
+    }
+
+    const nextFile = {
+      ...root,
+      mcpServers: surviving,
+    };
+    await writeAtomic(clone.mcpJsonPath, `${JSON.stringify(nextFile, null, 2)}\n`);
+
+    const manifestPath = path.join(clone.sourcePath, MANIFEST_FILENAME);
+    const existingManifest = await readManifest(manifestPath);
+    const mergedManifest = mergeManifest(existingManifest, removals);
+    await writeAtomic(manifestPath, `${JSON.stringify(mergedManifest, null, 2)}\n`);
+    rewrittenFiles += 1;
+  }
+
+  return { scannedFiles, rewrittenFiles, removedEntries };
+}

--- a/desktop/src/renderer/components/PluginsPage.tsx
+++ b/desktop/src/renderer/components/PluginsPage.tsx
@@ -2,7 +2,14 @@ import { useCallback, useMemo, useRef, useState } from "react";
 import { Blocks, Cable, ChevronDown, EllipsisVertical, Filter, Plus, PlugZap, RefreshCw, Search, Sparkles, Trash2 } from "lucide-react";
 
 import { Button } from "./ui/button";
-import type { DesktopAppRecord, DesktopExtensionOverviewResult, DesktopManagedExtensionKind, DesktopPluginRecord, DesktopSkillRecord } from "../../main/contracts";
+import type {
+  DesktopAppRecord,
+  DesktopExtensionHealth,
+  DesktopExtensionOverviewResult,
+  DesktopManagedExtensionKind,
+  DesktopPluginRecord,
+  DesktopSkillRecord,
+} from "../../main/contracts";
 import { PluginDetailView } from "./extensions/PluginDetailView";
 import { SkillDetailModal } from "./extensions/SkillDetailModal";
 import { AppDetailView } from "./extensions/AppDetailView";
@@ -26,6 +33,108 @@ function ExtensionIcon({ kind, src }: { kind: ExtensionIconKind; src?: string | 
   return (
     <div className="flex size-7 shrink-0 items-center justify-center rounded-md bg-surface-strong">
       <Icon className="size-3.5 text-muted" />
+    </div>
+  );
+}
+
+function ExtensionHealthBanner({ health }: { health: DesktopExtensionHealth }) {
+  const [expanded, setExpanded] = useState(false);
+  const { backend, pluginMcp } = health;
+  const quarantinedCount = pluginMcp.invalidEntries.length;
+  const failedReadsCount = backend.failedReads.length;
+  const hasRuntimeError = Boolean(backend.lastRuntimeError);
+
+  if (quarantinedCount === 0 && failedReadsCount === 0 && !hasRuntimeError) {
+    return null;
+  }
+
+  const severity: "warning" | "error" =
+    hasRuntimeError || failedReadsCount > 0 ? "error" : "warning";
+  const container = severity === "error"
+    ? "border-b border-red-200 bg-red-50 px-4 py-2 text-red-900"
+    : "border-b border-amber-200 bg-amber-50 px-4 py-2 text-amber-900";
+
+  const summaryParts: string[] = [];
+  if (quarantinedCount > 0) {
+    summaryParts.push(
+      `${quarantinedCount} plugin MCP ${quarantinedCount === 1 ? "entry" : "entries"} set aside`,
+    );
+  }
+  if (failedReadsCount > 0) {
+    summaryParts.push(
+      `${failedReadsCount} backend ${failedReadsCount === 1 ? "call" : "calls"} failed`,
+    );
+  }
+  if (hasRuntimeError) {
+    summaryParts.push("runtime restart reported an error");
+  }
+  const summary = summaryParts.join(" \u00B7 ");
+
+  return (
+    <div className={container}>
+      <button
+        className="flex w-full items-center gap-2 text-left text-xs font-medium"
+        onClick={() => setExpanded((value) => !value)}
+        type="button"
+      >
+        <span className="truncate">Extensions health: {summary}</span>
+        <span className="ml-auto text-[10px] uppercase tracking-wide opacity-70">
+          {expanded ? "Hide" : "Details"}
+        </span>
+      </button>
+      {expanded ? (
+        <div className="mt-2 space-y-2 text-[11px]">
+          {quarantinedCount > 0 ? (
+            <div>
+              <p className="font-medium">Quarantined plugin MCP entries</p>
+              <ul className="mt-1 space-y-1">
+                {pluginMcp.invalidEntries.map((entry, index) => (
+                  <li className="flex flex-col" key={`${entry.pluginName ?? "unknown"}:${entry.serverId}:${index}`}>
+                    <span>
+                      <span className="font-medium">{entry.pluginName ?? "Unknown plugin"}</span>
+                      {" \u2192 "}
+                      <code className="rounded bg-white/60 px-1 py-0.5">{entry.serverId}</code>
+                    </span>
+                    <span className="opacity-80">{entry.reason}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {failedReadsCount > 0 ? (
+            <div>
+              <p className="font-medium">Failed backend reads</p>
+              <ul className="mt-1 space-y-1">
+                {backend.failedReads.map((entry, index) => (
+                  <li className="flex flex-col" key={`${entry.method}:${index}`}>
+                    <code className="rounded bg-white/60 px-1 py-0.5">{entry.method}</code>
+                    <span className="opacity-80">{entry.message}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {hasRuntimeError ? (
+            <div>
+              <p className="font-medium">Last runtime error</p>
+              <p className="mt-1 opacity-80">{backend.lastRuntimeError}</p>
+              {backend.suspectedMcpServerIds.length > 0 ? (
+                <p className="mt-1 opacity-80">
+                  Likely MCP server(s):{" "}
+                  {backend.suspectedMcpServerIds.map((id, index) => (
+                    <span key={id}>
+                      {index > 0 ? ", " : null}
+                      <code className="rounded bg-white/60 px-1 py-0.5">{id}</code>
+                    </span>
+                  ))}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -543,6 +652,9 @@ export function PluginsPage({
           ))}
         </div>
       ) : null}
+
+      {/* ---- Extension health banner ---- */}
+      {overview?.health ? <ExtensionHealthBanner health={overview.health} /> : null}
 
       {/* ---- Content ---- */}
       {/* Show detail view for plugin/app/mcp (replaces card grid) */}


### PR DESCRIPTION
## Summary

Builds on #58. Two jobs:

1. **Disk-level quarantine** of malformed plugin `.mcp.json` entries. New `desktop/src/main/settings/plugin-mcp-quarantine.ts` classifies each entry (must carry `command` or `url`) and atomically strips invalid ones into a sibling `.mcp.json.quarantine-manifest.json` so codex can't ingest them on next cold start.
2. **User-visible health banner** on the Extensions page. Shows failed backend reads, the last runtime-restart error with any suspected MCP server ids, and the quarantined entries. Collapsed summary by default, expandable for details.

The quarantine runs at the start of `#buildOverview` — canonical sweep first (`.tmp/plugins/plugins/*`), then a per-plugin sweep over source paths returned by `plugin/list`. Idempotent on clean profiles.

## Context

This is **Pass A of Pass 1 (resilience)** in the four-pass plan:

1. Resilience — #58 (runtime-alive) + this PR (disk quarantine + UI banner) ✅
2. Protocol — kill `connectors://` `ERR_UNKNOWN_URL_SCHEME` noise.
3. Lifecycle — finish detail-view action wiring and keep app auth inside Sense-1.
4. Signed-in smoke script — end-to-end regression gate with restart persistence.

Why both pieces in one PR: the quarantine change without a UI surface would silently repair the problem but leave the user wondering what happened. The banner is the minimum viable visibility — one screen, one component, no new files for it.

## Dependencies

**Stacked on #58.** Base is `claude/laughing-knuth`. Merge #58 first, then this.

## Test plan

- [x] `node --test src/main/settings/plugin-mcp-quarantine.test.js` — 7/7 pass (classifier, rewrite + manifest, idempotency, missing dir, unparseable input, read-back).
- [x] `node --test src/main/settings/desktop-extension-service.test.js` — 26/26 pass (1 existing test updated for new quarantine behaviour).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm test:main` — 468/469 pass. One failure (`app-server-process-manager.test.js: unexpected crashes are retried once and then stop with an errored state`) is a pre-existing timing-sensitive flake; passes in isolation both on this branch and with changes stashed. Not introduced by this PR.
- [x] `pnpm test:unit` (renderer) — 143/143 pass.
- [ ] Manual signed-in Electron pass:
  - Extensions page populates, banner hidden when healthy.
  - Drop a malformed `.mcp.json` into a plugin clone (e.g. `{"mcpServers":{"bad":{"type":"http"}}}`), restart: banner shows "1 plugin MCP entry set aside", clicking "Details" lists the plugin name, server id, and reason, and the `.mcp.json` on disk has been rewritten without the bad entry. Sibling manifest file exists.
  - Force a codex restart failure (rarer now): banner flips to error-styled with the runtime error and suspected server ids.