### PR TITLE
Let admins edit and remove local team members

### DIFF
--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -46,6 +46,7 @@ import {
   type DesktopSettingsUpdateRequest,
   type DesktopCreateFirstTeamRequest,
   type DesktopSaveTeamMemberRequest,
+  type DesktopRemoveTeamMemberRequest,
   type DesktopTeamStateResult,
   IPC_CHANNELS,
   type DesktopBootstrap,
@@ -161,6 +162,7 @@ type DesktopIpcServices = {
   getDesktopTeamState(): Promise<DesktopTeamStateResult>;
   createDesktopFirstTeam(request: DesktopCreateFirstTeamRequest): Promise<DesktopTeamStateResult>;
   saveDesktopTeamMember(request: DesktopSaveTeamMemberRequest): Promise<DesktopTeamStateResult>;
+  removeDesktopTeamMember(request: DesktopRemoveTeamMemberRequest): Promise<DesktopTeamStateResult>;
   listDesktopAutomations(): Promise<DesktopAutomationListResult>;
   getDesktopAutomation(id: string): Promise<DesktopAutomationDetailResult>;
   saveDesktopAutomation(request: DesktopAutomationSaveRequest): Promise<DesktopAutomationDetailResult>;
@@ -512,6 +514,13 @@ export function registerDesktopIpcHandlers(services: DesktopIpcServices): void {
     IPC_CHANNELS.saveDesktopTeamMember,
     async (_event, request: DesktopSaveTeamMemberRequest): Promise<DesktopTeamStateResult> => {
       return await services.saveDesktopTeamMember(request);
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.removeDesktopTeamMember,
+    async (_event, request: DesktopRemoveTeamMemberRequest): Promise<DesktopTeamStateResult> => {
+      return await services.removeDesktopTeamMember(request);
     },
   );
 

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -1036,6 +1036,7 @@ async function bootstrapMainProcess(): Promise<void> {
     getDesktopTeamState: async () => await desktopSessionController.getDesktopTeamState(),
     createDesktopFirstTeam: async (request) => await desktopSessionController.createDesktopFirstTeam(request),
     saveDesktopTeamMember: async (request) => await desktopSessionController.saveDesktopTeamMember(request),
+    removeDesktopTeamMember: async (request) => await desktopSessionController.removeDesktopTeamMember(request),
     listDesktopAutomations: async () => await desktopSessionController.listDesktopAutomations(),
     getDesktopAutomation: async (id) => await desktopSessionController.getDesktopAutomation(id),
     saveDesktopAutomation: async (request) => await desktopSessionController.saveDesktopAutomation(request),

--- a/desktop/src/main/session-controller.ts
+++ b/desktop/src/main/session-controller.ts
@@ -63,6 +63,7 @@ import type {
   DesktopTeamStateResult,
   DesktopCreateFirstTeamRequest,
   DesktopSaveTeamMemberRequest,
+  DesktopRemoveTeamMemberRequest,
   DesktopVoiceAppendAudioRequest,
   DesktopVoiceStartRequest,
   DesktopVoiceStopRequest,
@@ -951,6 +952,10 @@ export class DesktopSessionController {
 
   async saveDesktopTeamMember(request: DesktopSaveTeamMemberRequest): Promise<DesktopTeamStateResult> {
     return await this.#desktopTenant.saveTeamMember(request);
+  }
+
+  async removeDesktopTeamMember(request: DesktopRemoveTeamMemberRequest): Promise<DesktopTeamStateResult> {
+    return await this.#desktopTenant.removeTeamMember(request);
   }
 
   async listDesktopAutomations(): Promise<DesktopAutomationListResult> {

--- a/desktop/src/main/tenant/desktop-tenant-service.test.js
+++ b/desktop/src/main/tenant/desktop-tenant-service.test.js
@@ -104,6 +104,349 @@ test("DesktopTenantService can create the first team and promote the creator to 
   });
 });
 
+test("DesktopTenantService lets admins update an existing local member's role", async () => {
+  const runtimeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-tenant-service-runtime-"));
+  const tenantRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-tenant-service-cloud-"));
+  const env = createEnv(runtimeRoot, tenantRoot);
+
+  await createTenant({
+    tenantId: "ops-team",
+    displayName: "Ops Team",
+    env,
+    now: "2026-04-09T09:00:00.000Z",
+  });
+  const adminMembership = await addTenantMember({
+    tenantId: "ops-team",
+    email: "george@example.com",
+    role: "admin",
+    displayName: "George",
+    env,
+    now: "2026-04-09T09:01:00.000Z",
+  });
+  await addTenantMember({
+    tenantId: "ops-team",
+    email: "teammate@example.com",
+    role: "member",
+    displayName: "Teammate",
+    env,
+    now: "2026-04-09T09:02:00.000Z",
+  });
+  await persistActiveTenantMembership("default", adminMembership, env);
+
+  const service = new DesktopTenantService({
+    env,
+    resolveProfile: async () => ({ id: "default" }),
+    resolveSignedInAccount: async () => ({
+      accountType: "chatgpt",
+      authMode: "chatgpt",
+      email: "george@example.com",
+      isSignedIn: true,
+      requiresOpenaiAuth: false,
+    }),
+  });
+
+  const result = await service.saveTeamMember({
+    email: "teammate@example.com",
+    role: "admin",
+  });
+
+  const updated = result.members.find((member) => member.email === "teammate@example.com");
+  assert.equal(updated?.role, "admin");
+  assert.equal(result.members.length, 2);
+});
+
+test("DesktopTenantService renames an existing member when previousEmail differs", async () => {
+  const runtimeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-tenant-service-runtime-"));
+  const tenantRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-tenant-service-cloud-"));
+  const env = createEnv(runtimeRoot, tenantRoot);
+
+  await createTenant({
+    tenantId: "ops-team",
+    displayName: "Ops Team",
+    env,
+    now: "2026-04-09T09:00:00.000Z",
+  });
+  const adminMembership = await addTenantMember({
+    tenantId: "ops-team",
+    email: "george@example.com",
+    role: "admin",
+    displayName: "George",
+    env,
+    now: "2026-04-09T09:01:00.000Z",
+  });
+  await addTenantMember({
+    tenantId: "ops-team",
+    email: "rian@example.com",
+    role: "member",
+    displayName: "Rian",
+    env,
+    now: "2026-04-09T09:02:00.000Z",
+  });
+  await persistActiveTenantMembership("default", adminMembership, env);
+
+  const service = new DesktopTenantService({
+    env,
+    resolveProfile: async () => ({ id: "default" }),
+    resolveSignedInAccount: async () => ({
+      accountType: "chatgpt",
+      authMode: "chatgpt",
+      email: "george@example.com",
+      isSignedIn: true,
+      requiresOpenaiAuth: false,
+    }),
+  });
+
+  const result = await service.saveTeamMember({
+    previousEmail: "rian@example.com",
+    email: "riana@example.com",
+    role: "member",
+  });
+
+  const emails = result.members.map((member) => member.email).sort();
+  assert.deepEqual(emails, ["george@example.com", "riana@example.com"]);
+  assert.equal(result.members.length, 2);
+});
+
+test("DesktopTenantService refuses to rename to an email that collides with another member", async () => {
+  const runtimeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-tenant-service-runtime-"));
+  const tenantRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-tenant-service-cloud-"));
+  const env = createEnv(runtimeRoot, tenantRoot);
+
+  await createTenant({
+    tenantId: "ops-team",
+    displayName: "Ops Team",
+    env,
+    now: "2026-04-09T09:00:00.000Z",
+  });
+  const adminMembership = await addTenantMember({
+    tenantId: "ops-team",
+    email: "george@example.com",
+    role: "admin",
+    displayName: "George",
+    env,
+    now: "2026-04-09T09:01:00.000Z",
+  });
+  await addTenantMember({
+    tenantId: "ops-team",
+    email: "one@example.com",
+    role: "member",
+    displayName: "One",
+    env,
+    now: "2026-04-09T09:02:00.000Z",
+  });
+  await addTenantMember({
+    tenantId: "ops-team",
+    email: "two@example.com",
+    role: "member",
+    displayName: "Two",
+    env,
+    now: "2026-04-09T09:03:00.000Z",
+  });
+  await persistActiveTenantMembership("default", adminMembership, env);
+
+  const service = new DesktopTenantService({
+    env,
+    resolveProfile: async () => ({ id: "default" }),
+    resolveSignedInAccount: async () => ({
+      accountType: "chatgpt",
+      authMode: "chatgpt",
+      email: "george@example.com",
+      isSignedIn: true,
+      requiresOpenaiAuth: false,
+    }),
+  });
+
+  await assert.rejects(
+    () => service.saveTeamMember({
+      previousEmail: "one@example.com",
+      email: "two@example.com",
+      role: "member",
+    }),
+    /already uses/,
+  );
+});
+
+test("DesktopTenantService refuses to rename the signed-in admin's own email", async () => {
+  const runtimeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-tenant-service-runtime-"));
+  const tenantRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-tenant-service-cloud-"));
+  const env = createEnv(runtimeRoot, tenantRoot);
+
+  await createTenant({
+    tenantId: "ops-team",
+    displayName: "Ops Team",
+    env,
+    now: "2026-04-09T09:00:00.000Z",
+  });
+  const adminMembership = await addTenantMember({
+    tenantId: "ops-team",
+    email: "george@example.com",
+    role: "admin",
+    displayName: "George",
+    env,
+    now: "2026-04-09T09:01:00.000Z",
+  });
+  await persistActiveTenantMembership("default", adminMembership, env);
+
+  const service = new DesktopTenantService({
+    env,
+    resolveProfile: async () => ({ id: "default" }),
+    resolveSignedInAccount: async () => ({
+      accountType: "chatgpt",
+      authMode: "chatgpt",
+      email: "george@example.com",
+      isSignedIn: true,
+      requiresOpenaiAuth: false,
+    }),
+  });
+
+  await assert.rejects(
+    () => service.saveTeamMember({
+      previousEmail: "george@example.com",
+      email: "george.stander@example.com",
+      role: "admin",
+    }),
+    /your own membership/,
+  );
+});
+
+test("DesktopTenantService lets admins remove local team members", async () => {
+  const runtimeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-tenant-service-runtime-"));
+  const tenantRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-tenant-service-cloud-"));
+  const env = createEnv(runtimeRoot, tenantRoot);
+
+  await createTenant({
+    tenantId: "ops-team",
+    displayName: "Ops Team",
+    env,
+    now: "2026-04-09T09:00:00.000Z",
+  });
+  const adminMembership = await addTenantMember({
+    tenantId: "ops-team",
+    email: "george@example.com",
+    role: "admin",
+    displayName: "George",
+    env,
+    now: "2026-04-09T09:01:00.000Z",
+  });
+  await addTenantMember({
+    tenantId: "ops-team",
+    email: "teammate@example.com",
+    role: "member",
+    displayName: "Teammate",
+    env,
+    now: "2026-04-09T09:02:00.000Z",
+  });
+  await persistActiveTenantMembership("default", adminMembership, env);
+
+  const service = new DesktopTenantService({
+    env,
+    resolveProfile: async () => ({ id: "default" }),
+    resolveSignedInAccount: async () => ({
+      accountType: "chatgpt",
+      authMode: "chatgpt",
+      email: "george@example.com",
+      isSignedIn: true,
+      requiresOpenaiAuth: false,
+    }),
+  });
+
+  const result = await service.removeTeamMember({ email: "teammate@example.com" });
+
+  assert.equal(result.members.length, 1);
+  assert.equal(result.members[0]?.email, "george@example.com");
+});
+
+test("DesktopTenantService refuses to let an admin remove themselves", async () => {
+  const runtimeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-tenant-service-runtime-"));
+  const tenantRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-tenant-service-cloud-"));
+  const env = createEnv(runtimeRoot, tenantRoot);
+
+  await createTenant({
+    tenantId: "ops-team",
+    displayName: "Ops Team",
+    env,
+    now: "2026-04-09T09:00:00.000Z",
+  });
+  const adminMembership = await addTenantMember({
+    tenantId: "ops-team",
+    email: "george@example.com",
+    role: "admin",
+    displayName: "George",
+    env,
+    now: "2026-04-09T09:01:00.000Z",
+  });
+  await persistActiveTenantMembership("default", adminMembership, env);
+
+  const service = new DesktopTenantService({
+    env,
+    resolveProfile: async () => ({ id: "default" }),
+    resolveSignedInAccount: async () => ({
+      accountType: "chatgpt",
+      authMode: "chatgpt",
+      email: "george@example.com",
+      isSignedIn: true,
+      requiresOpenaiAuth: false,
+    }),
+  });
+
+  await assert.rejects(
+    () => service.removeTeamMember({ email: "george@example.com" }),
+    /yourself/,
+  );
+});
+
+test("DesktopTenantService refuses to remove the last admin", async () => {
+  const runtimeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-tenant-service-runtime-"));
+  const tenantRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-tenant-service-cloud-"));
+  const env = createEnv(runtimeRoot, tenantRoot);
+
+  await createTenant({
+    tenantId: "ops-team",
+    displayName: "Ops Team",
+    env,
+    now: "2026-04-09T09:00:00.000Z",
+  });
+  const adminMembership = await addTenantMember({
+    tenantId: "ops-team",
+    email: "lead@example.com",
+    role: "admin",
+    displayName: "Lead",
+    env,
+    now: "2026-04-09T09:01:00.000Z",
+  });
+  await addTenantMember({
+    tenantId: "ops-team",
+    email: "founder@example.com",
+    role: "admin",
+    displayName: "Founder",
+    env,
+    now: "2026-04-09T09:02:00.000Z",
+  });
+  await persistActiveTenantMembership("default", adminMembership, env);
+
+  const service = new DesktopTenantService({
+    env,
+    resolveProfile: async () => ({ id: "default" }),
+    resolveSignedInAccount: async () => ({
+      accountType: "chatgpt",
+      authMode: "chatgpt",
+      email: "lead@example.com",
+      isSignedIn: true,
+      requiresOpenaiAuth: false,
+    }),
+  });
+
+  // Removing the other admin leaves only "lead" as admin.
+  const afterOne = await service.removeTeamMember({ email: "founder@example.com" });
+  assert.equal(afterOne.members.length, 1);
+
+  // Now the sole admin cannot be removed by anyone (including self-guard, which also blocks this).
+  await assert.rejects(
+    () => service.removeTeamMember({ email: "lead@example.com" }),
+    /yourself|last admin/,
+  );
+});
+
 test("DesktopTenantService lets admins add local team members", async () => {
   const runtimeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-tenant-service-runtime-"));
   const tenantRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-tenant-service-cloud-"));

--- a/desktop/src/main/tenant/desktop-tenant-service.test.js
+++ b/desktop/src/main/tenant/desktop-tenant-service.test.js
@@ -5,7 +5,7 @@ import path from "node:path";
 import fs from "node:fs/promises";
 
 import { DesktopTenantService } from "./desktop-tenant-service.ts";
-import { createTenant, addTenantMember, persistActiveTenantMembership } from "./tenant-state.ts";
+import { createTenant, addTenantMember, listTenantMembers, persistActiveTenantMembership } from "./tenant-state.ts";
 
 function createEnv(runtimeRoot, tenantRoot = null) {
   return {
@@ -207,7 +207,7 @@ test("DesktopTenantService renames an existing member when previousEmail differs
   assert.equal(result.members.length, 2);
 });
 
-test("DesktopTenantService refuses to rename to an email that collides with another member", async () => {
+test("DesktopTenantService rolls the rename back when the new email collides so the old row survives", async () => {
   const runtimeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-tenant-service-runtime-"));
   const tenantRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-tenant-service-cloud-"));
   const env = createEnv(runtimeRoot, tenantRoot);
@@ -264,6 +264,10 @@ test("DesktopTenantService refuses to rename to an email that collides with anot
     }),
     /already uses/,
   );
+
+  const survivors = await listTenantMembers({ tenantId: "ops-team", env });
+  const emails = survivors.map((member) => member.email).sort();
+  assert.deepEqual(emails, ["george@example.com", "one@example.com", "two@example.com"]);
 });
 
 test("DesktopTenantService refuses to rename the signed-in admin's own email", async () => {

--- a/desktop/src/main/tenant/desktop-tenant-service.ts
+++ b/desktop/src/main/tenant/desktop-tenant-service.ts
@@ -15,6 +15,7 @@ import {
   listTenantMembers,
   persistActiveTenantMembership,
   removeTenantMember,
+  renameTenantMember,
   resolveTenantMembershipForProfile,
   sanitizeTenantId,
   type TenantMembershipRecord,
@@ -214,30 +215,23 @@ export class DesktopTenantService {
         throw new Error("You cannot change the email of your own membership.");
       }
 
-      const members = await listTenantMembers({ tenantId: membership.tenantId, env: this.#env });
-      const source = members.find((candidate) => candidate.email === previousEmail);
-      if (!source) {
-        throw new Error("That member is not part of this team.");
-      }
-      const collision = members.find((candidate) => candidate.email === nextEmail);
-      if (collision) {
-        throw new Error(`Another member already uses ${nextEmail}.`);
-      }
-
-      await removeTenantMember({
+      await renameTenantMember({
         tenantId: membership.tenantId,
-        email: previousEmail,
+        previousEmail,
+        nextEmail,
+        role: request.role,
+        displayName: request.displayName?.trim() || null,
+        env: this.#env,
+      });
+    } else {
+      await addTenantMember({
+        tenantId: membership.tenantId,
+        email: nextEmail,
+        role: request.role,
+        displayName: request.displayName?.trim() || null,
         env: this.#env,
       });
     }
-
-    await addTenantMember({
-      tenantId: membership.tenantId,
-      email: nextEmail,
-      role: request.role,
-      displayName: request.displayName?.trim() || null,
-      env: this.#env,
-    });
 
     return await this.getTeamState();
   }

--- a/desktop/src/main/tenant/desktop-tenant-service.ts
+++ b/desktop/src/main/tenant/desktop-tenant-service.ts
@@ -2,6 +2,7 @@ import type {
   DesktopBootstrapTeamSetup,
   DesktopBootstrapTenant,
   DesktopCreateFirstTeamRequest,
+  DesktopRemoveTeamMemberRequest,
   DesktopSaveTeamMemberRequest,
   DesktopTeamMemberRecord,
   DesktopTeamStateResult,
@@ -13,10 +14,12 @@ import {
   getTenant,
   listTenantMembers,
   persistActiveTenantMembership,
+  removeTenantMember,
   resolveTenantMembershipForProfile,
   sanitizeTenantId,
   type TenantMembershipRecord,
 } from "./tenant-state.ts";
+import { normalizeEmail } from "./tenant-state-support.ts";
 
 type DesktopTenantServiceOptions = {
   env?: NodeJS.ProcessEnv;
@@ -198,16 +201,79 @@ export class DesktopTenantService {
       throw new Error("Only admins can manage team members.");
     }
 
-    const email = request.email.trim();
-    if (!email) {
+    const nextEmail = normalizeEmail(request.email);
+    if (!nextEmail) {
       throw new Error("A member email is required.");
+    }
+
+    const previousEmail = normalizeEmail(request.previousEmail);
+    const isRename = previousEmail !== null && previousEmail !== nextEmail;
+
+    if (isRename) {
+      if (previousEmail === membership.email) {
+        throw new Error("You cannot change the email of your own membership.");
+      }
+
+      const members = await listTenantMembers({ tenantId: membership.tenantId, env: this.#env });
+      const source = members.find((candidate) => candidate.email === previousEmail);
+      if (!source) {
+        throw new Error("That member is not part of this team.");
+      }
+      const collision = members.find((candidate) => candidate.email === nextEmail);
+      if (collision) {
+        throw new Error(`Another member already uses ${nextEmail}.`);
+      }
+
+      await removeTenantMember({
+        tenantId: membership.tenantId,
+        email: previousEmail,
+        env: this.#env,
+      });
     }
 
     await addTenantMember({
       tenantId: membership.tenantId,
-      email,
+      email: nextEmail,
       role: request.role,
       displayName: request.displayName?.trim() || null,
+      env: this.#env,
+    });
+
+    return await this.getTeamState();
+  }
+
+  async removeTeamMember(request: DesktopRemoveTeamMemberRequest): Promise<DesktopTeamStateResult> {
+    const { accountEmail, membership } = await this.#resolveIdentity();
+    if (!accountEmail || !membership) {
+      throw new Error("Create or restore a team before managing members.");
+    }
+    if (membership.role !== "admin") {
+      throw new Error("Only admins can manage team members.");
+    }
+
+    const targetEmail = normalizeEmail(request.email);
+    if (!targetEmail) {
+      throw new Error("A member email is required.");
+    }
+    if (targetEmail === membership.email) {
+      throw new Error("You cannot remove yourself from the team.");
+    }
+
+    const members = await listTenantMembers({ tenantId: membership.tenantId, env: this.#env });
+    const target = members.find((candidate) => candidate.email === targetEmail);
+    if (!target) {
+      throw new Error("That member is not part of this team.");
+    }
+    if (target.role === "admin") {
+      const adminCount = members.filter((candidate) => candidate.role === "admin").length;
+      if (adminCount <= 1) {
+        throw new Error("Promote another admin before removing the last admin.");
+      }
+    }
+
+    await removeTenantMember({
+      tenantId: membership.tenantId,
+      email: targetEmail,
       env: this.#env,
     });
 

--- a/desktop/src/main/tenant/tenant-state.ts
+++ b/desktop/src/main/tenant/tenant-state.ts
@@ -355,6 +355,135 @@ export async function addTenantMember({
   }
 }
 
+export async function renameTenantMember({
+  tenantId,
+  previousEmail,
+  nextEmail,
+  role = "member",
+  displayName = null,
+  now = new Date().toISOString(),
+  metadata = {},
+  env = process.env,
+}: {
+  tenantId: string;
+  previousEmail: string;
+  nextEmail: string;
+  role?: TenantRole;
+  displayName?: string | null;
+  now?: string;
+  metadata?: Record<string, unknown>;
+  env?: NodeJS.ProcessEnv;
+}): Promise<TenantMembershipRecord> {
+  const normalizedPrevious = normalizeEmail(previousEmail);
+  const normalizedNext = normalizeEmail(nextEmail);
+  if (!normalizedPrevious || !normalizedNext) {
+    throw new Error("Both previous and next emails are required to rename tenant membership.");
+  }
+  if (normalizedPrevious === normalizedNext) {
+    throw new Error("The next email must differ from the previous email to rename tenant membership.");
+  }
+  const resolvedTenantId = sanitizeTenantId(tenantId);
+  await ensureTenantStore(env);
+
+  const db = openTenantStore(env);
+  let membership: TenantMembershipRecord | null = null;
+  let committed = false;
+  try {
+    const tenant = mapTenantRow(
+      db.prepare(
+        `SELECT id, display_name, scope_id, scope_display_name, created_at, updated_at, metadata
+        FROM tenants
+        WHERE id = ?`,
+      ).get(resolvedTenantId),
+    );
+    if (!tenant) {
+      throw new Error(`Create tenant "${resolvedTenantId}" before renaming members.`);
+    }
+
+    const actorDisplayName = firstString(displayName) ?? normalizedNext.split("@")[0] ?? "Team member";
+    const actorId = buildActorId(tenant.id, normalizedNext);
+    const normalizedRole: TenantRole = role === "admin" ? "admin" : "member";
+    const nextMetadata = { ...metadata, tenantDisplayName: tenant.displayName };
+
+    db.exec("BEGIN IMMEDIATE");
+    try {
+      const deletion = db.prepare(
+        `DELETE FROM memberships WHERE tenant_id = ? AND email = ?`,
+      ).run(resolvedTenantId, normalizedPrevious);
+      if ((deletion.changes ?? 0) === 0) {
+        throw new Error(`No membership found for "${normalizedPrevious}" in tenant "${tenant.id}".`);
+      }
+
+      const collision = db.prepare(
+        `SELECT email FROM memberships WHERE tenant_id = ? AND email = ?`,
+      ).get(resolvedTenantId, normalizedNext);
+      if (collision) {
+        throw new Error(`Another member already uses ${normalizedNext}.`);
+      }
+
+      db.prepare(
+        `INSERT INTO memberships (
+          tenant_id,
+          email,
+          actor_id,
+          actor_display_name,
+          role,
+          joined_at,
+          updated_at,
+          metadata
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        resolvedTenantId,
+        normalizedNext,
+        actorId,
+        actorDisplayName,
+        normalizedRole,
+        now,
+        now,
+        JSON.stringify(nextMetadata),
+      );
+
+      const row = db.prepare(
+        `SELECT
+          memberships.tenant_id,
+          tenants.display_name AS tenant_display_name,
+          tenants.scope_id,
+          tenants.scope_display_name,
+          memberships.actor_id,
+          memberships.actor_display_name,
+          memberships.email,
+          memberships.role,
+          memberships.joined_at,
+          memberships.updated_at,
+          memberships.metadata
+        FROM memberships
+        JOIN tenants ON tenants.id = memberships.tenant_id
+        WHERE memberships.tenant_id = ? AND memberships.email = ?`,
+      ).get(resolvedTenantId, normalizedNext);
+      membership = mapMembershipRow(row);
+      if (!membership) {
+        throw new Error(`Could not load membership for "${normalizedNext}" in tenant "${tenant.id}".`);
+      }
+
+      db.exec("COMMIT");
+      committed = true;
+    } finally {
+      if (!committed) {
+        try {
+          db.exec("ROLLBACK");
+        } catch {
+          // rollback may throw if the transaction already ended; ignore.
+        }
+      }
+    }
+  } finally {
+    db.close();
+  }
+
+  await clearSharedTenantRegistryEntry({ email: normalizedPrevious, tenantId: resolvedTenantId }, env);
+  return membership!;
+}
+
 export async function removeTenantMember({
   tenantId,
   email,

--- a/desktop/src/main/tenant/tenant-state.ts
+++ b/desktop/src/main/tenant/tenant-state.ts
@@ -144,6 +144,25 @@ async function persistSharedTenantRegistryEntry(
   await fs.writeFile(registryFile, JSON.stringify(registry, null, 2), "utf8");
 }
 
+async function clearSharedTenantRegistryEntry(
+  { email, tenantId }: { email: string; tenantId: string },
+  env = process.env,
+): Promise<void> {
+  const normalizedEmail = normalizeEmail(email);
+  if (!normalizedEmail) {
+    return;
+  }
+  const registry = await loadSharedTenantRegistry(env);
+  const existing = registry[normalizedEmail];
+  if (!existing || existing.tenantId !== tenantId) {
+    return;
+  }
+  delete registry[normalizedEmail];
+  const registryFile = resolveSharedTenantRegistryFile(env);
+  await fs.mkdir(path.dirname(registryFile), { recursive: true });
+  await fs.writeFile(registryFile, JSON.stringify(registry, null, 2), "utf8");
+}
+
 export function sanitizeTenantId(value: string | null | undefined): string {
   return sanitizeTenantToken(value, "team");
 }
@@ -334,6 +353,33 @@ export async function addTenantMember({
   } finally {
     writeDb.close();
   }
+}
+
+export async function removeTenantMember({
+  tenantId,
+  email,
+  env = process.env,
+}: { tenantId: string; email: string; env?: NodeJS.ProcessEnv; }): Promise<boolean> {
+  const normalizedEmail = normalizeEmail(email);
+  if (!normalizedEmail) {
+    throw new Error("A member email is required to remove tenant membership.");
+  }
+  const resolvedTenantId = sanitizeTenantId(tenantId);
+  await ensureTenantStore(env);
+  const db = openTenantStore(env);
+  let deleted = false;
+  try {
+    const result = db.prepare(
+      `DELETE FROM memberships WHERE tenant_id = ? AND email = ?`,
+    ).run(resolvedTenantId, normalizedEmail);
+    deleted = (result.changes ?? 0) > 0;
+  } finally {
+    db.close();
+  }
+  if (deleted) {
+    await clearSharedTenantRegistryEntry({ email: normalizedEmail, tenantId: resolvedTenantId }, env);
+  }
+  return deleted;
 }
 
 export async function listTenantMembershipsByEmail({

--- a/desktop/src/preload/bridge/tenant.ts
+++ b/desktop/src/preload/bridge/tenant.ts
@@ -4,6 +4,7 @@ import {
   IPC_CHANNELS,
   type DesktopBridge,
   type DesktopCreateFirstTeamRequest,
+  type DesktopRemoveTeamMemberRequest,
   type DesktopSaveTeamMemberRequest,
   type DesktopTeamStateResult,
 } from "../../shared/contracts/index";
@@ -21,6 +22,9 @@ export function createTeamBridge(ipcRenderer: IpcRenderer): TeamBridge {
       },
       saveMember: async (request: DesktopSaveTeamMemberRequest): Promise<DesktopTeamStateResult> => {
         return ipcRenderer.invoke(IPC_CHANNELS.saveDesktopTeamMember, request) as Promise<DesktopTeamStateResult>;
+      },
+      removeMember: async (request: DesktopRemoveTeamMemberRequest): Promise<DesktopTeamStateResult> => {
+        return ipcRenderer.invoke(IPC_CHANNELS.removeDesktopTeamMember, request) as Promise<DesktopTeamStateResult>;
       },
     },
   };

--- a/desktop/src/renderer/components/settings/TeamSettingsSection.tsx
+++ b/desktop/src/renderer/components/settings/TeamSettingsSection.tsx
@@ -5,6 +5,7 @@ import { Input } from "../ui/input";
 import type {
   DesktopBootstrapTeamSetup,
   DesktopBootstrapTenant,
+  DesktopTeamMemberRecord,
   DesktopTeamStateResult,
 } from "../../../main/contracts";
 
@@ -47,10 +48,12 @@ export function TeamSettingsSection({
   const [teamState, setTeamState] = useState<DesktopTeamStateResult | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [removingEmail, setRemovingEmail] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [teamName, setTeamName] = useState("");
   const [memberEmail, setMemberEmail] = useState("");
   const [memberRole, setMemberRole] = useState<"member" | "admin">("member");
+  const [editingEmail, setEditingEmail] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -123,15 +126,60 @@ export function TeamSettingsSection({
       const result = await bridge.team.saveMember({
         email: memberEmail,
         role: memberRole,
+        previousEmail: editingEmail,
       });
       setTeamState(result);
       setMemberEmail("");
       setMemberRole("member");
+      setEditingEmail(null);
       await refreshBootstrap();
     } catch (nextError) {
       setError(sanitizeTeamErrorMessage(nextError instanceof Error ? nextError.message : "Could not save the team member."));
     } finally {
       setSaving(false);
+    }
+  }
+
+  function handleEditMember(member: DesktopTeamMemberRecord): void {
+    setEditingEmail(member.email);
+    setMemberEmail(member.email);
+    setMemberRole(member.role);
+    setError(null);
+  }
+
+  function handleCancelEdit(): void {
+    setEditingEmail(null);
+    setMemberEmail("");
+    setMemberRole("member");
+  }
+
+  async function handleRemoveMember(member: DesktopTeamMemberRecord): Promise<void> {
+    const bridge = window.sense1Desktop;
+    if (!bridge?.team?.removeMember) {
+      setError("Desktop team member removal is not available in this build.");
+      return;
+    }
+
+    const confirmed = window.confirm(
+      `Remove ${member.actorDisplayName} (${member.email}) from this team?`,
+    );
+    if (!confirmed) {
+      return;
+    }
+
+    setRemovingEmail(member.email);
+    setError(null);
+    try {
+      const result = await bridge.team.removeMember({ email: member.email });
+      setTeamState(result);
+      if (editingEmail === member.email) {
+        handleCancelEdit();
+      }
+      await refreshBootstrap();
+    } catch (nextError) {
+      setError(sanitizeTeamErrorMessage(nextError instanceof Error ? nextError.message : "Could not remove the team member."));
+    } finally {
+      setRemovingEmail(null);
     }
   }
 
@@ -203,9 +251,13 @@ export function TeamSettingsSection({
 
               {effectiveTeamState.teamSetup.canManageTeam ? (
                 <div className="rounded-xl bg-surface-low px-[0.9rem] py-[0.55rem]">
-                  <p className="text-[0.75rem] font-medium uppercase leading-[1.2] tracking-[0.05em] text-ink-faint">Add member</p>
+                  <p className="text-[0.75rem] font-medium uppercase leading-[1.2] tracking-[0.05em] text-ink-faint">
+                    {editingEmail ? "Edit member" : "Add member"}
+                  </p>
                   <p className="mt-[0.35rem] text-[0.9375rem] leading-[1.55] text-ink">
-                    Add or update a local member record for this team on this machine.
+                    {editingEmail
+                      ? `Update the email or role for ${editingEmail} on this machine.`
+                      : "Add or update a local member record for this team on this machine."}
                   </p>
                   <div className="mt-3 flex flex-col gap-2 sm:flex-row">
                     <Input
@@ -227,8 +279,17 @@ export function TeamSettingsSection({
                       disabled={saving || !memberEmail.trim()}
                       onClick={() => void handleSaveMember()}
                     >
-                      {saving ? "Saving..." : "Save member"}
+                      {saving ? "Saving..." : editingEmail ? "Update member" : "Save member"}
                     </Button>
+                    {editingEmail ? (
+                      <Button
+                        disabled={saving}
+                        onClick={() => handleCancelEdit()}
+                        variant="ghost"
+                      >
+                        Cancel
+                      </Button>
+                    ) : null}
                   </div>
                 </div>
               ) : (
@@ -243,19 +304,51 @@ export function TeamSettingsSection({
                 <div className="rounded-xl bg-surface-low px-[0.9rem] py-[0.55rem]">
                   <p className="text-[0.75rem] font-medium uppercase leading-[1.2] tracking-[0.05em] text-ink-faint">Members</p>
                   <div className="mt-3 flex flex-col gap-2">
-                    {effectiveTeamState.members.map((member) => (
-                      <div className="rounded-lg bg-surface-high px-3 py-2" key={`${member.tenantId}:${member.email}`}>
-                        <div className="flex items-center justify-between gap-3">
-                          <div className="min-w-0">
-                            <p className="truncate text-sm font-medium text-ink">{member.actorDisplayName}</p>
-                            <p className="truncate text-xs text-ink-muted">{member.email}</p>
+                    {effectiveTeamState.members.map((member) => {
+                      const isSelf = member.email === effectiveTeamState.accountEmail;
+                      const isEditing = editingEmail === member.email;
+                      const isRemovingThis = removingEmail === member.email;
+                      const busyWithOther = (saving && editingEmail !== member.email) || (removingEmail !== null && !isRemovingThis);
+                      return (
+                        <div
+                          className="rounded-lg bg-surface-high px-3 py-2"
+                          key={`${member.tenantId}:${member.email}`}
+                        >
+                          <div className="flex flex-wrap items-center justify-between gap-3">
+                            <div className="min-w-0">
+                              <p className="truncate text-sm font-medium text-ink">{member.actorDisplayName}</p>
+                              <p className="truncate text-xs text-ink-muted">{member.email}</p>
+                            </div>
+                            <div className="flex shrink-0 items-center gap-2">
+                              <span className="rounded-full bg-surface-low px-2.5 py-1 text-[11px] uppercase tracking-[0.08em] text-ink-faint">
+                                {member.role}
+                              </span>
+                              {effectiveTeamState.teamSetup.canManageTeam ? (
+                                <>
+                                  <Button
+                                    disabled={busyWithOther || isRemovingThis}
+                                    onClick={() => handleEditMember(member)}
+                                    size="sm"
+                                    variant={isEditing ? "default" : "secondary"}
+                                  >
+                                    {isEditing ? "Editing" : "Edit"}
+                                  </Button>
+                                  <Button
+                                    disabled={busyWithOther || isSelf}
+                                    onClick={() => void handleRemoveMember(member)}
+                                    size="sm"
+                                    title={isSelf ? "You cannot remove yourself." : undefined}
+                                    variant="destructive"
+                                  >
+                                    {isRemovingThis ? "Removing..." : "Remove"}
+                                  </Button>
+                                </>
+                              ) : null}
+                            </div>
                           </div>
-                          <span className="shrink-0 rounded-full bg-surface-low px-2.5 py-1 text-[11px] uppercase tracking-[0.08em] text-ink-faint">
-                            {member.role}
-                          </span>
                         </div>
-                      </div>
-                    ))}
+                      );
+                    })}
                   </div>
                 </div>
               ) : null}

--- a/desktop/src/renderer/components/settings/TeamSettingsSection.tsx
+++ b/desktop/src/renderer/components/settings/TeamSettingsSection.tsx
@@ -334,7 +334,7 @@ export function TeamSettingsSection({
                                     {isEditing ? "Editing" : "Edit"}
                                   </Button>
                                   <Button
-                                    disabled={busyWithOther || isSelf}
+                                    disabled={busyWithOther || isSelf || isRemovingThis}
                                     onClick={() => void handleRemoveMember(member)}
                                     size="sm"
                                     title={isSelf ? "You cannot remove yourself." : undefined}

--- a/desktop/src/renderer/state/session/desktop-bridge.ts
+++ b/desktop/src/renderer/state/session/desktop-bridge.ts
@@ -51,6 +51,7 @@ export function getDesktopBridge(): DesktopBridge | null {
     typeof bridge.team?.getState !== "function" ||
     typeof bridge.team?.createFirstTeam !== "function" ||
     typeof bridge.team?.saveMember !== "function" ||
+    typeof bridge.team?.removeMember !== "function" ||
     typeof bridge.automations?.list !== "function" ||
     typeof bridge.automations?.get !== "function" ||
     typeof bridge.automations?.save !== "function" ||

--- a/desktop/src/shared/contracts/bridge.ts
+++ b/desktop/src/shared/contracts/bridge.ts
@@ -40,6 +40,7 @@ import type { RuntimeInfo } from "./runtime.js";
 import type { DesktopPolicyRulesResult, DesktopSettingsResult, DesktopSettingsUpdateRequest } from "./settings.js";
 import type {
   DesktopCreateFirstTeamRequest,
+  DesktopRemoveTeamMemberRequest,
   DesktopSaveTeamMemberRequest,
   DesktopTeamStateResult,
 } from "./tenant.js";
@@ -152,6 +153,7 @@ export interface DesktopBridge {
     getState(): Promise<DesktopTeamStateResult>;
     createFirstTeam(request: DesktopCreateFirstTeamRequest): Promise<DesktopTeamStateResult>;
     saveMember(request: DesktopSaveTeamMemberRequest): Promise<DesktopTeamStateResult>;
+    removeMember(request: DesktopRemoveTeamMemberRequest): Promise<DesktopTeamStateResult>;
   };
   automations: {
     list(): Promise<DesktopAutomationListResult>;

--- a/desktop/src/shared/contracts/runtime.ts
+++ b/desktop/src/shared/contracts/runtime.ts
@@ -72,6 +72,7 @@ export const IPC_CHANNELS = {
   getDesktopTeamState: "sense1:desktop:team:get-state",
   createDesktopFirstTeam: "sense1:desktop:team:create-first",
   saveDesktopTeamMember: "sense1:desktop:team:save-member",
+  removeDesktopTeamMember: "sense1:desktop:team:remove-member",
   listDesktopAutomations: "sense1:desktop:automations:list",
   getDesktopAutomation: "sense1:desktop:automations:get",
   saveDesktopAutomation: "sense1:desktop:automations:save",

--- a/desktop/src/shared/contracts/tenant.ts
+++ b/desktop/src/shared/contracts/tenant.ts
@@ -28,4 +28,9 @@ export interface DesktopSaveTeamMemberRequest {
   readonly email: string;
   readonly role: "member" | "admin";
   readonly displayName?: string | null;
+  readonly previousEmail?: string | null;
+}
+
+export interface DesktopRemoveTeamMemberRequest {
+  readonly email: string;
 }


### PR DESCRIPTION
## Summary
- Adds `removeMember` IPC/service/bridge path with guards against self-removal and removing the last admin
- Extends `saveMember` with `previousEmail` so an edit that changes the email atomically drops the old row and inserts the new one
- Surfaces per-row **Edit** and **Remove** controls on the Settings > Team members list, with edit-mode banner, rename collision protection, and confirm dialog before remove

Closes #83

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test:main` (557/557, including 8 new tenant-service tests)
- [x] `pnpm test:renderer` (177/177)
- [x] `pnpm build`
- [x] `pnpm qa:electron:smoke`
- [x] Manual smoke in dev: create team, add member, edit role, rename to fix typo, remove member, verify self-remove disabled, verify last-admin rename guard blocks self-rename