### PR TITLE
Keep MCP OAuth inside Sense-1 and replace reload toggle dance with one RPC

### DIFF
--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -19,6 +19,7 @@ import {
   type DesktopInputResponseRequest,
   type DesktopInterruptTurnRequest,
   type DesktopMcpServerEnabledRequest,
+  type DesktopMcpServerReloadRequest,
   type DesktopPluginDetailRequest,
   type DesktopPluginDetailResult,
   type DesktopPolicyRulesResult,
@@ -143,6 +144,7 @@ type DesktopIpcServices = {
   setDesktopAppEnabled(request: DesktopAppEnabledRequest): Promise<DesktopExtensionOverviewResult>;
   startDesktopMcpServerAuth(request: DesktopMcpServerAuthRequest): Promise<DesktopMcpServerAuthResult>;
   setDesktopMcpServerEnabled(request: DesktopMcpServerEnabledRequest): Promise<DesktopExtensionOverviewResult>;
+  reloadDesktopMcpServer(request: DesktopMcpServerReloadRequest): Promise<DesktopExtensionOverviewResult>;
   readDesktopSkillDetail(request: DesktopSkillDetailRequest): Promise<DesktopSkillDetailResult>;
   setDesktopSkillEnabled(request: DesktopSkillEnabledRequest): Promise<DesktopExtensionOverviewResult>;
   uninstallDesktopSkill(request: DesktopSkillUninstallRequest): Promise<DesktopExtensionOverviewResult>;
@@ -430,6 +432,13 @@ export function registerDesktopIpcHandlers(services: DesktopIpcServices): void {
     IPC_CHANNELS.setDesktopMcpServerEnabled,
     async (_event, request: DesktopMcpServerEnabledRequest): Promise<DesktopExtensionOverviewResult> => {
       return await services.setDesktopMcpServerEnabled(request);
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.reloadDesktopMcpServer,
+    async (_event, request: DesktopMcpServerReloadRequest): Promise<DesktopExtensionOverviewResult> => {
+      return await services.reloadDesktopMcpServer(request);
     },
   );
 

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -813,6 +813,7 @@ async function bootstrapMainProcess(): Promise<void> {
     setDesktopAppEnabled: async (request) => await desktopSessionController.setDesktopAppEnabled(request),
     startDesktopMcpServerAuth: async (request) => await desktopSessionController.startDesktopMcpServerAuth(request),
     setDesktopMcpServerEnabled: async (request) => await desktopSessionController.setDesktopMcpServerEnabled(request),
+    reloadDesktopMcpServer: async (request) => await desktopSessionController.reloadDesktopMcpServer(request),
     readDesktopSkillDetail: async (request) => await desktopSessionController.readDesktopSkillDetail(request),
     setDesktopSkillEnabled: async (request) => await desktopSessionController.setDesktopSkillEnabled(request),
     uninstallDesktopSkill: async (request) => await desktopSessionController.uninstallDesktopSkill(request),

--- a/desktop/src/main/session-controller.ts
+++ b/desktop/src/main/session-controller.ts
@@ -32,6 +32,7 @@ import type {
   DesktopInterruptTurnRequest,
   DesktopLastSelectedThreadRequest,
   DesktopMcpServerAuthRequest,
+  DesktopMcpServerReloadRequest,
   DesktopMcpServerAuthResult,
   DesktopMcpServerEnabledRequest,
   DesktopRuntimeEvent,
@@ -899,6 +900,12 @@ export class DesktopSessionController {
     request: DesktopMcpServerEnabledRequest,
   ): Promise<DesktopExtensionOverviewResult> {
     return await this.#desktopExtensions.setMcpServerEnabled(request);
+  }
+
+  async reloadDesktopMcpServer(
+    request: DesktopMcpServerReloadRequest,
+  ): Promise<DesktopExtensionOverviewResult> {
+    return await this.#desktopExtensions.reloadMcpServer(request);
   }
 
   async readDesktopSkillDetail(

--- a/desktop/src/main/settings/desktop-extension-service.test.js
+++ b/desktop/src/main/settings/desktop-extension-service.test.js
@@ -2150,7 +2150,7 @@ test("readPluginDetail prefers plugin/read and falls back to local metadata", as
   }
 });
 
-test("startMcpServerAuth opens the returned authorization URL", async () => {
+test("startMcpServerAuth opens the authorization URL inside a Sense-1 managed window, not the default browser", async () => {
   const externallyOpened = [];
   const managedAuthOpened = [];
 
@@ -2217,8 +2217,89 @@ test("startMcpServerAuth opens the returned authorization URL", async () => {
 
   const result = await service.startMcpServerAuth({ serverId: "docs" });
   assert.equal(result.authorizationUrl, "https://example.com/oauth/start");
-  assert.deepEqual(externallyOpened, ["https://example.com/oauth/start"]);
-  assert.deepEqual(managedAuthOpened, []);
+  assert.deepEqual(
+    managedAuthOpened,
+    ["https://example.com/oauth/start"],
+    "MCP OAuth must land inside the Sense-1 managed auth window",
+  );
+  assert.deepEqual(
+    externallyOpened,
+    [],
+    "MCP OAuth must not bounce the user out to the default browser or ChatGPT desktop",
+  );
+});
+
+test("reloadMcpServer calls config/mcpServer/reload once without toggling enabled state", async () => {
+  const runtimeStateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-runtime-state-"));
+  const env = { ...process.env, SENSE1_RUNTIME_STATE_ROOT: runtimeStateRoot };
+  const managerCalls = [];
+  try {
+    const service = new DesktopExtensionService({
+      env,
+      manager: {
+        request: async (method, params) => {
+          managerCalls.push({ method, params });
+          if (method === "config/read") return { config: { mcp_servers: { docs: { enabled: true } } } };
+          if (method === "plugin/list") return { marketplaces: [] };
+          if (method === "app/list") return { data: [] };
+          if (method === "mcpServerStatus/list") {
+            return { data: [{ id: "docs", state: "ready", authStatus: "connected" }] };
+          }
+          if (method === "skills/list") return { data: [] };
+          if (method === "account/read") return createAccountReadResult();
+          if (method === "config/mcpServer/reload") return {};
+          throw new Error(`Unexpected method: ${method}`);
+        },
+      },
+      openExternal: async () => {},
+      openManagedAuth: async () => {},
+      resolveProfile: async () => ({ id: "default" }),
+    });
+
+    const overview = await service.reloadMcpServer({ serverId: "docs" });
+    const reloadCalls = managerCalls.filter((call) => call.method === "config/mcpServer/reload");
+    const toggleCalls = managerCalls.filter((call) => call.method === "config/value/write");
+    assert.equal(reloadCalls.length, 1, "reload must call the reload RPC exactly once");
+    assert.equal(toggleCalls.length, 0, "reload must not toggle the enabled flag");
+    assert.equal(overview.health.backend.lastRuntimeError, null);
+    const docs = overview.mcpServers.find((server) => server.id === "docs");
+    assert.ok(docs, "mcp server record returned");
+    assert.equal(docs.enabled, true, "enabled state preserved after reload");
+  } finally {
+    await fs.rm(runtimeStateRoot, { force: true, recursive: true });
+  }
+});
+
+test("reloadMcpServer surfaces the codex error in health when reload rejects", async () => {
+  const runtimeStateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-runtime-state-"));
+  const env = { ...process.env, SENSE1_RUNTIME_STATE_ROOT: runtimeStateRoot };
+  try {
+    const service = new DesktopExtensionService({
+      env,
+      manager: {
+        request: async (method) => {
+          if (method === "config/read") return { config: {} };
+          if (method === "plugin/list") return { marketplaces: [] };
+          if (method === "app/list") return { data: [] };
+          if (method === "mcpServerStatus/list") return { data: [] };
+          if (method === "skills/list") return { data: [] };
+          if (method === "account/read") return createAccountReadResult();
+          if (method === "config/mcpServer/reload") {
+            throw new Error("MCP reload failed: upstream timed out");
+          }
+          throw new Error(`Unexpected method: ${method}`);
+        },
+      },
+      openExternal: async () => {},
+      openManagedAuth: async () => {},
+      resolveProfile: async () => ({ id: "default" }),
+    });
+
+    const overview = await service.reloadMcpServer({ serverId: "docs" });
+    assert.match(overview.health.backend.lastRuntimeError ?? "", /MCP reload failed/);
+  } finally {
+    await fs.rm(runtimeStateRoot, { force: true, recursive: true });
+  }
 });
 
 test("readSkillDetail returns the skill markdown body", async () => {

--- a/desktop/src/main/settings/desktop-extension-service.ts
+++ b/desktop/src/main/settings/desktop-extension-service.ts
@@ -28,6 +28,7 @@ import type {
   DesktopMcpServerAuthResult,
   DesktopMcpServerEnabledRequest,
   DesktopMcpServerRecord,
+  DesktopMcpServerReloadRequest,
   DesktopPluginDetailRequest,
   DesktopPluginDetailResult,
   DesktopPluginDetailSkillRecord,
@@ -1786,11 +1787,28 @@ export class DesktopExtensionService {
       throw new Error("Sense-1 could not start MCP authentication for that server.");
     }
 
-    await this.#openExternal(authorizationUrl);
+    // Keep the OAuth flow inside a Sense-1 managed window so the callback
+    // round-trip lands back here and the user never gets bounced out to the
+    // default browser or a ChatGPT desktop handoff.
+    await this.#openManagedAuth(authorizationUrl);
     return {
       authorizationUrl,
       overview: await this.getOverview({ forceRefetch: true }),
     };
+  }
+
+  async reloadMcpServer(request: DesktopMcpServerReloadRequest): Promise<DesktopExtensionOverviewResult> {
+    let runtimeError: string | null = null;
+    try {
+      await this.#manager.request("config/mcpServer/reload", {
+        id: request.serverId,
+        serverId: request.serverId,
+      });
+    } catch (error) {
+      runtimeError = formatError(error);
+      console.warn(`[desktop:extensions] config/mcpServer/reload for "mcp-reload" failed. ${runtimeError}`);
+    }
+    return await this.#buildOverview({ forceRefetch: true }, runtimeError);
   }
 
   async setMcpServerEnabled(request: DesktopMcpServerEnabledRequest): Promise<DesktopExtensionOverviewResult> {

--- a/desktop/src/preload/bridge/management.ts
+++ b/desktop/src/preload/bridge/management.ts
@@ -16,6 +16,7 @@ import {
   type DesktopExtensionOverviewRequest,
   type DesktopExtensionOverviewResult,
   type DesktopMcpServerEnabledRequest,
+  type DesktopMcpServerReloadRequest,
   type DesktopPluginDetailRequest,
   type DesktopPluginDetailResult,
   type DesktopPluginInstallRequest,
@@ -61,6 +62,9 @@ export function createManagementBridge(ipcRenderer: IpcRenderer): ManagementBrid
       },
       setMcpServerEnabled: async (request: DesktopMcpServerEnabledRequest): Promise<DesktopExtensionOverviewResult> => {
         return ipcRenderer.invoke(IPC_CHANNELS.setDesktopMcpServerEnabled, request) as Promise<DesktopExtensionOverviewResult>;
+      },
+      reloadMcpServer: async (request: DesktopMcpServerReloadRequest): Promise<DesktopExtensionOverviewResult> => {
+        return ipcRenderer.invoke(IPC_CHANNELS.reloadDesktopMcpServer, request) as Promise<DesktopExtensionOverviewResult>;
       },
       readSkillDetail: async (request: DesktopSkillDetailRequest): Promise<DesktopSkillDetailResult> => {
         return ipcRenderer.invoke(IPC_CHANNELS.readDesktopSkillDetail, request) as Promise<DesktopSkillDetailResult>;

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -169,6 +169,7 @@ export default function App() {
         removeApp={management.removeApp}
         setAppEnabled={management.setAppEnabled}
         setMcpServerEnabled={management.setMcpServerEnabled}
+        reloadMcpServer={management.reloadMcpServer}
         setPluginEnabled={management.setPluginEnabled}
         setSkillEnabled={management.setSkillEnabled}
         startMcpServerAuth={management.startMcpServerAuth}

--- a/desktop/src/renderer/components/PluginsPage.tsx
+++ b/desktop/src/renderer/components/PluginsPage.tsx
@@ -152,6 +152,7 @@ type PluginsPageProps = {
   removeApp: (request: { appId: string }) => Promise<unknown>;
   setAppEnabled: (request: { appId: string; enabled: boolean }) => Promise<unknown>;
   setMcpServerEnabled: (request: { serverId: string; enabled: boolean }) => Promise<unknown>;
+  reloadMcpServer: (request: { serverId: string }) => Promise<unknown>;
   setPluginEnabled: (request: { pluginId: string; enabled: boolean }) => Promise<unknown>;
   setSkillEnabled: (request: { path: string; enabled: boolean }) => Promise<unknown>;
   startMcpServerAuth?: (request: { serverId: string }) => Promise<unknown>;
@@ -471,6 +472,7 @@ export function PluginsPage({
   removeApp,
   setAppEnabled,
   setMcpServerEnabled,
+  reloadMcpServer,
   setPluginEnabled,
   setSkillEnabled,
   startMcpServerAuth,
@@ -712,10 +714,8 @@ export function PluginsPage({
             void runAction(`mcp-auth:${selectedManagedRecord.id}`, async () => await startMcpServerAuth({ serverId: selectedManagedRecord.id }), `Started auth flow for ${selectedManagedRecord.displayName}.`);
           } : undefined}
           onReload={selectedManagedRecord.canReload ? () => {
-            const wasEnabled = selectedManagedRecord.enablementState === "enabled";
             void runAction(`mcp-reload:${selectedManagedRecord.id}`, async () => {
-              await setMcpServerEnabled({ serverId: selectedManagedRecord.id, enabled: false });
-              await setMcpServerEnabled({ serverId: selectedManagedRecord.id, enabled: wasEnabled });
+              await reloadMcpServer({ serverId: selectedManagedRecord.id });
             }, `Reloaded ${selectedManagedRecord.displayName}.`);
           } : undefined}
           pendingActionKey={pendingActionKey}

--- a/desktop/src/renderer/features/management/use-desktop-management.ts
+++ b/desktop/src/renderer/features/management/use-desktop-management.ts
@@ -8,6 +8,7 @@ import type {
   DesktopMcpServerAuthRequest,
   DesktopMcpServerAuthResult,
   DesktopMcpServerEnabledRequest,
+  DesktopMcpServerReloadRequest,
   DesktopPluginInstallRequest,
   DesktopPluginUninstallRequest,
   DesktopPluginEnabledRequest,
@@ -127,6 +128,13 @@ export function useDesktopManagement({
     return nextOverview;
   }, []);
 
+  const reloadMcpServer = useCallback(async (request: DesktopMcpServerReloadRequest) => {
+    const bridge = requireDesktopBridge();
+    const nextOverview = await bridge.management.reloadMcpServer(request);
+    setOverview(nextOverview);
+    return nextOverview;
+  }, []);
+
   const setSkillEnabled = useCallback(async (request: DesktopSkillEnabledRequest) => {
     const bridge = requireDesktopBridge();
     const nextOverview = await bridge.management.setSkillEnabled(request);
@@ -150,6 +158,7 @@ export function useDesktopManagement({
     loadOverview,
     removeApp,
     setAppEnabled,
+    reloadMcpServer,
     setMcpServerEnabled,
     setPluginEnabled,
     setSkillEnabled,

--- a/desktop/src/shared/contracts/bridge.ts
+++ b/desktop/src/shared/contracts/bridge.ts
@@ -17,6 +17,7 @@ import type {
   DesktopExtensionOverviewRequest,
   DesktopExtensionOverviewResult,
   DesktopMcpServerEnabledRequest,
+  DesktopMcpServerReloadRequest,
   DesktopPluginDetailRequest,
   DesktopPluginDetailResult,
   DesktopPluginInstallRequest,
@@ -128,6 +129,7 @@ export interface DesktopBridge {
     setAppEnabled(request: DesktopAppEnabledRequest): Promise<DesktopExtensionOverviewResult>;
     startMcpServerAuth(request: DesktopMcpServerAuthRequest): Promise<DesktopMcpServerAuthResult>;
     setMcpServerEnabled(request: DesktopMcpServerEnabledRequest): Promise<DesktopExtensionOverviewResult>;
+    reloadMcpServer(request: DesktopMcpServerReloadRequest): Promise<DesktopExtensionOverviewResult>;
     readSkillDetail(request: DesktopSkillDetailRequest): Promise<DesktopSkillDetailResult>;
     setSkillEnabled(request: DesktopSkillEnabledRequest): Promise<DesktopExtensionOverviewResult>;
     uninstallSkill(request: DesktopSkillUninstallRequest): Promise<DesktopExtensionOverviewResult>;

--- a/desktop/src/shared/contracts/management.ts
+++ b/desktop/src/shared/contracts/management.ts
@@ -204,6 +204,10 @@ export interface DesktopMcpServerAuthRequest {
   readonly serverId: string;
 }
 
+export interface DesktopMcpServerReloadRequest {
+  readonly serverId: string;
+}
+
 export interface DesktopMcpServerAuthResult {
   readonly authorizationUrl: string;
   readonly overview: DesktopExtensionOverviewResult;

--- a/desktop/src/shared/contracts/runtime.ts
+++ b/desktop/src/shared/contracts/runtime.ts
@@ -62,6 +62,7 @@ export const IPC_CHANNELS = {
   setDesktopAppEnabled: "sense1:desktop:extensions:set-app-enabled",
   startDesktopMcpServerAuth: "sense1:desktop:extensions:start-mcp-auth",
   setDesktopMcpServerEnabled: "sense1:desktop:extensions:set-mcp-enabled",
+  reloadDesktopMcpServer: "sense1:desktop:extensions:reload-mcp",
   readDesktopSkillDetail: "sense1:desktop:extensions:read-skill-detail",
   setDesktopSkillEnabled: "sense1:desktop:extensions:set-skill-enabled",
   uninstallDesktopSkill: "sense1:desktop:extensions:uninstall-skill",


### PR DESCRIPTION
## Summary

Two lifecycle bugs the audit found, both fixed here:

- **MCP OAuth escape → managed window.** `startMcpServerAuth` was calling `#openExternal`, which defaults to `shell.openExternal(url)` → default browser or ChatGPT desktop handler. Every other auth path (app install, plugin install) already uses `#openManagedAuth` → `openDesktopManagedAuthWindow` (BrowserWindow inside Sense-1). MCP was the lone inconsistency. Now routes through the managed window.
- **MCP Reload no longer toggles enabled.** `PluginsPage` implemented reload as `setMcpServerEnabled(false)` → `setMcpServerEnabled(true)`, causing two codex restarts and a brief disabled window. New backend `reloadMcpServer` method calls `config/mcpServer/reload` once. Contract, IPC channel, preload bridge, session controller delegate, hook, and renderer all updated.

## Context

Pass C (lifecycle) in the sequenced plan. Stacks on `claude/laughing-knuth-pass-b-protocol` (PR #60).

Done means per the plan:
- [x] every entity type can be managed from its detail view (already true pre-PR; confirmed via audit, no changes needed there)
- [x] auth flows stay inside Sense-1 (**this PR** — MCP was the one escape)
- [x] post-action state persists after restart (already true via `getOverview({forceRefetch: true})` after each mutation; audit confirmed)

## Deferred to a Pass C.2 polish (not blocking)

- `AppDetailView` "Remove app" button renders on `isAccessible || enabled` rather than checking `canUninstall`. Cosmetic; no dangerous path.
- UI selection state (active tab, selected entity) not persisted across restart. UX polish, no data loss.

## Test plan

- [x] `node --test src/main/settings/desktop-extension-service.test.js` — 29/29 pass (1 flipped, 2 new).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm test:unit` — 476/478 pass. The 2 failures (`app-server-process-manager.test.js: start seeds...`, `start injects...`) are a known pre-existing timing-sensitive flake that passes solo (17/17) and fails under full-suite load on this machine — confirmed unrelated to these changes, same flake reported on the previous two stacked PRs.
- [ ] Manual signed-in Electron pass: click an MCP with `authState === "required"`, confirm the OAuth window opens inside Sense-1 (not the default browser). Click Reload on an enabled MCP, confirm it stays enabled throughout and only triggers a single `config/mcpServer/reload` RPC.

## Stacking

Base = `claude/laughing-knuth-pass-b-protocol`. When the parent chain merges to main (Pass A, Pass B, then this), everything flattens cleanly.