### PR TITLE
[codex] Add desktop bug reporting through Sentry and Linear

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@openai/codex": "0.120.0",
+    "@sentry/electron": "7.11.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "electron-updater": "6.8.3",

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@openai/codex':
         specifier: 0.120.0
         version: 0.120.0
+      '@sentry/electron':
+        specifier: 7.11.0
+        version: 7.11.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -520,6 +523,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@fastify/otel@0.18.0':
+    resolution: {integrity: sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -601,6 +609,216 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@opentelemetry/api-logs@0.207.0':
+    resolution: {integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api-logs@0.212.0':
+    resolution: {integrity: sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api-logs@0.214.0':
+    resolution: {integrity: sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/context-async-hooks@2.7.0':
+    resolution: {integrity: sha512-MWXggArM+Y11mPS8VOrqxOj+YMGQSRuvhM91eSBX4xFpJa05mpkeVvM8pPux5ElkEjV5RMgrkisrlP/R83SpBQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.6.1':
+    resolution: {integrity: sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.7.0':
+    resolution: {integrity: sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/instrumentation-amqplib@0.61.0':
+    resolution: {integrity: sha512-mCKoyTGfRNisge4br0NpOFSy2Z1NnEW8hbCJdUDdJFHrPqVzc4IIBPA/vX0U+LUcQqrQvJX+HMIU0dbDRe0i0Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-connect@0.57.0':
+    resolution: {integrity: sha512-FMEBChnI4FLN5TE9DHwfH7QpNir1JzXno1uz/TAucVdLCyrG0jTrKIcNHt/i30A0M2AunNBCkcd8Ei26dIPKdg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-dataloader@0.31.0':
+    resolution: {integrity: sha512-f654tZFQXS5YeLDNb9KySrwtg7SnqZN119FauD7acBoTzuLduaiGTNz88ixcVSOOMGZ+EjJu/RFtx5klObC95g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-express@0.62.0':
+    resolution: {integrity: sha512-Tvx+vgAZKEQxU3Rx+xWLiR0mLxHwmk69/8ya04+VsV9WYh8w6Lhx5hm5yAMvo1wy0KqWgFKBLwSeo3sHCwdOww==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-fs@0.33.0':
+    resolution: {integrity: sha512-sCZWXGalQ01wr3tAhSR9ucqFJ0phidpAle6/17HVjD6gN8FLmZMK/8sKxdXYHy3PbnlV1P4zeiSVFNKpbFMNLA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-generic-pool@0.57.0':
+    resolution: {integrity: sha512-orhmlaK+ZIW9hKU+nHTbXrCSXZcH83AescTqmpamHRobRmYSQwRbD0a1odc0yAzuzOtxYiHiXAnpnIpaSSY7Ow==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-graphql@0.62.0':
+    resolution: {integrity: sha512-3YNuLVPUxafXkH1jBAbGsKNsP3XVzcFDhCDCE3OqBwCwShlqQbLMRMFh1T/d5jaVZiGVmSsfof+ICKD2iOV8xg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-hapi@0.60.0':
+    resolution: {integrity: sha512-aNljZKYrEa7obLAxd1bCEDxF7kzCLGXTuTJZ8lMR9rIVEjmuKBXN1gfqpm/OB//Zc2zP4iIve1jBp7sr3mQV6w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-http@0.214.0':
+    resolution: {integrity: sha512-FlkDhZDRjDJDcO2LcSCtjRpkal1NJ8y0fBqBhTvfAR3JSYY2jAIj1kSS5IjmEBt4c3aWv+u/lqLuoCDrrKCSKg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-ioredis@0.62.0':
+    resolution: {integrity: sha512-ZYt//zcPve8qklaZX+5Z4MkU7UpEkFRrxsf2cnaKYBitqDnsCN69CPAuuMOX6NYdW2rG9sFy7V/QWtBlP5XiNQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-kafkajs@0.23.0':
+    resolution: {integrity: sha512-4K+nVo+zI+aDz0Z85SObwbdixIbzS9moIuKJaYsdlzcHYnKOPtB7ya8r8Ezivy/GVIBHiKJVq4tv+BEkgOMLaQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-knex@0.58.0':
+    resolution: {integrity: sha512-Hc/o8fSsaWxZ8r1Yw4rNDLwTpUopTf4X32y4W6UhlHmW8Wizz8wfhgOKIelSeqFVTKBBPIDUOsQWuIMxBmu8Bw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-koa@0.62.0':
+    resolution: {integrity: sha512-uVip0VuGUQXZ+vFxkKxAUNq8qNl+VFlyHDh/U6IQ8COOEDfbEchdaHnpFrMYF3psZRUuoSIgb7xOeXj00RdwDA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
+  '@opentelemetry/instrumentation-lru-memoizer@0.58.0':
+    resolution: {integrity: sha512-6grM3TdMyHzlGY1cUA+mwoPueB1F3dYKgKtZIH6jOFXqfHAByyLTc+6PFjGM9tKh52CFBJaDwodNlL/Td39z7Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mongodb@0.67.0':
+    resolution: {integrity: sha512-1WJp5N1lYfHq2IhECOTewFs5Tf2NfUOwQRqs/rZdXKTezArMlucxgzAaqcgp3A3YREXopXTpXHsxZTGHjNhMdQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mongoose@0.60.0':
+    resolution: {integrity: sha512-8BahAZpKsOoc+lrZGb7Ofn4g3z8qtp5IxDfvAVpKXsEheQN7ONMH5djT5ihy6yf8yyeQJGS0gXFfpEAEeEHqQg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mysql2@0.60.0':
+    resolution: {integrity: sha512-m/5d3bxQALllCzezYDk/6vajh0tj5OijMMvOZGr+qN1NMXm1dzMNwyJ0gNZW7Fo3YFRyj/jJMxIw+W7d525dlw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mysql@0.60.0':
+    resolution: {integrity: sha512-08pO8GFPEIz2zquKDGteBZDNmwketdgH8hTe9rVYgW9kCJXq1Psj3wPQGx+VaX4ZJKCfPeoLMYup9+cxHvZyVQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-pg@0.66.0':
+    resolution: {integrity: sha512-KxfLGXBb7k2ueaPJfq2GXBDXBly8P+SpR/4Mj410hhNgmQF3sCqwXvUBQxZQkDAmsdBAoenM+yV1LhtsMRamcA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-redis@0.62.0':
+    resolution: {integrity: sha512-y3pPpot7WzR/8JtHcYlTYsyY8g+pbFhAqbwAuG5bLPnR6v6pt1rQc0DpH0OlGP/9CZbWBP+Zhwp9yFoygf/ZXQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-tedious@0.33.0':
+    resolution: {integrity: sha512-Q6WQwAD01MMTub31GlejoiFACYNw26J426wyjvU7by7fDIr2nZXNW4vhTGs7i7F0TnXBO3xN688g1tdUgYwJ5w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-undici@0.24.0':
+    resolution: {integrity: sha512-oKzZ3uvqP17sV0EsoQcJgjEfIp0kiZRbYu/eD8p13Cbahumf8lb/xpYeNr/hfAJ4owzEtIDcGIjprfLcYbIKBQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
+
+  '@opentelemetry/instrumentation@0.207.0':
+    resolution: {integrity: sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.212.0':
+    resolution: {integrity: sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.214.0':
+    resolution: {integrity: sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/redis-common@0.38.3':
+    resolution: {integrity: sha512-VCghU1JYs/4gP6Gqf/xro9MEsZ7LrMv2uONVsaESKL38ZOB9BqnI98FfS23wjMnHlpuE+TTaWSoAVNpTwYXzjw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+
+  '@opentelemetry/resources@2.7.0':
+    resolution: {integrity: sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.7.0':
+    resolution: {integrity: sha512-Yg9zEXJB50DLVLpsKPk7NmNqlPlS+OvqhJGh0A8oawIOTPOwlm4eXs9BMJV7L79lvEwI+dWtAj+YjTyddV336A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.40.0':
+    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/sql-common@0.41.2':
+    resolution: {integrity: sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -609,6 +827,11 @@ packages:
     resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@prisma/instrumentation@7.6.0':
+    resolution: {integrity: sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.8
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
@@ -735,6 +958,82 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sentry-internal/browser-utils@10.47.0':
+    resolution: {integrity: sha512-bVFRAeJWMBcBCvJKIFCMJ1/yQToL4vPGqfmlnDZeypcxkqUDKQ/Y3ziLHXoDL2sx0lagcgU2vH1QhCQ67Aujjw==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/feedback@10.47.0':
+    resolution: {integrity: sha512-pdvMmi4dQpX5S/vAAzrhHPIw3T3HjUgDNgUiCBrlp7N9/6zGO2gNPhUnNekP+CjgI/z0rvf49RLqlDenpNrMOg==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay-canvas@10.47.0':
+    resolution: {integrity: sha512-A5OY8friSe6g8WAK4L8IeOPiEd9D3Ps40DzRH5j2f6SUja0t90mKMvHRcRf8zq0d4BkdB+JM7tjOkwxpuv8heA==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay@10.47.0':
+    resolution: {integrity: sha512-ScdovxP7hJxgMt70+7hFvwT02GIaIUAxdEM/YPsayZBeCoAukPW8WiwztJfoKtsfPyKJ5A6f0H3PIxTPcA9Row==}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@10.47.0':
+    resolution: {integrity: sha512-rC0agZdxKA5XWfL4VwPOr/rJMogXDqZgnVzr93YWpFn9DMZT/7LzxSJVPIJwRUjx3bFEby3PcTa3YaX7pxm1AA==}
+    engines: {node: '>=18'}
+
+  '@sentry/core@10.47.0':
+    resolution: {integrity: sha512-nsYRAx3EWezDut+Zl+UwwP07thh9uY7CfSAi2whTdcJl5hu1nSp2z8bba7Vq/MGbNLnazkd3A+GITBEML924JA==}
+    engines: {node: '>=18'}
+
+  '@sentry/electron@7.11.0':
+    resolution: {integrity: sha512-AKz66R/o/tULOg23zJyQZU2RK2uyV7PRYEWxDeyGDIfJeg+tXN1Zwjf/WuPcpoVE3xsXcCGBReboqMLgff587Q==}
+    peerDependencies:
+      '@sentry/node-native': 10.47.0
+    peerDependenciesMeta:
+      '@sentry/node-native':
+        optional: true
+
+  '@sentry/node-core@10.47.0':
+    resolution: {integrity: sha512-qv6LsqHbkQmd0aQEUox/svRSz26J+l4gGjFOUNEay2armZu9XLD+Ct89jpFgZD5oIPNAj2jraodTRqydXiwS5w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/context-async-hooks': ^1.30.1 || ^2.1.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/resources': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/context-async-hooks':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/resources':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      '@opentelemetry/semantic-conventions':
+        optional: true
+
+  '@sentry/node@10.47.0':
+    resolution: {integrity: sha512-R+btqPepv88o635G6HtVewLjqCLUedBg5HBs7Nq1qbbKvyti01uArUF2f+3DsLenk5B9LUNiRlE+frZA44Ahmw==}
+    engines: {node: '>=18'}
+
+  '@sentry/opentelemetry@10.47.0':
+    resolution: {integrity: sha512-f6Hw2lrpCjlOksiosP0Z2jK/+l+21SIdoNglVeG/sttMyx8C8ywONKh0Ha50sFsvB1VaB8n94RKzzf3hkh9V3g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/context-async-hooks': ^1.30.1 || ^2.1.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
@@ -836,6 +1135,9 @@ packages:
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -863,11 +1165,20 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/mysql@2.15.27':
+    resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
+
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
   '@types/node@25.3.5':
     resolution: {integrity: sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==}
+
+  '@types/pg-pool@2.0.7':
+    resolution: {integrity: sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==}
+
+  '@types/pg@8.15.6':
+    resolution: {integrity: sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==}
 
   '@types/plist@3.0.5':
     resolution: {integrity: sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==}
@@ -882,6 +1193,9 @@ packages:
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
+
+  '@types/tedious@4.0.14':
+    resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -905,6 +1219,16 @@ packages:
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -1081,6 +1405,9 @@ packages:
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
+
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -1389,6 +1716,9 @@ packages:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
+  forwarded-parse@2.1.2:
+    resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
+
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
@@ -1545,6 +1875,13 @@ packages:
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  import-in-the-middle@2.0.6:
+    resolution: {integrity: sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==}
+
+  import-in-the-middle@3.0.1:
+    resolution: {integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==}
+    engines: {node: '>=18'}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -1995,6 +2332,9 @@ packages:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
 
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2086,6 +2426,17 @@ packages:
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2110,6 +2461,22 @@ packages:
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   postject@1.0.0-alpha.6:
     resolution: {integrity: sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==}
@@ -2186,6 +2553,10 @@ packages:
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
+
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
   resedit@1.7.2:
     resolution: {integrity: sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==}
@@ -2542,6 +2913,10 @@ packages:
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
     engines: {node: '>=8.0'}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -2947,6 +3322,16 @@ snapshots:
   '@esbuild/win32-x64@0.27.4':
     optional: true
 
+  '@fastify/otel@0.18.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      minimatch: 10.2.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -3033,12 +3418,287 @@ snapshots:
   '@openai/codex@0.120.0-win32-x64':
     optional: true
 
+  '@opentelemetry/api-logs@0.207.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api-logs@0.212.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api-logs@0.214.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/context-async-hooks@2.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/instrumentation-amqplib@0.61.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-connect@0.57.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/connect': 3.4.38
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-dataloader@0.31.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-express@0.62.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-fs@0.33.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-generic-pool@0.57.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-graphql@0.62.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-hapi@0.60.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-http@0.214.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      forwarded-parse: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-ioredis@0.62.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/redis-common': 0.38.3
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-kafkajs@0.23.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-knex@0.58.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-koa@0.62.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-lru-memoizer@0.58.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mongodb@0.67.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mongoose@0.60.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mysql2@0.60.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mysql@0.60.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/mysql': 2.15.27
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-pg@0.66.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.1)
+      '@types/pg': 8.15.6
+      '@types/pg-pool': 2.0.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-redis@0.62.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/redis-common': 0.38.3
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-tedious@0.33.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/tedious': 4.0.14
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-undici@0.24.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.207.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.207.0
+      import-in-the-middle: 2.0.6
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.212.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.212.0
+      import-in-the-middle: 2.0.6
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.214.0
+      import-in-the-middle: 3.0.1
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/redis-common@0.38.3': {}
+
+  '@opentelemetry/resources@2.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/semantic-conventions@1.40.0': {}
+
+  '@opentelemetry/sql-common@0.41.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
   '@playwright/test@1.58.2':
     dependencies:
       playwright: 1.58.2
+
+  '@prisma/instrumentation@7.6.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.207.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
@@ -3114,6 +3774,107 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
+
+  '@sentry-internal/browser-utils@10.47.0':
+    dependencies:
+      '@sentry/core': 10.47.0
+
+  '@sentry-internal/feedback@10.47.0':
+    dependencies:
+      '@sentry/core': 10.47.0
+
+  '@sentry-internal/replay-canvas@10.47.0':
+    dependencies:
+      '@sentry-internal/replay': 10.47.0
+      '@sentry/core': 10.47.0
+
+  '@sentry-internal/replay@10.47.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.47.0
+      '@sentry/core': 10.47.0
+
+  '@sentry/browser@10.47.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.47.0
+      '@sentry-internal/feedback': 10.47.0
+      '@sentry-internal/replay': 10.47.0
+      '@sentry-internal/replay-canvas': 10.47.0
+      '@sentry/core': 10.47.0
+
+  '@sentry/core@10.47.0': {}
+
+  '@sentry/electron@7.11.0':
+    dependencies:
+      '@sentry/browser': 10.47.0
+      '@sentry/core': 10.47.0
+      '@sentry/node': 10.47.0
+    transitivePeerDependencies:
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+
+  '@sentry/node-core@10.47.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
+    dependencies:
+      '@sentry/core': 10.47.0
+      '@sentry/opentelemetry': 10.47.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      import-in-the-middle: 3.0.1
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@sentry/node@10.47.0':
+    dependencies:
+      '@fastify/otel': 0.18.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-amqplib': 0.61.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-connect': 0.57.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-dataloader': 0.31.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-express': 0.62.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-fs': 0.33.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-generic-pool': 0.57.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-graphql': 0.62.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-hapi': 0.60.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-http': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-ioredis': 0.62.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-kafkajs': 0.23.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-knex': 0.58.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-koa': 0.62.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-lru-memoizer': 0.58.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongodb': 0.67.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongoose': 0.60.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql': 0.60.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql2': 0.60.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-pg': 0.66.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-redis': 0.62.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-tedious': 0.33.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-undici': 0.24.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@prisma/instrumentation': 7.6.0(@opentelemetry/api@1.9.1)
+      '@sentry/core': 10.47.0
+      '@sentry/node-core': 10.47.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      '@sentry/opentelemetry': 10.47.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      import-in-the-middle: 3.0.1
+    transitivePeerDependencies:
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+
+  '@sentry/opentelemetry@10.47.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@sentry/core': 10.47.0
 
   '@sindresorhus/is@4.6.0': {}
 
@@ -3196,6 +3957,10 @@ snapshots:
       '@types/node': 25.3.5
       '@types/responselike': 1.0.3
 
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 25.3.5
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -3226,6 +3991,10 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/mysql@2.15.27':
+    dependencies:
+      '@types/node': 25.3.5
+
   '@types/node@22.19.15':
     dependencies:
       undici-types: 6.21.0
@@ -3233,6 +4002,16 @@ snapshots:
   '@types/node@25.3.5':
     dependencies:
       undici-types: 7.18.2
+
+  '@types/pg-pool@2.0.7':
+    dependencies:
+      '@types/pg': 8.15.6
+
+  '@types/pg@8.15.6':
+    dependencies:
+      '@types/node': 25.3.5
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
 
   '@types/plist@3.0.5':
     dependencies:
@@ -3249,6 +4028,10 @@ snapshots:
       csstype: 3.2.3
 
   '@types/responselike@1.0.3':
+    dependencies:
+      '@types/node': 25.3.5
+
+  '@types/tedious@4.0.14':
     dependencies:
       '@types/node': 25.3.5
 
@@ -3269,6 +4052,12 @@ snapshots:
   '@xmldom/xmldom@0.8.12': {}
 
   abbrev@3.0.1: {}
+
+  acorn-import-attributes@1.9.5(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
 
@@ -3489,6 +4278,8 @@ snapshots:
   ci-info@4.3.1: {}
 
   ci-info@4.4.0: {}
+
+  cjs-module-lexer@2.2.0: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -3893,6 +4684,8 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
+  forwarded-parse@2.1.2: {}
+
   fs-extra@10.1.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -4108,6 +4901,20 @@ snapshots:
       safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
+
+  import-in-the-middle@2.0.6:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 2.2.0
+      module-details-from-path: 1.0.4
+
+  import-in-the-middle@3.0.1:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 2.2.0
+      module-details-from-path: 1.0.4
 
   imurmurhash@0.1.4: {}
 
@@ -4725,6 +5532,8 @@ snapshots:
     dependencies:
       minimist: 1.2.8
 
+  module-details-from-path@1.0.4: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
@@ -4821,6 +5630,18 @@ snapshots:
 
   pend@1.2.0: {}
 
+  pg-int8@1.0.1: {}
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
@@ -4844,6 +5665,16 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   postject@1.0.0-alpha.6:
     dependencies:
@@ -4956,6 +5787,13 @@ snapshots:
       unified: 11.0.5
 
   require-directory@2.1.1: {}
+
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   resedit@1.7.2:
     dependencies:
@@ -5328,6 +6166,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   xmlbuilder@15.1.1: {}
+
+  xtend@4.0.2: {}
 
   y18n@5.0.8: {}
 

--- a/desktop/src/main/bug-reporting/bug-promotion-service.test.js
+++ b/desktop/src/main/bug-reporting/bug-promotion-service.test.js
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { decideDesktopBugPromotion } from "./bug-promotion-service.ts";
+
+test("decideDesktopBugPromotion skips reports that lack enough actionable detail", () => {
+  const decision = decideDesktopBugPromotion({
+    linearConfigured: true,
+    report: {
+      reportType: "manual",
+      title: "Bug",
+      description: "short",
+      expectedBehavior: null,
+      reproductionSteps: null,
+      attachments: [],
+    },
+  });
+
+  assert.deepEqual(decision, {
+    disposition: "skip",
+    reason: "Report does not yet contain enough actionable detail for ticket creation.",
+    severity: "medium",
+  });
+});
+
+test("decideDesktopBugPromotion defers actionable reports when Linear is unavailable", () => {
+  const decision = decideDesktopBugPromotion({
+    linearConfigured: false,
+    report: {
+      reportType: "manual",
+      title: "Composer send button stopped working",
+      description: "Clicking send does nothing after switching threads twice.",
+      expectedBehavior: null,
+      reproductionSteps: null,
+      attachments: [],
+    },
+  });
+
+  assert.equal(decision.disposition, "deferred");
+  assert.equal(decision.severity, "medium");
+});
+
+test("decideDesktopBugPromotion creates tickets for actionable manual reports when Linear is configured", () => {
+  const decision = decideDesktopBugPromotion({
+    linearConfigured: true,
+    report: {
+      reportType: "manual",
+      title: "Desktop crashes on launch",
+      description: "The app crashes immediately after sign-in and blocks all work.",
+      expectedBehavior: null,
+      reproductionSteps: null,
+      attachments: [],
+    },
+  });
+
+  assert.equal(decision.disposition, "create");
+  assert.equal(decision.severity, "high");
+});

--- a/desktop/src/main/bug-reporting/bug-promotion-service.ts
+++ b/desktop/src/main/bug-reporting/bug-promotion-service.ts
@@ -1,0 +1,68 @@
+import type { DesktopBugPromotionDisposition, DesktopBugReportDraft, DesktopBugSeverity } from "../../shared/contracts/bug-reporting.ts";
+
+export interface DesktopBugPromotionDecision {
+  readonly disposition: DesktopBugPromotionDisposition;
+  readonly reason: string;
+  readonly severity: DesktopBugSeverity;
+}
+
+function normalizeWhitespace(value: string | null | undefined): string {
+  return String(value ?? "").replace(/\s+/g, " ").trim();
+}
+
+export function resolveDesktopBugSeverity(report: DesktopBugReportDraft): DesktopBugSeverity {
+  if (report.severity) {
+    return report.severity;
+  }
+
+  if (report.reportType === "automatic") {
+    return "high";
+  }
+
+  const description = normalizeWhitespace(report.description).toLowerCase();
+  if (/\bcrash|data loss|corrupt|blocked|broken\b/.test(description)) {
+    return "high";
+  }
+
+  return "medium";
+}
+
+export function decideDesktopBugPromotion(options: {
+  readonly linearConfigured: boolean;
+  readonly report: DesktopBugReportDraft;
+}): DesktopBugPromotionDecision {
+  const { linearConfigured, report } = options;
+  const title = normalizeWhitespace(report.title);
+  const description = normalizeWhitespace(report.description);
+  const severity = resolveDesktopBugSeverity(report);
+
+  if (!title || description.length < 10) {
+    return {
+      disposition: "skip",
+      reason: "Report does not yet contain enough actionable detail for ticket creation.",
+      severity,
+    };
+  }
+
+  if (!linearConfigured) {
+    return {
+      disposition: "deferred",
+      reason: "Linear is not configured in this environment, so promotion is deferred after Sentry ingestion.",
+      severity,
+    };
+  }
+
+  if (report.reportType === "automatic" && severity !== "critical" && severity !== "high") {
+    return {
+      disposition: "skip",
+      reason: "Automatic event did not meet the severity threshold for Linear promotion.",
+      severity,
+    };
+  }
+
+  return {
+    disposition: "create",
+    reason: "Report meets the actionability threshold for Linear ticket creation.",
+    severity,
+  };
+}

--- a/desktop/src/main/bug-reporting/desktop-bug-reporting-service.test.js
+++ b/desktop/src/main/bug-reporting/desktop-bug-reporting-service.test.js
@@ -1,0 +1,102 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { DesktopBugReportingService } from "./desktop-bug-reporting-service.ts";
+
+test("DesktopBugReportingService submits reports to Sentry and defers Linear when not configured", async () => {
+  const captured = [];
+  const service = new DesktopBugReportingService({
+    env: {
+      HOME: "/Users/george",
+    },
+    runtimeInfo: {
+      apiVersion: "1.0.0",
+      appVersion: "0.11.0",
+      electronVersion: "35.2.1",
+      platform: "darwin",
+      startedAt: "2026-04-20T07:00:00.000Z",
+    },
+    getBootstrap: async () => ({
+      profile: {
+        id: "default",
+        source: "default",
+        rootPath: "/tmp/runtime",
+        codexHome: "/tmp/codex",
+      },
+      auth: {
+        isSignedIn: true,
+        email: "george@example.com",
+        accountType: "chatgpt",
+        requiresOpenaiAuth: false,
+      },
+      runtime: {
+        apiVersion: "1.0.0",
+        appVersion: "0.11.0",
+        electronVersion: "35.2.1",
+        platform: "darwin",
+        startedAt: "2026-04-20T07:00:00.000Z",
+        state: "running",
+        lastError: null,
+        restartCount: 0,
+        lastStateAt: "2026-04-20T07:00:00.000Z",
+      },
+      profileId: "default",
+      profileOptions: [],
+      isSignedIn: true,
+      accountEmail: "george@example.com",
+      runtimeStatus: { appVersion: "0.11.0", platform: "darwin" },
+      runtimeSetup: null,
+      tenant: null,
+      teamSetup: {
+        mode: "local",
+        source: "desktopLocal",
+        canWorkLocally: true,
+        canCreateFirstTeam: true,
+        canManageTeam: true,
+      },
+      runContext: null,
+      auditEvents: [],
+      recentThreads: [],
+      recentFolders: [],
+      workspaceSidebarOrder: [],
+      lastSelectedThreadId: null,
+      selectedThread: null,
+      pendingApprovals: [],
+    }),
+    getVisibleThreadContext: () => ({
+      id: "thread-1",
+      title: "Broken composer flow",
+      workspaceRoot: "/Users/george/project",
+      cwd: "/Users/george/project",
+    }),
+    getRecentLogs: () => [{
+      level: "error",
+      message: "OPENAI_API_KEY=abc123",
+      timestamp: "2026-04-20T07:10:00.000Z",
+    }],
+    captureManualBugReport: ({ report, context }) => {
+      captured.push({ report, context });
+      return "evt_123";
+    },
+  });
+
+  const result = await service.submitReport({
+    reportType: "manual",
+    title: "Composer send button stopped working",
+    description: "Clicking send does nothing after switching threads twice.",
+    expectedBehavior: "The current prompt should submit immediately.",
+    reproductionSteps: "Switch threads twice and click send.",
+    attachments: [{
+      kind: "file",
+      path: "/Users/george/Desktop/screenshot.png",
+      mimeType: "image/png",
+    }],
+  });
+
+  assert.equal(captured.length, 1);
+  assert.equal(captured[0]?.report.attachments[0]?.path, "~/Desktop/screenshot.png");
+  assert.equal(captured[0]?.context.thread?.workspaceRoot, "~/project");
+  assert.equal(captured[0]?.context.thread?.cwd, "~/project");
+  assert.equal(result.sentryEventId, "evt_123");
+  assert.equal(result.promotionDisposition, "deferred");
+});

--- a/desktop/src/main/bug-reporting/desktop-bug-reporting-service.test.js
+++ b/desktop/src/main/bug-reporting/desktop-bug-reporting-service.test.js
@@ -100,3 +100,121 @@ test("DesktopBugReportingService submits reports to Sentry and defers Linear whe
   assert.equal(result.sentryEventId, "evt_123");
   assert.equal(result.promotionDisposition, "deferred");
 });
+
+test("DesktopBugReportingService defers gracefully when Linear issue creation fails after Sentry capture", async () => {
+  const captured = [];
+  const service = new DesktopBugReportingService({
+    env: {
+      USERPROFILE: "C:\\Users\\George",
+    },
+    runtimeInfo: {
+      apiVersion: "1.0.0",
+      appVersion: "0.11.0",
+      electronVersion: "35.2.1",
+      platform: "win32",
+      startedAt: "2026-04-20T07:00:00.000Z",
+    },
+    getBootstrap: async () => ({
+      profile: {
+        id: "default",
+        source: "default",
+        rootPath: "C:\\runtime",
+        codexHome: "C:\\codex",
+      },
+      auth: {
+        isSignedIn: true,
+        email: "george@example.com",
+        accountType: "chatgpt",
+        requiresOpenaiAuth: false,
+      },
+      runtime: {
+        apiVersion: "1.0.0",
+        appVersion: "0.11.0",
+        electronVersion: "35.2.1",
+        platform: "win32",
+        startedAt: "2026-04-20T07:00:00.000Z",
+        state: "running",
+        lastError: null,
+        restartCount: 0,
+        lastStateAt: "2026-04-20T07:00:00.000Z",
+      },
+      profileId: "default",
+      profileOptions: [],
+      isSignedIn: true,
+      accountEmail: "george@example.com",
+      runtimeStatus: { appVersion: "0.11.0", platform: "win32" },
+      runtimeSetup: null,
+      tenant: null,
+      teamSetup: {
+        mode: "local",
+        source: "desktopLocal",
+        canWorkLocally: true,
+        canCreateFirstTeam: true,
+        canManageTeam: true,
+      },
+      runContext: null,
+      auditEvents: [],
+      recentThreads: [],
+      recentFolders: [],
+      workspaceSidebarOrder: [],
+      lastSelectedThreadId: null,
+      selectedThread: null,
+      pendingApprovals: [],
+    }),
+    getVisibleThreadContext: () => ({
+      id: "thread-2",
+      title: "Windows path leak",
+      workspaceRoot: "C:\\Users\\George\\project",
+      cwd: "C:\\Users\\George\\project",
+    }),
+    getRecentLogs: () => [{
+      level: "error",
+      message: "OPENAI_API_KEY=abc123 C:\\Users\\George\\project",
+      timestamp: "2026-04-20T07:10:00.000Z",
+    }],
+    captureManualBugReport: ({ report, context }) => {
+      captured.push({ report, context });
+      return "evt_456";
+    },
+    linearIssueAdapter: /** @type {any} */ ({
+      isConfigured: () => true,
+      createIssue: async () => {
+        throw new Error("403 Forbidden");
+      },
+    }),
+  });
+
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => {
+    warnings.push(args.join(" "));
+  };
+
+  try {
+    const result = await service.submitReport({
+      reportType: "manual",
+      title: "Save action fails on Windows",
+      description: "Saving after opening the workspace fails and should create a ticket.",
+      expectedBehavior: null,
+      reproductionSteps: null,
+      severity: "high",
+      attachments: [{
+        kind: "file",
+        path: "C:\\Users\\George\\Desktop\\screenshot.png",
+        mimeType: "image/png",
+      }],
+    });
+
+    assert.equal(captured.length, 1);
+    assert.equal(captured[0]?.report.attachments[0]?.path, "~\\Desktop\\screenshot.png");
+    assert.equal(captured[0]?.context.thread?.workspaceRoot, "~\\project");
+    assert.equal(captured[0]?.context.thread?.cwd, "~\\project");
+    assert.equal(result.sentryEventId, "evt_456");
+    assert.equal(result.promotionDisposition, "deferred");
+    assert.equal(result.linearIssueId, null);
+    assert.match(result.promotionReason, /deferred/i);
+    assert.equal(warnings.length, 1);
+  } finally {
+    console.warn = originalWarn;
+  }
+});

--- a/desktop/src/main/bug-reporting/desktop-bug-reporting-service.ts
+++ b/desktop/src/main/bug-reporting/desktop-bug-reporting-service.ts
@@ -9,7 +9,7 @@ import type { RuntimeInfoResult } from "../../shared/contracts/runtime.ts";
 import type { DesktopLogEntry } from "../logging/desktop-log-buffer.ts";
 import { decideDesktopBugPromotion } from "./bug-promotion-service.ts";
 import { LinearIssueAdapter } from "./linear-issue-adapter.ts";
-import { redactLogEntries, redactSensitivePath, redactSensitiveText } from "./redaction.ts";
+import { redactLogEntries, redactSensitivePath, redactSensitiveText, resolveRedactionHomeDir } from "./redaction.ts";
 
 export interface DesktopBugReportingThreadContext {
   readonly id: string | null;
@@ -106,7 +106,7 @@ export class DesktopBugReportingService {
 
   async submitReport(report: DesktopBugReportDraft): Promise<DesktopBugReportResult> {
     const bootstrap = await this.#getBootstrap();
-    const homeDir = firstNonEmptyString(this.#env.HOME) ?? null;
+    const homeDir = resolveRedactionHomeDir(this.#env);
     const thread = normalizeThreadContext(this.#getVisibleThreadContext(), homeDir);
     const sanitizedReport: DesktopBugReportDraft = {
       ...report,
@@ -146,17 +146,31 @@ export class DesktopBugReportingService {
       };
     }
 
-    const linearIssue = await this.#linearIssueAdapter.createIssue({
-      title: sanitizedReport.title,
-      severity: promotionDecision.severity,
-      description: this.#buildLinearIssueDescription({
-        bootstrap,
-        recentLogs,
-        report: sanitizedReport,
+    let linearIssue;
+    try {
+      linearIssue = await this.#linearIssueAdapter.createIssue({
+        title: sanitizedReport.title,
+        severity: promotionDecision.severity,
+        description: this.#buildLinearIssueDescription({
+          bootstrap,
+          recentLogs,
+          report: sanitizedReport,
+          sentryEventId,
+          thread,
+        }),
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.warn(`[desktop:bug-reporting] Failed to create Linear issue after Sentry capture: ${errorMessage}`);
+      return {
         sentryEventId,
-        thread,
-      }),
-    });
+        sentryIssueUrl: null,
+        promotionDisposition: "deferred",
+        promotionReason: "Sentry captured the report, but Linear ticket creation failed and was deferred.",
+        linearIssueId: null,
+        linearIssueUrl: null,
+      };
+    }
 
     return {
       sentryEventId,

--- a/desktop/src/main/bug-reporting/desktop-bug-reporting-service.ts
+++ b/desktop/src/main/bug-reporting/desktop-bug-reporting-service.ts
@@ -1,0 +1,216 @@
+import type {
+  DesktopBugAttachment,
+  DesktopBugReportDraft,
+  DesktopBugReportResult,
+  DesktopBugReportingStatus,
+} from "../../shared/contracts/bug-reporting.ts";
+import type { DesktopBootstrap } from "../../shared/contracts/bootstrap.ts";
+import type { RuntimeInfoResult } from "../../shared/contracts/runtime.ts";
+import type { DesktopLogEntry } from "../logging/desktop-log-buffer.ts";
+import { decideDesktopBugPromotion } from "./bug-promotion-service.ts";
+import { LinearIssueAdapter } from "./linear-issue-adapter.ts";
+import { redactLogEntries, redactSensitivePath, redactSensitiveText } from "./redaction.ts";
+
+export interface DesktopBugReportingThreadContext {
+  readonly id: string | null;
+  readonly title: string | null;
+  readonly workspaceRoot: string | null;
+  readonly cwd: string | null;
+}
+
+export interface CaptureManualBugReportInput {
+  readonly report: DesktopBugReportDraft;
+  readonly severity: string;
+  readonly context: {
+    readonly runtimeInfo: RuntimeInfoResult;
+    readonly thread: DesktopBugReportingThreadContext | null;
+    readonly accountEmail: string | null;
+    readonly tenantName: string | null;
+    readonly recentLogs: DesktopLogEntry[];
+  };
+}
+
+type CaptureManualBugReport = (input: CaptureManualBugReportInput) => string;
+
+function firstNonEmptyString(...values: Array<unknown>): string | null {
+  for (const value of values) {
+    if (typeof value !== "string") {
+      continue;
+    }
+    const trimmed = value.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return null;
+}
+
+function normalizeAttachment(attachment: DesktopBugAttachment, homeDir: string | null): DesktopBugAttachment {
+  return {
+    ...attachment,
+    path: redactSensitivePath(attachment.path, homeDir),
+  };
+}
+
+function normalizeThreadContext(
+  thread: DesktopBugReportingThreadContext | null,
+  homeDir: string | null,
+): DesktopBugReportingThreadContext | null {
+  if (!thread) {
+    return null;
+  }
+
+  return {
+    ...thread,
+    workspaceRoot: thread.workspaceRoot ? redactSensitivePath(thread.workspaceRoot, homeDir) : null,
+    cwd: thread.cwd ? redactSensitivePath(thread.cwd, homeDir) : null,
+  };
+}
+
+export class DesktopBugReportingService {
+  readonly #env: NodeJS.ProcessEnv;
+  readonly #runtimeInfo: RuntimeInfoResult;
+  readonly #getBootstrap: () => Promise<DesktopBootstrap>;
+  readonly #getVisibleThreadContext: () => DesktopBugReportingThreadContext | null;
+  readonly #getRecentLogs: (limit?: number) => DesktopLogEntry[];
+  readonly #captureManualBugReport: CaptureManualBugReport;
+  readonly #linearIssueAdapter: LinearIssueAdapter;
+
+  constructor(options: {
+    readonly env?: NodeJS.ProcessEnv;
+    readonly runtimeInfo: RuntimeInfoResult;
+    readonly getBootstrap: () => Promise<DesktopBootstrap>;
+    readonly getVisibleThreadContext: () => DesktopBugReportingThreadContext | null;
+    readonly getRecentLogs: (limit?: number) => DesktopLogEntry[];
+    readonly captureManualBugReport?: CaptureManualBugReport;
+    readonly linearIssueAdapter?: LinearIssueAdapter;
+  }) {
+    this.#env = options.env ?? process.env;
+    this.#runtimeInfo = options.runtimeInfo;
+    this.#getBootstrap = options.getBootstrap;
+    this.#getVisibleThreadContext = options.getVisibleThreadContext;
+    this.#getRecentLogs = options.getRecentLogs;
+    this.#captureManualBugReport = options.captureManualBugReport ?? (() => {
+      throw new Error("captureManualBugReport must be provided by the Electron main process.");
+    });
+    this.#linearIssueAdapter = options.linearIssueAdapter ?? new LinearIssueAdapter({ env: this.#env });
+  }
+
+  getStatus(): DesktopBugReportingStatus {
+    return {
+      sentryEnabled: true,
+      linearConfigured: this.#linearIssueAdapter.isConfigured(),
+      linearIntegrationMode: this.#linearIssueAdapter.isConfigured() ? "directApi" : "sentryIntegrationOnly",
+    };
+  }
+
+  async submitReport(report: DesktopBugReportDraft): Promise<DesktopBugReportResult> {
+    const bootstrap = await this.#getBootstrap();
+    const homeDir = firstNonEmptyString(this.#env.HOME) ?? null;
+    const thread = normalizeThreadContext(this.#getVisibleThreadContext(), homeDir);
+    const sanitizedReport: DesktopBugReportDraft = {
+      ...report,
+      title: redactSensitiveText(report.title.trim()),
+      description: redactSensitiveText(report.description.trim()),
+      expectedBehavior: report.expectedBehavior ? redactSensitiveText(report.expectedBehavior.trim()) : null,
+      reproductionSteps: report.reproductionSteps ? redactSensitiveText(report.reproductionSteps.trim()) : null,
+      attachments: report.attachments.map((attachment) => normalizeAttachment(attachment, homeDir)),
+    };
+    const recentLogs = redactLogEntries(this.#getRecentLogs(25), homeDir);
+
+    const promotionDecision = decideDesktopBugPromotion({
+      linearConfigured: this.#linearIssueAdapter.isConfigured(),
+      report: sanitizedReport,
+    });
+
+    const sentryEventId = this.#captureManualBugReport({
+      report: sanitizedReport,
+      severity: promotionDecision.severity,
+      context: {
+        runtimeInfo: this.#runtimeInfo,
+        thread,
+        accountEmail: bootstrap.accountEmail,
+        tenantName: bootstrap.tenant?.displayName ?? null,
+        recentLogs,
+      },
+    });
+
+    if (promotionDecision.disposition !== "create") {
+      return {
+        sentryEventId,
+        sentryIssueUrl: null,
+        promotionDisposition: promotionDecision.disposition,
+        promotionReason: promotionDecision.reason,
+        linearIssueId: null,
+        linearIssueUrl: null,
+      };
+    }
+
+    const linearIssue = await this.#linearIssueAdapter.createIssue({
+      title: sanitizedReport.title,
+      severity: promotionDecision.severity,
+      description: this.#buildLinearIssueDescription({
+        bootstrap,
+        recentLogs,
+        report: sanitizedReport,
+        sentryEventId,
+        thread,
+      }),
+    });
+
+    return {
+      sentryEventId,
+      sentryIssueUrl: null,
+      promotionDisposition: "create",
+      promotionReason: promotionDecision.reason,
+      linearIssueId: linearIssue.id,
+      linearIssueUrl: linearIssue.url,
+    };
+  }
+
+  #buildLinearIssueDescription(options: {
+    readonly bootstrap: DesktopBootstrap;
+    readonly recentLogs: DesktopLogEntry[];
+    readonly report: DesktopBugReportDraft;
+    readonly sentryEventId: string;
+    readonly thread: DesktopBugReportingThreadContext | null;
+  }): string {
+    const { bootstrap, recentLogs, report, sentryEventId, thread } = options;
+    const details = [
+      report.description,
+      "",
+      "### Diagnostics",
+      `- Sentry event ID: \`${sentryEventId}\``,
+      `- App version: \`${this.#runtimeInfo.appVersion}\``,
+      `- Electron: \`${this.#runtimeInfo.electronVersion}\``,
+      `- Platform: \`${this.#runtimeInfo.platform}\``,
+      `- Account: ${bootstrap.accountEmail ?? "unknown"}`,
+      `- Tenant: ${bootstrap.tenant?.displayName ?? "local"}`,
+      `- Thread ID: ${thread?.id ?? "none"}`,
+      `- Workspace root: ${thread?.workspaceRoot ?? "none"}`,
+      `- CWD: ${thread?.cwd ?? "none"}`,
+    ];
+
+    if (report.expectedBehavior) {
+      details.push("", "### Expected behavior", report.expectedBehavior);
+    }
+    if (report.reproductionSteps) {
+      details.push("", "### Reproduction steps", report.reproductionSteps);
+    }
+    if (report.attachments.length > 0) {
+      details.push("", "### Attachment metadata");
+      for (const attachment of report.attachments) {
+        details.push(`- ${attachment.kind}: \`${attachment.path}\``);
+      }
+    }
+    if (recentLogs.length > 0) {
+      details.push("", "### Recent redacted logs", "```text");
+      for (const entry of recentLogs.slice(-10)) {
+        details.push(`[${entry.timestamp}] ${entry.level.toUpperCase()} ${entry.message}`);
+      }
+      details.push("```");
+    }
+
+    return details.join("\n");
+  }
+}

--- a/desktop/src/main/bug-reporting/linear-issue-adapter.test.js
+++ b/desktop/src/main/bug-reporting/linear-issue-adapter.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { LinearIssueAdapter } from "./linear-issue-adapter.ts";
+
+test("LinearIssueAdapter reports configuration state from env", () => {
+  const adapter = new LinearIssueAdapter({
+    env: {
+      SENSE1_LINEAR_API_KEY: "linear-key",
+      SENSE1_LINEAR_TEAM_ID: "team-123",
+    },
+    fetchImpl: fetch,
+  });
+
+  assert.equal(adapter.isConfigured(), true);
+});
+
+test("LinearIssueAdapter creates issues through Linear GraphQL", async () => {
+  const calls = [];
+  const adapter = new LinearIssueAdapter({
+    env: {
+      SENSE1_LINEAR_API_KEY: "linear-key",
+      SENSE1_LINEAR_TEAM_ID: "team-123",
+      SENSE1_LINEAR_WORKSPACE_URL: "sense-1",
+    },
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      return new Response(JSON.stringify({
+        data: {
+          issueCreate: {
+            success: true,
+            issue: {
+              id: "issue_123",
+              identifier: "SEN-42",
+            },
+          },
+        },
+      }), { status: 200, headers: { "Content-Type": "application/json" } });
+    },
+  });
+
+  const result = await adapter.createIssue({
+    title: "Composer send button stopped working",
+    description: "Detailed markdown body",
+    severity: "high",
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(result.id, "issue_123");
+  assert.equal(result.url, "https://linear.app/sense-1/issue/SEN-42");
+});

--- a/desktop/src/main/bug-reporting/linear-issue-adapter.ts
+++ b/desktop/src/main/bug-reporting/linear-issue-adapter.ts
@@ -1,0 +1,121 @@
+import type { DesktopBugSeverity } from "../../shared/contracts/bug-reporting.ts";
+
+const LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql";
+
+export interface LinearIssueCreateInput {
+  readonly title: string;
+  readonly description: string;
+  readonly severity: DesktopBugSeverity;
+}
+
+export interface LinearIssueCreateResult {
+  readonly id: string;
+  readonly identifier: string | null;
+  readonly url: string | null;
+}
+
+type FetchLike = typeof fetch;
+
+function firstNonEmptyString(...values: Array<unknown>): string | null {
+  for (const value of values) {
+    if (typeof value !== "string") {
+      continue;
+    }
+    const trimmed = value.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return null;
+}
+
+export class LinearIssueAdapter {
+  readonly #apiKey: string | null;
+  readonly #teamId: string | null;
+  readonly #workspaceUrl: string | null;
+  readonly #fetchImpl: FetchLike;
+
+  constructor(options: {
+    readonly env?: NodeJS.ProcessEnv;
+    readonly fetchImpl?: FetchLike;
+  } = {}) {
+    const env = options.env ?? process.env;
+    this.#apiKey = firstNonEmptyString(env.SENSE1_LINEAR_API_KEY);
+    this.#teamId = firstNonEmptyString(env.SENSE1_LINEAR_TEAM_ID);
+    this.#workspaceUrl = firstNonEmptyString(env.SENSE1_LINEAR_WORKSPACE_URL);
+    this.#fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  isConfigured(): boolean {
+    return Boolean(this.#apiKey && this.#teamId);
+  }
+
+  async createIssue(input: LinearIssueCreateInput): Promise<LinearIssueCreateResult> {
+    if (!this.#apiKey || !this.#teamId) {
+      throw new Error("Linear issue creation requires SENSE1_LINEAR_API_KEY and SENSE1_LINEAR_TEAM_ID.");
+    }
+
+    const response = await this.#fetchImpl(LINEAR_GRAPHQL_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: this.#apiKey,
+      },
+      body: JSON.stringify({
+        query: `mutation IssueCreate($input: IssueCreateInput!) {
+          issueCreate(input: $input) {
+            success
+            issue {
+              id
+              identifier
+            }
+          }
+        }`,
+        variables: {
+          input: {
+            title: input.title,
+            description: input.description,
+            teamId: this.#teamId,
+          },
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Linear API request failed with status ${response.status}.`);
+    }
+
+    const payload = await response.json() as {
+      errors?: Array<{ message?: string }>;
+      data?: {
+        issueCreate?: {
+          success?: boolean;
+          issue?: {
+            id?: string;
+            identifier?: string | null;
+          } | null;
+        } | null;
+      };
+    };
+
+    if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+      throw new Error(payload.errors.map((entry) => entry.message || "Unknown Linear GraphQL error").join("; "));
+    }
+
+    const issue = payload.data?.issueCreate?.issue;
+    if (!payload.data?.issueCreate?.success || !issue?.id) {
+      throw new Error("Linear issue creation did not return a created issue.");
+    }
+
+    const identifier = typeof issue.identifier === "string" && issue.identifier.trim() ? issue.identifier.trim() : null;
+    const url = this.#workspaceUrl && identifier
+      ? `https://linear.app/${this.#workspaceUrl}/issue/${identifier}`
+      : null;
+
+    return {
+      id: issue.id,
+      identifier,
+      url,
+    };
+  }
+}

--- a/desktop/src/main/bug-reporting/redaction.test.js
+++ b/desktop/src/main/bug-reporting/redaction.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { redactLogEntries, redactSensitivePath, redactSensitiveText } from "./redaction.ts";
+import { redactLogEntries, redactSensitivePath, redactSensitiveText, resolveRedactionHomeDir } from "./redaction.ts";
 
 test("redactSensitiveText strips common secret patterns", () => {
   assert.equal(
@@ -33,4 +33,13 @@ test("redactLogEntries applies text and path redaction together", () => {
       timestamp: "2026-04-20T00:00:00.000Z",
     },
   ]);
+});
+
+test("resolveRedactionHomeDir falls back to USERPROFILE on Windows-like environments", () => {
+  assert.equal(
+    resolveRedactionHomeDir({
+      USERPROFILE: "C:\\Users\\George",
+    }),
+    "C:\\Users\\George",
+  );
 });

--- a/desktop/src/main/bug-reporting/redaction.test.js
+++ b/desktop/src/main/bug-reporting/redaction.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { redactLogEntries, redactSensitivePath, redactSensitiveText } from "./redaction.ts";
+
+test("redactSensitiveText strips common secret patterns", () => {
+  assert.equal(
+    redactSensitiveText("Authorization: Bearer secret-token OPENAI_API_KEY=abc123 sk-test-secret"),
+    "Authorization: Bearer [REDACTED] OPENAI_API_KEY=[REDACTED] sk-[REDACTED]",
+  );
+});
+
+test("redactSensitivePath shortens home-scoped paths", () => {
+  assert.equal(
+    redactSensitivePath("/Users/george/projects/sense-1", "/Users/george"),
+    "~/projects/sense-1",
+  );
+});
+
+test("redactLogEntries applies text and path redaction together", () => {
+  const entries = redactLogEntries([
+    {
+      level: "error",
+      message: "OPENAI_API_KEY=abc123 /Users/george/project",
+      timestamp: "2026-04-20T00:00:00.000Z",
+    },
+  ], "/Users/george");
+
+  assert.deepEqual(entries, [
+    {
+      level: "error",
+      message: "OPENAI_API_KEY=[REDACTED] ~/project",
+      timestamp: "2026-04-20T00:00:00.000Z",
+    },
+  ]);
+});

--- a/desktop/src/main/bug-reporting/redaction.ts
+++ b/desktop/src/main/bug-reporting/redaction.ts
@@ -1,3 +1,5 @@
+import os from "node:os";
+
 import type { DesktopLogEntry } from "../logging/desktop-log-buffer.ts";
 
 const SECRET_ASSIGNMENT_PATTERN = /\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_KEY|ACCESS_KEY)[A-Z0-9_]*)=([^\s]+)/gi;
@@ -8,6 +10,37 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function firstNonEmptyString(...values: Array<unknown>): string | null {
+  for (const value of values) {
+    if (typeof value !== "string") {
+      continue;
+    }
+
+    const trimmed = value.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  return null;
+}
+
+export function resolveRedactionHomeDir(env: NodeJS.ProcessEnv = process.env): string | null {
+  const windowsHome = firstNonEmptyString(env.HOMEDRIVE) && firstNonEmptyString(env.HOMEPATH)
+    ? `${firstNonEmptyString(env.HOMEDRIVE)}${firstNonEmptyString(env.HOMEPATH)}`
+    : null;
+  const configuredHome = firstNonEmptyString(env.HOME, env.USERPROFILE, windowsHome);
+  if (configuredHome) {
+    return configuredHome;
+  }
+
+  try {
+    return firstNonEmptyString(os.homedir());
+  } catch {
+    return null;
+  }
+}
+
 export function redactSensitiveText(input: string): string {
   return input
     .replace(SECRET_ASSIGNMENT_PATTERN, "$1=[REDACTED]")
@@ -15,7 +48,7 @@ export function redactSensitiveText(input: string): string {
     .replace(OPENAI_KEY_PATTERN, "sk-[REDACTED]");
 }
 
-export function redactSensitivePath(filePath: string, homeDir: string | null = process.env.HOME ?? null): string {
+export function redactSensitivePath(filePath: string, homeDir: string | null = resolveRedactionHomeDir()): string {
   const trimmed = String(filePath || "").trim();
   if (!trimmed) {
     return "";
@@ -27,7 +60,7 @@ export function redactSensitivePath(filePath: string, homeDir: string | null = p
   return trimmed;
 }
 
-export function redactLogEntries(entries: DesktopLogEntry[], homeDir: string | null = process.env.HOME ?? null): DesktopLogEntry[] {
+export function redactLogEntries(entries: DesktopLogEntry[], homeDir: string | null = resolveRedactionHomeDir()): DesktopLogEntry[] {
   return entries.map((entry) => ({
     ...entry,
     message: redactSensitivePath(redactSensitiveText(entry.message), homeDir),

--- a/desktop/src/main/bug-reporting/redaction.ts
+++ b/desktop/src/main/bug-reporting/redaction.ts
@@ -1,0 +1,35 @@
+import type { DesktopLogEntry } from "../logging/desktop-log-buffer.ts";
+
+const SECRET_ASSIGNMENT_PATTERN = /\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_KEY|ACCESS_KEY)[A-Z0-9_]*)=([^\s]+)/gi;
+const BEARER_PATTERN = /\bBearer\s+[^\s]+/gi;
+const OPENAI_KEY_PATTERN = /\bsk-[A-Za-z0-9_-]+\b/g;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function redactSensitiveText(input: string): string {
+  return input
+    .replace(SECRET_ASSIGNMENT_PATTERN, "$1=[REDACTED]")
+    .replace(BEARER_PATTERN, "Bearer [REDACTED]")
+    .replace(OPENAI_KEY_PATTERN, "sk-[REDACTED]");
+}
+
+export function redactSensitivePath(filePath: string, homeDir: string | null = process.env.HOME ?? null): string {
+  const trimmed = String(filePath || "").trim();
+  if (!trimmed) {
+    return "";
+  }
+  if (homeDir) {
+    const escapedHomeDir = escapeRegExp(homeDir);
+    return trimmed.replace(new RegExp(escapedHomeDir, "g"), "~");
+  }
+  return trimmed;
+}
+
+export function redactLogEntries(entries: DesktopLogEntry[], homeDir: string | null = process.env.HOME ?? null): DesktopLogEntry[] {
+  return entries.map((entry) => ({
+    ...entry,
+    message: redactSensitivePath(redactSensitiveText(entry.message), homeDir),
+  }));
+}

--- a/desktop/src/main/bug-reporting/sentry-reporting.ts
+++ b/desktop/src/main/bug-reporting/sentry-reporting.ts
@@ -1,0 +1,77 @@
+import * as Sentry from "@sentry/electron/main";
+
+import type { DesktopBugReportDraft } from "../../shared/contracts/bug-reporting.ts";
+import type { RuntimeInfoResult } from "../../shared/contracts/runtime.ts";
+
+export interface DesktopCapturedBugContext {
+  readonly runtimeInfo: RuntimeInfoResult;
+  readonly thread: {
+    readonly id: string | null;
+    readonly title: string | null;
+    readonly workspaceRoot: string | null;
+    readonly cwd: string | null;
+  } | null;
+  readonly accountEmail: string | null;
+  readonly tenantName: string | null;
+  readonly recentLogs: Array<{ readonly level: string; readonly message: string; readonly timestamp: string }>;
+}
+
+function normalizeFingerprintValue(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "report";
+}
+
+export function captureDesktopManualBugReport(options: {
+  readonly report: DesktopBugReportDraft;
+  readonly severity: string;
+  readonly context: DesktopCapturedBugContext;
+}): string {
+  const { context, report, severity } = options;
+  let eventId = "";
+
+  Sentry.withScope((scope) => {
+    scope.setLevel(severity === "critical" || severity === "high" ? "error" : "warning");
+    scope.setTag("sense1.report.type", report.reportType);
+    scope.setTag("sense1.report.severity", severity);
+    scope.setTag("sense1.report.source", "desktop-manual-report");
+    if (context.thread?.id) {
+      scope.setTag("sense1.thread.id", context.thread.id);
+    }
+    if (context.thread?.workspaceRoot) {
+      scope.setTag("sense1.workspace.root", context.thread.workspaceRoot);
+    }
+    scope.setFingerprint([
+      "sense1-manual-bug-report",
+      normalizeFingerprintValue(report.title || report.description),
+    ]);
+    scope.setContext("sense1BugReport", {
+      expectedBehavior: report.expectedBehavior,
+      reproductionSteps: report.reproductionSteps,
+      attachmentPaths: report.attachments.map((entry) => entry.path),
+    });
+    scope.setContext("sense1Diagnostics", {
+      appVersion: context.runtimeInfo.appVersion,
+      electronVersion: context.runtimeInfo.electronVersion,
+      platform: context.runtimeInfo.platform,
+      startedAt: context.runtimeInfo.startedAt,
+      thread: context.thread,
+      tenantName: context.tenantName,
+      recentLogs: context.recentLogs,
+    });
+    if (context.accountEmail) {
+      scope.setUser({ email: context.accountEmail });
+    }
+    scope.setExtra("description", report.description);
+    if (report.expectedBehavior) {
+      scope.setExtra("expectedBehavior", report.expectedBehavior);
+    }
+    if (report.reproductionSteps) {
+      scope.setExtra("reproductionSteps", report.reproductionSteps);
+    }
+    if (report.attachments.length > 0) {
+      scope.setExtra("attachmentMetadata", report.attachments);
+    }
+    eventId = Sentry.captureMessage(report.title || "Desktop bug report");
+  });
+
+  return eventId;
+}

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -6,6 +6,9 @@ import {
   type DesktopAppRemoveRequest,
   type DesktopAppInstallRequest,
   type DesktopAppEnabledRequest,
+  type DesktopBugReportDraft,
+  type DesktopBugReportResult,
+  type DesktopBugReportingStatus,
   type DesktopMcpServerAuthRequest,
   type DesktopMcpServerAuthResult,
   type DesktopAutomationDeleteRequest,
@@ -96,6 +99,8 @@ let pendingThreadDeltaFlushTimer: NodeJS.Timeout | null = null;
 
 type DesktopIpcServices = {
   getBootstrap(): Promise<DesktopBootstrap>;
+  submitDesktopBugReport(request: DesktopBugReportDraft): Promise<DesktopBugReportResult>;
+  getDesktopBugReportingStatus(): Promise<DesktopBugReportingStatus>;
   getRuntimeInfo(): RuntimeInfoResult;
   getUpdateState(): Promise<DesktopUpdateState>;
   checkForUpdates(): Promise<DesktopUpdateState>;
@@ -194,6 +199,20 @@ export function registerDesktopIpcHandlers(services: DesktopIpcServices): void {
   ipcMain.handle(IPC_CHANNELS.getDesktopBootstrap, async (): Promise<DesktopBootstrap> => {
     return await services.getBootstrap();
   });
+
+  ipcMain.handle(
+    IPC_CHANNELS.submitDesktopBugReport,
+    async (_event, request: DesktopBugReportDraft): Promise<DesktopBugReportResult> => {
+      return await services.submitDesktopBugReport(request);
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.getDesktopBugReportingStatus,
+    async (): Promise<DesktopBugReportingStatus> => {
+      return await services.getDesktopBugReportingStatus();
+    },
+  );
 
   ipcMain.handle(
     IPC_CHANNELS.rememberLastSelectedThread,

--- a/desktop/src/main/logging/desktop-log-buffer.ts
+++ b/desktop/src/main/logging/desktop-log-buffer.ts
@@ -1,0 +1,76 @@
+export interface DesktopLogEntry {
+  readonly level: "log" | "info" | "warn" | "error";
+  readonly message: string;
+  readonly timestamp: string;
+}
+
+export interface DesktopLogBuffer {
+  push(entry: DesktopLogEntry): void;
+  list(limit?: number): DesktopLogEntry[];
+}
+
+function stringifyLogArg(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (value instanceof Error) {
+    return value.stack ?? value.message;
+  }
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export function formatDesktopLogMessage(args: unknown[]): string {
+  return args.map((value) => stringifyLogArg(value)).join(" ").trim();
+}
+
+export function createDesktopLogBuffer(limit = 200): DesktopLogBuffer {
+  const entries: DesktopLogEntry[] = [];
+
+  return {
+    push(entry: DesktopLogEntry): void {
+      entries.push(entry);
+      if (entries.length > limit) {
+        entries.splice(0, entries.length - limit);
+      }
+    },
+    list(maxEntries = 50): DesktopLogEntry[] {
+      if (maxEntries <= 0) {
+        return [];
+      }
+      return entries.slice(-maxEntries);
+    },
+  };
+}
+
+export function installDesktopLogBuffer(
+  buffer: DesktopLogBuffer,
+  consoleLike: Console = console,
+): void {
+  const installKey = "__sense1LogBufferInstalled";
+  const taggedConsole = consoleLike as Console & { [installKey]?: boolean };
+  if (taggedConsole[installKey] === true) {
+    return;
+  }
+
+  const levels = ["log", "info", "warn", "error"] as const;
+
+  for (const level of levels) {
+    const original = consoleLike[level].bind(consoleLike);
+    consoleLike[level] = ((...args: unknown[]) => {
+      buffer.push({
+        level,
+        message: formatDesktopLogMessage(args),
+        timestamp: new Date().toISOString(),
+      });
+      original(...args);
+    }) as Console[typeof level];
+  }
+
+  taggedConsole[installKey] = true;
+}

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, Notification, nativeImage, shell } from "electron";
+import * as Sentry from "@sentry/electron/main";
 
 import { AppServerProcessManager } from "./runtime/app-server-process-manager.js";
 import { DESKTOP_APP_VERSION } from "./app/app-version.ts";
@@ -35,11 +36,23 @@ import {
   coalesceRuntimeNotifications,
   type RuntimeNotification,
 } from "./session/runtime-notification-coalescer.ts";
+import {
+  resolveSentryDsn,
+  resolveSentryEnvironment,
+  resolveSentryRelease,
+  shouldEnableSentryDebug,
+} from "../shared/sentry.ts";
 import type { DesktopBootstrap, DesktopSteerTurnResult, DesktopTaskRunResult, DesktopThreadInputState, DesktopThreadReadResult, DesktopThreadSnapshot, DesktopThreadSummary } from "../shared/contracts/index";
 
 const DESKTOP_APP_NAME = "Sense-1 Workspace";
 const LATEST_RELEASE_URL = "https://github.com/georgestander/sense-1-workspace/releases/latest";
 const shouldEnforceSingleInstance = process.env.NODE_ENV !== "test";
+Sentry.init({
+  dsn: resolveSentryDsn(process.env),
+  environment: resolveSentryEnvironment(process.env),
+  release: resolveSentryRelease(DESKTOP_APP_VERSION),
+  debug: shouldEnableSentryDebug(process.env),
+});
 app.setName(DESKTOP_APP_NAME);
 const isSingleInstance = shouldEnforceSingleInstance ? app.requestSingleInstanceLock() : true;
 const appServerManager = new AppServerProcessManager();

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -32,6 +32,10 @@ import { resolveDesktopInteractionState } from "./session/interaction-state.ts";
 import { ThreadInputQueueService } from "./session/thread-input-queue-service.ts";
 import { resolveBootstrapVisibleThreadId, shouldRestoreQueuedFollowUp } from "./session/thread-runtime-behavior.ts";
 import { RuntimeFileChangeTracker } from "./session/runtime-file-change-tracker.ts";
+import { DesktopBugReportingService } from "./bug-reporting/desktop-bug-reporting-service.ts";
+import { redactSensitivePath } from "./bug-reporting/redaction.ts";
+import { captureDesktopManualBugReport } from "./bug-reporting/sentry-reporting.ts";
+import { createDesktopLogBuffer, installDesktopLogBuffer } from "./logging/desktop-log-buffer.ts";
 import {
   coalesceRuntimeNotifications,
   type RuntimeNotification,
@@ -67,6 +71,8 @@ const runtimeInfo = {
 const SHOULD_LOG_RUNTIME_EVENTS = process.env.SENSE1_DEBUG_RUNTIME_EVENTS === "1";
 const SHOULD_DEBUG_RUNTIME_PERF = process.env.SENSE1_DEBUG_PERF === "1";
 const ACCUMULATOR_STREAM_FLUSH_MS = 16;
+const desktopLogBuffer = createDesktopLogBuffer();
+installDesktopLogBuffer(desktopLogBuffer);
 const threadAccumulator = new ThreadStateAccumulator();
 const threadInputQueue = new ThreadInputQueueService();
 const workspaceFileActivity = new WorkspaceFileActivityTracker();
@@ -167,6 +173,9 @@ function processAccumulatorNotification(
   const threadId = typeof params?.threadId === "string" ? params.threadId.trim() : "";
   if (threadId && deltas.length > 0) {
     touchedThreadIds.add(threadId);
+    if (threadId === currentVisibleThreadId) {
+      syncSentryThreadScope();
+    }
   }
 }
 
@@ -267,6 +276,9 @@ function initializeActiveThread(result: {
   }
   emitThreadInputStateDelta(result.threadId, threadInputQueue.markThreadStarted(result.threadId));
   syncUpdaterBusyState();
+  if (currentVisibleThreadId === result.threadId) {
+    syncSentryThreadScope();
+  }
   void persistInteractionState(result.threadId).catch(() => {});
 }
 
@@ -354,8 +366,74 @@ function emitThreadInputStateDelta(threadId: string, threadInputState: DesktopTh
   emitDesktopThreadDelta(threadAccumulator.setThreadInputState(threadId, threadInputState));
 }
 
+function redactSentryScopePath(value: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+
+  return redactSensitivePath(value, process.env.HOME ?? null);
+}
+
+function syncSentryThreadScope(): void {
+  const threadId = currentVisibleThreadId;
+  const threadState = threadId ? threadAccumulator.getThreadState(threadId) : null;
+  const workspaceRoot = redactSentryScopePath(threadState?.workspaceRoot ?? null);
+  const cwd = redactSentryScopePath(threadState?.cwd ?? null);
+
+  if (threadId) {
+    Sentry.setTag("sense1.thread.id", threadId);
+  } else {
+    Sentry.setTag("sense1.thread.id", "none");
+  }
+
+  if (workspaceRoot) {
+    Sentry.setTag("sense1.workspace.root", workspaceRoot);
+  } else {
+    Sentry.setTag("sense1.workspace.root", "none");
+  }
+
+  Sentry.setContext("sense1DesktopThread", {
+    id: threadId,
+    title: threadState?.title ?? null,
+    workspaceRoot,
+    cwd,
+    interactionState: threadState?.interactionState ?? null,
+    state: threadState?.state ?? null,
+  });
+}
+
+function getVisibleThreadBugContext(): {
+  readonly id: string | null;
+  readonly title: string | null;
+  readonly workspaceRoot: string | null;
+  readonly cwd: string | null;
+} | null {
+  const threadId = firstString(currentVisibleThreadId);
+  if (!threadId) {
+    return null;
+  }
+
+  const threadState = threadAccumulator.getThreadState(threadId);
+  if (!threadState) {
+    return {
+      id: threadId,
+      title: null,
+      workspaceRoot: null,
+      cwd: null,
+    };
+  }
+
+  return {
+    id: threadId,
+    title: threadState.title ?? null,
+    workspaceRoot: threadState.workspaceRoot ?? null,
+    cwd: threadState.cwd ?? null,
+  };
+}
+
 function updateVisibleThread(threadId: string | null): void {
   currentVisibleThreadId = firstString(threadId);
+  syncSentryThreadScope();
   if (!currentVisibleThreadId) {
     return;
   }
@@ -505,6 +583,14 @@ const desktopSessionController = new DesktopSessionController(appServerManager, 
     });
   },
   runtimeInfo,
+});
+const bugReportingService = new DesktopBugReportingService({
+  env: process.env,
+  runtimeInfo,
+  getBootstrap: async () => await desktopSessionController.getBootstrap(),
+  getVisibleThreadContext: () => getVisibleThreadBugContext(),
+  getRecentLogs: (limit) => desktopLogBuffer.list(limit),
+  captureManualBugReport: captureDesktopManualBugReport,
 });
 let runtimeStartInFlight: Promise<void> | null = null;
 let isGracefulQuitInProgress = false;
@@ -723,6 +809,8 @@ async function bootstrapMainProcess(): Promise<void> {
       updateVisibleThread(resolveBootstrapVisibleThreadId(bootstrap));
       return decorateBootstrap(bootstrap);
     },
+    submitDesktopBugReport: async (request) => await bugReportingService.submitReport(request),
+    getDesktopBugReportingStatus: async () => bugReportingService.getStatus(),
     rememberLastSelectedThread: async (request) => {
       await desktopSessionController.rememberLastSelectedThread(request);
       updateVisibleThread(request.threadId ?? null);
@@ -753,6 +841,9 @@ async function bootstrapMainProcess(): Promise<void> {
         const snapshotDelta = threadAccumulator.loadSnapshot(threadId, decoratedResult.thread);
         threadAccumulator.setActiveThread(threadId);
         emitDesktopThreadDelta(snapshotDelta);
+        if (currentVisibleThreadId === threadId) {
+          syncSentryThreadScope();
+        }
         syncUpdaterBusyState();
         void persistInteractionState(threadId).catch(() => {});
       }

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -33,7 +33,7 @@ import { ThreadInputQueueService } from "./session/thread-input-queue-service.ts
 import { resolveBootstrapVisibleThreadId, shouldRestoreQueuedFollowUp } from "./session/thread-runtime-behavior.ts";
 import { RuntimeFileChangeTracker } from "./session/runtime-file-change-tracker.ts";
 import { DesktopBugReportingService } from "./bug-reporting/desktop-bug-reporting-service.ts";
-import { redactSensitivePath } from "./bug-reporting/redaction.ts";
+import { redactSensitivePath, resolveRedactionHomeDir } from "./bug-reporting/redaction.ts";
 import { captureDesktopManualBugReport } from "./bug-reporting/sentry-reporting.ts";
 import { createDesktopLogBuffer, installDesktopLogBuffer } from "./logging/desktop-log-buffer.ts";
 import {
@@ -371,7 +371,7 @@ function redactSentryScopePath(value: string | null): string | null {
     return null;
   }
 
-  return redactSensitivePath(value, process.env.HOME ?? null);
+  return redactSensitivePath(value, resolveRedactionHomeDir(process.env));
 }
 
 function syncSentryThreadScope(): void {

--- a/desktop/src/preload/bridge/reports.ts
+++ b/desktop/src/preload/bridge/reports.ts
@@ -1,0 +1,24 @@
+import type { IpcRenderer } from "electron";
+
+import {
+  IPC_CHANNELS,
+  type DesktopBridge,
+  type DesktopBugReportDraft,
+  type DesktopBugReportResult,
+  type DesktopBugReportingStatus,
+} from "../../shared/contracts/index";
+
+type ReportsBridge = Pick<DesktopBridge, "reports">;
+
+export function createReportsBridge(ipcRenderer: IpcRenderer): ReportsBridge {
+  return {
+    reports: {
+      submit: async (request: DesktopBugReportDraft): Promise<DesktopBugReportResult> => {
+        return ipcRenderer.invoke(IPC_CHANNELS.submitDesktopBugReport, request) as Promise<DesktopBugReportResult>;
+      },
+      getStatus: async (): Promise<DesktopBugReportingStatus> => {
+        return ipcRenderer.invoke(IPC_CHANNELS.getDesktopBugReportingStatus) as Promise<DesktopBugReportingStatus>;
+      },
+    },
+  };
+}

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -10,6 +10,7 @@ import { createManagementBridge } from "./bridge/management";
 import { createSystemBridge } from "./bridge/system";
 import { createTeamBridge } from "./bridge/tenant";
 import { createWorkspaceBridge } from "./bridge/workspace";
+import { createReportsBridge } from "./bridge/reports";
 
 Sentry.init();
 
@@ -20,6 +21,7 @@ const desktopBridge: DesktopBridge = {
   ...createTeamBridge(ipcRenderer),
   ...createWorkspaceBridge(ipcRenderer),
   ...createSystemBridge(ipcRenderer),
+  ...createReportsBridge(ipcRenderer),
 };
 
 contextBridge.exposeInMainWorld(
@@ -41,6 +43,7 @@ contextBridge.exposeInMainWorld(
     settings: Object.freeze(desktopBridge.settings),
     management: Object.freeze(desktopBridge.management),
     team: Object.freeze(desktopBridge.team),
+    reports: Object.freeze(desktopBridge.reports),
     automations: Object.freeze(desktopBridge.automations),
     projections: Object.freeze(desktopBridge.projections),
     substrate: Object.freeze(desktopBridge.substrate),

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer } from "electron";
+import * as Sentry from "@sentry/electron/renderer";
 
 import {
   DESKTOP_BRIDGE_API_VERSION,
@@ -9,6 +10,8 @@ import { createManagementBridge } from "./bridge/management";
 import { createSystemBridge } from "./bridge/system";
 import { createTeamBridge } from "./bridge/tenant";
 import { createWorkspaceBridge } from "./bridge/workspace";
+
+Sentry.init();
 
 const desktopBridge: DesktopBridge = {
   apiVersion: DESKTOP_BRIDGE_API_VERSION,

--- a/desktop/src/renderer/main.tsx
+++ b/desktop/src/renderer/main.tsx
@@ -1,9 +1,12 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import * as Sentry from "@sentry/electron/renderer";
 
 import App from "./App";
 import { applyTheme, readStoredTheme } from "./lib/theme";
 import "./styles.css";
+
+Sentry.init();
 
 applyTheme(readStoredTheme());
 
@@ -18,4 +21,3 @@ createRoot(rootElement).render(
     <App />
   </StrictMode>,
 );
-

--- a/desktop/src/shared/bug-reporting.test.js
+++ b/desktop/src/shared/bug-reporting.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("DesktopBugReportDraft shape stays consumable by manual report flows", () => {
+  const draft = {
+    reportType: "manual",
+    title: "Composer send button stopped working",
+    description: "Clicking send does nothing after switching threads twice.",
+    expectedBehavior: "Send should submit the current prompt.",
+    reproductionSteps: "Open one thread, switch to another, switch back, then click send.",
+    attachments: [],
+  };
+
+  assert.equal(draft.reportType, "manual");
+  assert.equal(Array.isArray(draft.attachments), true);
+});

--- a/desktop/src/shared/contracts/bridge.ts
+++ b/desktop/src/shared/contracts/bridge.ts
@@ -1,4 +1,5 @@
 import type { DesktopBootstrap } from "./bootstrap.js";
+import type { DesktopBugReportDraft, DesktopBugReportResult, DesktopBugReportingStatus } from "./bug-reporting.js";
 import type {
   DesktopAutomationDeleteRequest,
   DesktopAutomationDetailResult,
@@ -92,6 +93,10 @@ export interface DesktopBridge {
   };
   input: {
     respond(request: DesktopInputResponseRequest): Promise<void>;
+  };
+  reports: {
+    submit(request: DesktopBugReportDraft): Promise<DesktopBugReportResult>;
+    getStatus(): Promise<DesktopBugReportingStatus>;
   };
   voice: {
     start(request: DesktopVoiceStartRequest): Promise<void>;

--- a/desktop/src/shared/contracts/bug-reporting.ts
+++ b/desktop/src/shared/contracts/bug-reporting.ts
@@ -1,0 +1,38 @@
+export type DesktopBugReportType = "manual" | "automatic";
+
+export type DesktopBugSeverity = "low" | "medium" | "high" | "critical";
+
+export type DesktopBugPromotionDisposition = "skip" | "link" | "create" | "deferred";
+
+export type DesktopBugAttachmentKind = "screenshot" | "file";
+
+export interface DesktopBugAttachment {
+  readonly kind: DesktopBugAttachmentKind;
+  readonly path: string;
+  readonly mimeType: string | null;
+}
+
+export interface DesktopBugReportDraft {
+  readonly reportType: DesktopBugReportType;
+  readonly title: string;
+  readonly description: string;
+  readonly expectedBehavior: string | null;
+  readonly reproductionSteps: string | null;
+  readonly severity?: DesktopBugSeverity | null;
+  readonly attachments: DesktopBugAttachment[];
+}
+
+export interface DesktopBugReportingStatus {
+  readonly sentryEnabled: boolean;
+  readonly linearConfigured: boolean;
+  readonly linearIntegrationMode: "directApi" | "sentryIntegrationOnly" | "disabled";
+}
+
+export interface DesktopBugReportResult {
+  readonly sentryEventId: string | null;
+  readonly sentryIssueUrl: string | null;
+  readonly promotionDisposition: DesktopBugPromotionDisposition;
+  readonly promotionReason: string;
+  readonly linearIssueId: string | null;
+  readonly linearIssueUrl: string | null;
+}

--- a/desktop/src/shared/contracts/index.ts
+++ b/desktop/src/shared/contracts/index.ts
@@ -1,5 +1,6 @@
 export * from "./automations.js";
 export * from "./bootstrap.js";
+export * from "./bug-reporting.js";
 export * from "./bridge.js";
 export * from "./events.js";
 export * from "./management.js";

--- a/desktop/src/shared/contracts/runtime.ts
+++ b/desktop/src/shared/contracts/runtime.ts
@@ -34,6 +34,8 @@ export const IPC_CHANNELS = {
   startDesktopVoice: "sense1:desktop:voice:start",
   appendDesktopVoiceAudio: "sense1:desktop:voice:append-audio",
   stopDesktopVoice: "sense1:desktop:voice:stop",
+  submitDesktopBugReport: "sense1:desktop:reports:submit-bug-report",
+  getDesktopBugReportingStatus: "sense1:desktop:reports:get-status",
   runtimeEvent: "sense1:desktop:runtime:event",
   threadDelta: "sense1:desktop:thread:delta",
   listModels: "sense1:desktop:models:list",

--- a/desktop/src/shared/sentry.test.js
+++ b/desktop/src/shared/sentry.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  resolveSentryDsn,
+  resolveSentryEnvironment,
+  resolveSentryRelease,
+  shouldEnableSentryDebug,
+} from "./sentry.ts";
+
+test("resolveSentryDsn falls back to the shipped desktop DSN", () => {
+  const dsn = resolveSentryDsn();
+
+  assert.match(dsn, /^https:\/\/.+@o\d+\.ingest\.[^/]+\.sentry\.io\/\d+$/);
+});
+
+test("resolveSentryDsn prefers an explicit environment override", () => {
+  assert.equal(
+    resolveSentryDsn({
+      SENSE1_SENTRY_DSN: "https://override@example.ingest.sentry.io/123",
+    }),
+    "https://override@example.ingest.sentry.io/123",
+  );
+});
+
+test("resolveSentryEnvironment defaults to development", () => {
+  assert.equal(resolveSentryEnvironment(), "development");
+  assert.equal(resolveSentryEnvironment({ NODE_ENV: "production" }), "production");
+});
+
+test("resolveSentryRelease prefixes the desktop app version", () => {
+  assert.equal(resolveSentryRelease("0.11.0"), "sense-1-workspace@0.11.0");
+  assert.equal(resolveSentryRelease(""), "sense-1-workspace@unknown");
+});
+
+test("shouldEnableSentryDebug only enables debug logging for the explicit opt-in flag", () => {
+  assert.equal(shouldEnableSentryDebug(), false);
+  assert.equal(shouldEnableSentryDebug({ SENSE1_SENTRY_DEBUG: "1" }), true);
+});

--- a/desktop/src/shared/sentry.ts
+++ b/desktop/src/shared/sentry.ts
@@ -1,0 +1,39 @@
+const DEFAULT_SENTRY_DSN =
+  "https://459c4631425b2df5faf5cb85b5aab0a9@o4511250952224768.ingest.de.sentry.io/4511250957205584";
+
+type SentryEnv = {
+  NODE_ENV?: string | undefined;
+  SENSE1_SENTRY_DSN?: string | undefined;
+  SENSE1_SENTRY_DEBUG?: string | undefined;
+};
+
+function firstNonEmptyString(...values: Array<unknown>): string | null {
+  for (const value of values) {
+    if (typeof value !== "string") {
+      continue;
+    }
+
+    const trimmed = value.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  return null;
+}
+
+export function resolveSentryDsn(env: SentryEnv = {}): string {
+  return firstNonEmptyString(env.SENSE1_SENTRY_DSN, DEFAULT_SENTRY_DSN) ?? DEFAULT_SENTRY_DSN;
+}
+
+export function resolveSentryEnvironment(env: SentryEnv = {}): string {
+  return firstNonEmptyString(env.NODE_ENV, "development") ?? "development";
+}
+
+export function resolveSentryRelease(appVersion: string): string {
+  return `sense-1-workspace@${firstNonEmptyString(appVersion, "unknown") ?? "unknown"}`;
+}
+
+export function shouldEnableSentryDebug(env: SentryEnv = {}): boolean {
+  return env.SENSE1_SENTRY_DEBUG === "1";
+}


### PR DESCRIPTION
## Summary

This PR adds the backend foundation for a proper desktop bug-reporting system in Sense-1 Workspace.

Manual reports can now move through a dedicated desktop bridge into the Electron main process, where we collect recent logs, redact secrets and home-scoped filesystem paths, capture the report in Sentry, and promote the report into Linear when the local environment is configured with the required Linear credentials.

The goal is to make bug reports actionable instead of just observable. Sentry remains the evidence system of record, while Linear becomes the execution system when the report crosses an actionability threshold.

## Related issues

Refs #40
Refs #41

## User impact

Before this change, the desktop app had Sentry bootstrap in place but no backend-owned reporting flow for turning a user-submitted bug report into a durable, enriched incident record and, when appropriate, an executable ticket.

After this change, the backend exposes a stable reporting surface the UI lane can call. Submitted reports are normalized, redacted, enriched with runtime and visible-thread context, and captured into Sentry. If the report is actionable and Linear is configured locally, the app creates a Linear issue with the report details, diagnostics, attachments metadata, and recent redacted logs.

## Root cause

We had observability plumbing, but not a real bug-reporting pipeline. The missing pieces were:

- no shared report contract between renderer and main
- no main-process service for redaction, diagnostics capture, or promotion policy
- no direct path from a desktop bug report to an executable Linear ticket
- no bounded log buffer or thread-context enrichment for report payloads

## What changed

The change introduces:

- shared contracts for bug-report drafts, reporting status, and submission results
- preload bridge methods for `reports.submit()` and `reports.getStatus()`
- main-process IPC handlers for bug-report submission and status lookup
- a bounded desktop log buffer for recent diagnostics
- redaction helpers for secrets and home-directory paths
- a promotion policy service that decides whether to skip, defer, or create a ticket
- a Sentry reporting helper for manual desktop bug reports
- a Linear GraphQL adapter for direct issue creation
- a main-process orchestration service that ties bootstrap context, thread context, logs, Sentry, and Linear together
- Sentry scope synchronization for visible-thread context on automatic main-process events, with path redaction applied there as well
- focused tests for redaction, promotion policy, Linear issue creation, shared contract shape, and end-to-end service behavior

## Notes on automatic crashes

This backend pass also improves the metadata attached to automatic main-process Sentry events by synchronizing visible thread context into the Sentry scope.

Native crash-to-ticket promotion is intentionally not claimed as fully client-side here, because macOS Crashpad limits what can safely run in crash hooks. That means crash-class automation is better treated as a downstream Sentry-side workflow, while this PR gives those events better context and gives manual reports a direct action path immediately.

## Validation

I verified this change with:

- `pnpm -C desktop typecheck`
- `pnpm -C desktop test:unit`
- `pnpm -C desktop build`
- `pnpm -C desktop check:structure:strict` (still reports pre-existing repository structure warnings; no new structure violation was introduced by this feature beyond touching already-large files)

## Follow-up

The UI flow for collecting and submitting reports remains intentionally separate and is tracked in the companion UI sub-issue.
