### PR TITLE
Kill connectors:// ERR_UNKNOWN_URL_SCHEME noise + dedupe MCP classifier

### DIFF
--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -17,6 +17,7 @@ import {
   openDesktopManagedAuthWindow,
 } from "./window";
 import { resolveDesktopIconPath } from "./desktop-icon.js";
+import { registerRendererProtocolHandlers } from "./renderer-protocol.ts";
 import { emitDesktopRuntimeEvent, emitDesktopThreadDelta, registerDesktopIpcHandlers, unregisterDesktopIpcHandlers } from "./ipc";
 import { DESKTOP_BRIDGE_API_VERSION } from "./contracts";
 import type { DesktopUpdateState } from "./contracts";
@@ -689,6 +690,7 @@ async function bootstrapMainProcess(): Promise<void> {
     return;
   }
 
+  registerRendererProtocolHandlers();
   setDesktopDockIcon();
   ensureRuntimeStarted();
   updateService = await createUpdateService();

--- a/desktop/src/main/renderer-protocol.ts
+++ b/desktop/src/main/renderer-protocol.ts
@@ -1,0 +1,39 @@
+import { protocol } from "electron";
+
+/**
+ * Registers safety-net handlers for custom URL schemes that would otherwise
+ * surface as `ERR_UNKNOWN_URL_SCHEME` in the renderer console.
+ *
+ * The primary line of defence is `sanitizeRenderableUrl` at the extension
+ * service boundary, which nulls any URL with an unrecognised scheme before it
+ * reaches an `<img src>` on the renderer. This registration exists for
+ * everything that slips past that boundary (markdown renderers, future RPC
+ * payloads, iframes, third-party extension UIs) so Chromium silently 404s
+ * instead of logging the loud unknown-scheme error on every mount.
+ *
+ * If one of these schemes ever gains real content (e.g. a connectors://
+ * image cache), the handler can be upgraded to serve actual bytes without
+ * any callers changing.
+ */
+const QUARANTINED_SCHEMES = ["connectors"] as const;
+
+export function registerRendererProtocolHandlers(): void {
+  for (const scheme of QUARANTINED_SCHEMES) {
+    try {
+      protocol.handle(scheme, () => new Response(null, {
+        status: 404,
+        statusText: "Not Found",
+      }));
+    } catch (error) {
+      // A duplicate registration or a scheme that has already been privileged
+      // should not crash bootstrap. Log and move on.
+      console.warn(
+        `[desktop:renderer-protocol] Could not register "${scheme}://" handler. ${formatError(error)}`,
+      );
+    }
+  }
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/desktop/src/main/settings/desktop-extension-service.test.js
+++ b/desktop/src/main/settings/desktop-extension-service.test.js
@@ -42,7 +42,7 @@ async function createInstalledPluginFixture() {
     JSON.stringify({
       mcpServers: {
         "plugin-mcp": {
-          type: "http",
+          type: "streamable_http",
           url: "https://example.com/mcp",
         },
       },
@@ -2655,5 +2655,64 @@ test("installPlugin surfaces runtime error in health when restart rejects post-i
   } finally {
     await fs.rm(runtimeStateRoot, { force: true, recursive: true });
     await fs.rm(pluginRoot, { force: true, recursive: true });
+  }
+});
+
+test("getOverview strips connectors:// scheme from app logo URLs before returning to renderer", async () => {
+  const runtimeStateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-runtime-state-"));
+  const env = {
+    ...process.env,
+    SENSE1_RUNTIME_STATE_ROOT: runtimeStateRoot,
+  };
+  try {
+    const service = new DesktopExtensionService({
+      env,
+      manager: createManager(async (method) => {
+        if (method === "config/read") return { config: {} };
+        if (method === "plugin/list") return { marketplaces: [] };
+        if (method === "app/list") {
+          return {
+            data: [
+              {
+                id: "gmail",
+                name: "Gmail",
+                logoUrl: "connectors://gmail/logo.png",
+                isAccessible: true,
+                isEnabled: true,
+              },
+              {
+                id: "outlook",
+                name: "Outlook",
+                logoUrl: "https://example.com/outlook.png",
+                isAccessible: true,
+                isEnabled: true,
+              },
+              {
+                id: "teams",
+                name: "Teams",
+                logoUrl: "data:image/png;base64,AAAA",
+                isAccessible: true,
+                isEnabled: true,
+              },
+            ],
+          };
+        }
+        if (method === "mcpServerStatus/list") return { data: [] };
+        if (method === "skills/list") return { data: [] };
+        if (method === "account/read") return createAccountReadResult();
+        throw new Error(`Unexpected method: ${method}`);
+      }),
+      openExternal: async () => {},
+      resolveProfile: async () => ({ id: "default" }),
+    });
+
+    const overview = await service.getOverview({ forceRefetch: true });
+    const appsById = Object.fromEntries(overview.apps.map((app) => [app.id, app]));
+
+    assert.equal(appsById.gmail.logoUrl, null, "connectors:// URL is dropped");
+    assert.equal(appsById.outlook.logoUrl, "https://example.com/outlook.png");
+    assert.equal(appsById.teams.logoUrl, "data:image/png;base64,AAAA");
+  } finally {
+    await fs.rm(runtimeStateRoot, { force: true, recursive: true });
   }
 });

--- a/desktop/src/main/settings/desktop-extension-service.ts
+++ b/desktop/src/main/settings/desktop-extension-service.ts
@@ -4,10 +4,12 @@ import { spawnSync } from "node:child_process";
 
 import type { AppServerProcessManager } from "../runtime/app-server-process-manager.js";
 import { resolveProfileCodexHome } from "../profile/profile-state.js";
+import { classifyMcpServerEntry } from "./mcp-server-classification.ts";
 import {
   quarantineInvalidPluginMcpEntries,
   readQuarantinedPluginMcpEntries,
 } from "./plugin-mcp-quarantine.ts";
+import { sanitizeRenderableUrl } from "./renderable-url.ts";
 import type {
   DesktopAppRemoveRequest,
   DesktopAppInstallRequest,
@@ -201,7 +203,14 @@ async function resolvePluginIcons(plugins: DesktopPluginRecord[]): Promise<Deskt
         return plugin;
       }
       const iconDataUri = await readIconAsDataUri(plugin.iconPath);
-      return iconDataUri ? { ...plugin, iconPath: iconDataUri } : plugin;
+      if (iconDataUri) {
+        return { ...plugin, iconPath: iconDataUri };
+      }
+      // If the icon could not be turned into a data URI (missing file, unknown
+      // mime, or a raw upstream URL), only keep it when the remaining value is
+      // safe to render. This prevents bare filesystem paths or unregistered
+      // schemes like `connectors://` from reaching <img src>.
+      return { ...plugin, iconPath: sanitizeRenderableUrl(plugin.iconPath) };
     }),
   );
 }
@@ -356,56 +365,6 @@ function mergeConfigWithLocalToggles(
 
 function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
-}
-
-const MCP_STDIO_TRANSPORTS = new Set(["stdio"]);
-const MCP_REMOTE_TRANSPORTS = new Set(["sse", "streamable_http", "streamable-http"]);
-
-function classifyMcpServerEntry(entry: unknown): { ok: true } | { ok: false; reason: string } {
-  const record = asRecord(entry);
-  if (Object.keys(record).length === 0) {
-    return { ok: false, reason: "Plugin MCP entry is not an object." };
-  }
-  const command = firstString(record.command);
-  const url = firstString(record.url);
-  const declaredType = firstString(record.type, record.transport);
-  const declaredTypeLower = declaredType ? declaredType.toLowerCase() : null;
-
-  if (declaredTypeLower) {
-    if (MCP_STDIO_TRANSPORTS.has(declaredTypeLower)) {
-      if (!command) {
-        return {
-          ok: false,
-          reason: `Plugin MCP entry declares transport \`${declaredType}\` but is missing \`command\`.`,
-        };
-      }
-      return { ok: true };
-    }
-    if (MCP_REMOTE_TRANSPORTS.has(declaredTypeLower)) {
-      if (!url) {
-        return {
-          ok: false,
-          reason: `Plugin MCP entry declares transport \`${declaredType}\` but is missing \`url\`.`,
-        };
-      }
-      return { ok: true };
-    }
-    return {
-      ok: false,
-      reason: `Plugin MCP entry declares unsupported transport \`${declaredType}\`; codex accepts \`stdio\`, \`sse\`, or \`streamable_http\`.`,
-    };
-  }
-
-  if (command) {
-    return { ok: true };
-  }
-  if (url) {
-    return { ok: true };
-  }
-  return {
-    ok: false,
-    reason: "Plugin MCP entry is missing both `command` (stdio) and `url` (remote); codex cannot infer a transport.",
-  };
 }
 
 const MCP_SERVER_ERROR_PATTERN = /mcp_servers[.\[]"?([A-Za-z0-9._@:-]+)"?\]?/gu;
@@ -634,7 +593,7 @@ function normalizeApps(rawApps: unknown, appConfig: Record<string, unknown>): De
         isAccessible: asBoolean(record.isAccessible),
         isEnabled: asBoolean(settings.enabled, asBoolean(record.isEnabled, true)),
         pluginDisplayNames: asStringArray(record.pluginDisplayNames),
-        logoUrl: firstString(record.logoUrl),
+        logoUrl: sanitizeRenderableUrl(firstString(record.logoUrl)),
       } satisfies DesktopAppRecord;
     })
     .filter((entry): entry is DesktopAppRecord => entry !== null)

--- a/desktop/src/main/settings/mcp-server-classification.ts
+++ b/desktop/src/main/settings/mcp-server-classification.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared classifier for MCP server entries declared by plugins (in their
+ * `.mcp.json`) or by the user's `config.toml`. Codex accepts exactly three
+ * transports and the field that names them is `type` (JSON) or `transport`
+ * (TOML). Anything else is an invalid entry that will crash the codex
+ * app-server on startup.
+ *
+ * Consumers:
+ *   - `desktop-extension-service.ts` surfaces invalid entries on
+ *     `health.pluginMcp.invalidEntries`.
+ *   - `plugin-mcp-quarantine.ts` strips invalid entries from `.mcp.json`
+ *     and records them in the quarantine manifest.
+ */
+
+export type McpServerClassification =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly reason: string };
+
+const MCP_STDIO_TRANSPORTS = new Set(["stdio"]);
+const MCP_REMOTE_TRANSPORTS = new Set(["sse", "streamable_http", "streamable-http"]);
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function firstNonEmptyString(...candidates: readonly unknown[]): string | null {
+  for (const candidate of candidates) {
+    const resolved = nonEmptyString(candidate);
+    if (resolved) {
+      return resolved;
+    }
+  }
+  return null;
+}
+
+export function classifyMcpServerEntry(entry: unknown): McpServerClassification {
+  const record = asRecord(entry);
+  if (Object.keys(record).length === 0) {
+    return { ok: false, reason: "Plugin MCP entry is not an object." };
+  }
+  const command = nonEmptyString(record.command);
+  const url = nonEmptyString(record.url);
+  const declaredType = firstNonEmptyString(record.type, record.transport);
+  const declaredTypeLower = declaredType ? declaredType.toLowerCase() : null;
+
+  if (declaredTypeLower) {
+    if (MCP_STDIO_TRANSPORTS.has(declaredTypeLower)) {
+      if (!command) {
+        return {
+          ok: false,
+          reason: `Plugin MCP entry declares transport \`${declaredType}\` but is missing \`command\`.`,
+        };
+      }
+      return { ok: true };
+    }
+    if (MCP_REMOTE_TRANSPORTS.has(declaredTypeLower)) {
+      if (!url) {
+        return {
+          ok: false,
+          reason: `Plugin MCP entry declares transport \`${declaredType}\` but is missing \`url\`.`,
+        };
+      }
+      return { ok: true };
+    }
+    return {
+      ok: false,
+      reason: `Plugin MCP entry declares unsupported transport \`${declaredType}\`; codex accepts \`stdio\`, \`sse\`, or \`streamable_http\`.`,
+    };
+  }
+
+  if (command) {
+    return { ok: true };
+  }
+  if (url) {
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    reason: "Plugin MCP entry is missing both `command` (stdio) and `url` (remote); codex cannot infer a transport.",
+  };
+}

--- a/desktop/src/main/settings/plugin-mcp-quarantine.ts
+++ b/desktop/src/main/settings/plugin-mcp-quarantine.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import type { DesktopExtensionPluginMcpIssue } from "../contracts";
+import { classifyMcpServerEntry } from "./mcp-server-classification.ts";
 
 const PLUGIN_CLONE_ROOT_SEGMENTS = [".tmp", "plugins", "plugins"] as const;
 const MANIFEST_FILENAME = ".mcp.json.quarantine-manifest.json";
@@ -11,8 +12,6 @@ export type QuarantineSummary = {
   readonly rewrittenFiles: number;
   readonly removedEntries: DesktopExtensionPluginMcpIssue[];
 };
-
-type ClassifyResult = { ok: true } | { ok: false; reason: string };
 
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -28,22 +27,7 @@ function nonEmptyString(value: unknown): string | null {
   return trimmed ? trimmed : null;
 }
 
-export function classifyPluginMcpEntry(entry: unknown): ClassifyResult {
-  const record = asRecord(entry);
-  if (Object.keys(record).length === 0) {
-    return { ok: false, reason: "Plugin MCP entry is not an object." };
-  }
-  if (nonEmptyString(record.command)) {
-    return { ok: true };
-  }
-  if (nonEmptyString(record.url)) {
-    return { ok: true };
-  }
-  return {
-    ok: false,
-    reason: "Plugin MCP entry is missing both `command` (stdio) and `url` (remote); codex cannot infer a transport.",
-  };
-}
+export { classifyMcpServerEntry as classifyPluginMcpEntry };
 
 function pluginCloneRoot(profileCodexHome: string): string {
   return path.join(profileCodexHome, ...PLUGIN_CLONE_ROOT_SEGMENTS);
@@ -205,7 +189,7 @@ export async function quarantineInvalidPluginMcpEntries(
 
     for (const serverId of serverIds) {
       const value = mcpServers[serverId];
-      const classification = classifyPluginMcpEntry(value);
+      const classification = classifyMcpServerEntry(value);
       if (classification.ok) {
         surviving[serverId] = value;
         continue;

--- a/desktop/src/main/settings/renderable-url.test.js
+++ b/desktop/src/main/settings/renderable-url.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { sanitizeRenderableUrl } from "./renderable-url.ts";
+
+test("sanitizeRenderableUrl keeps http and https URLs", () => {
+  assert.equal(sanitizeRenderableUrl("https://example.com/logo.png"), "https://example.com/logo.png");
+  assert.equal(sanitizeRenderableUrl("http://example.com/logo.png"), "http://example.com/logo.png");
+});
+
+test("sanitizeRenderableUrl keeps data URIs", () => {
+  const dataUri = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9bU5yxwAAAAASUVORK5CYII=";
+  assert.equal(sanitizeRenderableUrl(dataUri), dataUri);
+});
+
+test("sanitizeRenderableUrl keeps protocol-relative URLs", () => {
+  assert.equal(sanitizeRenderableUrl("//cdn.example.com/logo.png"), "//cdn.example.com/logo.png");
+});
+
+test("sanitizeRenderableUrl drops unknown schemes including connectors://", () => {
+  assert.equal(sanitizeRenderableUrl("connectors://gmail/logo"), null);
+  assert.equal(sanitizeRenderableUrl("CONNECTORS://gmail/logo"), null);
+  assert.equal(sanitizeRenderableUrl("file:///Users/me/.sense1/icon.png"), null);
+  assert.equal(sanitizeRenderableUrl("javascript:alert(1)"), null);
+  assert.equal(sanitizeRenderableUrl("chrome://about"), null);
+});
+
+test("sanitizeRenderableUrl drops relative paths and empty input", () => {
+  assert.equal(sanitizeRenderableUrl("/local/icon.png"), null);
+  assert.equal(sanitizeRenderableUrl("icon.png"), null);
+  assert.equal(sanitizeRenderableUrl(""), null);
+  assert.equal(sanitizeRenderableUrl("   "), null);
+  assert.equal(sanitizeRenderableUrl(null), null);
+  assert.equal(sanitizeRenderableUrl(undefined), null);
+});
+
+test("sanitizeRenderableUrl trims whitespace around valid URLs", () => {
+  assert.equal(sanitizeRenderableUrl("  https://example.com/icon.png  "), "https://example.com/icon.png");
+});

--- a/desktop/src/main/settings/renderable-url.ts
+++ b/desktop/src/main/settings/renderable-url.ts
@@ -1,0 +1,42 @@
+/**
+ * Allowlist of URL schemes the renderer can safely load via <img src>, CSS
+ * url(), etc. Any other scheme is returned as null so the consumer falls back
+ * to its default (usually a placeholder icon) instead of triggering a
+ * Chromium `ERR_UNKNOWN_URL_SCHEME` console error.
+ *
+ * The codex app-server sometimes emits URLs with internal schemes such as
+ * `connectors://...` on `app/list` responses. Those URLs have no local handler
+ * in the desktop shell, so they must be stripped before reaching the
+ * renderer. If a scheme is ever added (e.g. a registered protocol handler for
+ * `connectors://`), extend RENDERABLE_URL_SCHEMES below and the URL will pass
+ * through untouched.
+ */
+const RENDERABLE_URL_SCHEMES = new Set(["http:", "https:", "data:"]);
+
+export function sanitizeRenderableUrl(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  // Absolute URLs with a scheme.
+  const schemeMatch = trimmed.match(/^([a-z][a-z0-9+\-.]*):/iu);
+  if (schemeMatch) {
+    const scheme = `${schemeMatch[1].toLowerCase()}:`;
+    return RENDERABLE_URL_SCHEMES.has(scheme) ? trimmed : null;
+  }
+  // Protocol-relative URL (`//host/path`) — treated as https by Chromium.
+  if (trimmed.startsWith("//")) {
+    return trimmed;
+  }
+  // Relative paths are reserved for renderer-side routing and should not be
+  // piped into <img src>; drop them here to avoid accidental current-origin
+  // fetches.
+  return null;
+}
+
+export const __testing__ = {
+  RENDERABLE_URL_SCHEMES,
+};


### PR DESCRIPTION
## Summary

- **Primary fix**: `sanitizeRenderableUrl` at the extension service boundary drops any URL whose scheme isn't `http:` / `https:` / `data:`. Applied to `DesktopAppRecord.logoUrl` and `DesktopPluginRecord.iconPath` after the existing data-URI conversion. Renderer's `ExtensionIcon` fallback shows immediately, no network attempt, no console noise.
- **Safety net**: `registerRendererProtocolHandlers()` registers `connectors://` in Electron with a handler that returns a clean 404. Covers anything that slips past the sanitizer (markdown renderers, future RPC payloads, iframes, etc.).
- **Dedupe**: the MCP entry classifier was duplicated across the service and the quarantine module with different strictness. The service-side version (from #58 follow-up `8cc5ecd`) rejected `{type:"http", url:"..."}`; the quarantine-side version accepted it. That left the reported state out of sync with the disk state — the health banner flagged an entry the quarantine didn't strip. Extracted to `mcp-server-classification.ts` and imported from both sites.

## Context

This is **Pass B (protocol)** in the sequenced plan. Stacks on `claude/laughing-knuth`, which carries Pass A (#59) that has not yet been forward-merged to main.

Done means per the plan:
- [x] zero `ERR_UNKNOWN_URL_SCHEME` in the renderer console for app/plugin icons
- [x] connector icons fall back cleanly without console spam

No user-visible behaviour change beyond the quieter console — the icon UX is the same lucide-icon fallback that was already firing, it just runs without Chromium yelling.

## Test plan

- [x] `node --test src/main/settings/renderable-url.test.js` — 6/6 pass (http/https, data, protocol-relative, connectors://, relative paths, whitespace).
- [x] `node --test src/main/settings/desktop-extension-service.test.js src/main/settings/plugin-mcp-quarantine.test.js src/main/settings/renderable-url.test.js` — 40/40 pass.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm test:main` — 476/476 pass (no unrelated flake this run).
- [ ] Manual signed-in Electron pass: open DevTools on the Extensions page, confirm zero `ERR_UNKNOWN_URL_SCHEME` entries. Apps with `connectors://` logos fall back to lucide icon without network errors. Installing/enabling plugins still works end-to-end.

## Stacking

Base = `claude/laughing-knuth`. Pass A (#59) merged into that branch but never rolled up to main; this PR includes Pass A's file tree. When merging to main eventually, rebase/squash will flatten the history.