### PR TITLE
Improve desktop responsiveness and align settings terminology

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ CLAUDE.md
 .omx/
 .env*.local
 /docs/*
+.agent/
 
 # Build output
 /desktop/dist/

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -5,7 +5,6 @@ import { AppServerProcessManager } from "./runtime/app-server-process-manager.js
 import { DESKTOP_APP_VERSION } from "./app/app-version.ts";
 import { DesktopSessionController } from "./session-controller.js";
 import { resolveDesktopProfile } from "./bootstrap/desktop-bootstrap.js";
-import { resolveSignedInDesktopProfile } from "./bootstrap/bootstrap-profile.js";
 import {
   filterProfileCodexHomeRoots,
   latestUserEntryRequestsManagedInventoryInstall,
@@ -27,7 +26,6 @@ import { ThreadStateAccumulator } from "./session/thread-state-accumulator.js";
 import { DesktopUpdateService } from "./updates/update-service.ts";
 import { WorkspaceFileActivityTracker } from "./workspace/workspace-file-activity.ts";
 import { collectOutOfWorkspacePathsFromRuntimeMessage } from "./workspace/workspace-boundary.ts";
-import { DesktopWorkspaceStateService } from "./workspace/workspace-state-service.ts";
 import { resolveDesktopInteractionState } from "./session/interaction-state.ts";
 import { ThreadInputQueueService } from "./session/thread-input-queue-service.ts";
 import { resolveBootstrapVisibleThreadId, shouldRestoreQueuedFollowUp } from "./session/thread-runtime-behavior.ts";
@@ -106,10 +104,6 @@ const threadInputQueue = new ThreadInputQueueService();
 const workspaceFileActivity = new WorkspaceFileActivityTracker();
 const runtimeFileChangeTracker = new RuntimeFileChangeTracker();
 const managementInventoryChangeTracker = new ManagementInventoryChangeTracker();
-const workspaceState = new DesktopWorkspaceStateService({
-  env: process.env,
-  resolveProfile: async () => await resolveSignedInDesktopProfile(appServerManager, process.env),
-});
 let updateService = createDisabledUpdateService();
 let currentVisibleThreadId: string | null = null;
 let currentAccountType: string | null = null;
@@ -296,7 +290,7 @@ async function persistInteractionState(threadId: string): Promise<void> {
     return;
   }
 
-  await workspaceState.rememberThreadInteractionState(threadId, currentThreadState.interactionState);
+  await desktopSessionController.rememberThreadInteractionState(threadId, currentThreadState.interactionState);
 }
 
 function initializeActiveThread(result: {
@@ -819,10 +813,15 @@ appServerManager.on("notification", (message) => {
       void persistInteractionState(threadId).catch(() => {});
     }
     runtimeFileChangeTracker.clear(threadId);
-    if (
-      managementInventoryChangeTracker.consume(threadId)
-      || latestUserEntryRequestsManagedInventoryInstall(currentThreadState)
-    ) {
+    const inventoryChanged = managementInventoryChangeTracker.consume(threadId);
+    const managedInventoryInstallRequested = latestUserEntryRequestsManagedInventoryInstall(currentThreadState);
+    if (inventoryChanged || managedInventoryInstallRequested) {
+      console.warn("[sense1:perf:main]", {
+        event: "managementInventoryChanged",
+        inventoryChanged,
+        managedInventoryInstallRequested,
+        threadId,
+      });
       emitDesktopRuntimeEvent({ kind: "managementInventoryChanged" });
     }
 

--- a/desktop/src/main/profile/profile-paths.js
+++ b/desktop/src/main/profile/profile-paths.js
@@ -11,6 +11,8 @@ const ACTIVE_PROFILE_FILE = "_active.json";
 const ARTIFACT_ROOT_FILE = "artifact-root.json";
 const SUBSTRATE_DB_FILE = "sense1.db";
 const AUTH_FILE = "auth.json";
+const ensuredProfileDirectoriesCache = new Map();
+const runtimeStateRootCache = new Map();
 const SENSE1_SKILL_CREATOR_OVERRIDE_MARKER = "## Sense-1 Workspace Desktop Override";
 const SENSE1_SKILL_CREATOR_OVERRIDE = [
   SENSE1_SKILL_CREATOR_OVERRIDE_MARKER,
@@ -104,10 +106,32 @@ export function sanitizeProfileId(value) {
   return cleaned || DEFAULT_PROFILE_ID;
 }
 
-export function resolveRuntimeStateRoot(env = process.env) {
+function buildRuntimeStateRootCacheKey(env = process.env) {
   const explicitRoot = env.SENSE1_RUNTIME_STATE_ROOT?.trim();
   if (explicitRoot) {
-    return path.resolve(explicitRoot);
+    return `explicit:${process.platform}:${path.resolve(explicitRoot)}`;
+  }
+
+  return JSON.stringify({
+    home: env.HOME?.trim() || os.homedir(),
+    localAppData: env.LOCALAPPDATA?.trim() || "",
+    platform: process.platform,
+    xdgDataHome: env.XDG_DATA_HOME?.trim() || "",
+  });
+}
+
+export function resolveRuntimeStateRoot(env = process.env) {
+  const cacheKey = buildRuntimeStateRootCacheKey(env);
+  const cachedRoot = runtimeStateRootCache.get(cacheKey);
+  if (cachedRoot) {
+    return cachedRoot;
+  }
+
+  const explicitRoot = env.SENSE1_RUNTIME_STATE_ROOT?.trim();
+  if (explicitRoot) {
+    const resolvedRoot = path.resolve(explicitRoot);
+    runtimeStateRootCache.set(cacheKey, resolvedRoot);
+    return resolvedRoot;
   }
 
   if (process.platform === "darwin") {
@@ -125,6 +149,7 @@ export function resolveRuntimeStateRoot(env = process.env) {
           exactMatches.map((entryName) => path.join(appSupportRoot, entryName)),
         );
         if (preferredExactMatch) {
+          runtimeStateRootCache.set(cacheKey, preferredExactMatch);
           return preferredExactMatch;
         }
       }
@@ -134,21 +159,29 @@ export function resolveRuntimeStateRoot(env = process.env) {
           (entryName) => entryName.toLowerCase() === candidateName.toLowerCase(),
         );
         if (looseMatch) {
-          return path.join(appSupportRoot, looseMatch);
+          const resolvedRoot = path.join(appSupportRoot, looseMatch);
+          runtimeStateRootCache.set(cacheKey, resolvedRoot);
+          return resolvedRoot;
         }
       }
     }
 
-    return path.join(appSupportRoot, DARWIN_RUNTIME_STATE_ROOT_NAMES[0]);
+    const resolvedRoot = path.join(appSupportRoot, DARWIN_RUNTIME_STATE_ROOT_NAMES[0]);
+    runtimeStateRootCache.set(cacheKey, resolvedRoot);
+    return resolvedRoot;
   }
 
   if (process.platform === "win32") {
     const localAppData = env.LOCALAPPDATA || path.join(os.homedir(), "AppData", "Local");
-    return path.join(localAppData, APP_NAME);
+    const resolvedRoot = path.join(localAppData, APP_NAME);
+    runtimeStateRootCache.set(cacheKey, resolvedRoot);
+    return resolvedRoot;
   }
 
   const xdgDataHome = env.XDG_DATA_HOME || path.join(os.homedir(), ".local", "share");
-  return path.join(xdgDataHome, APP_NAME);
+  const resolvedRoot = path.join(xdgDataHome, APP_NAME);
+  runtimeStateRootCache.set(cacheKey, resolvedRoot);
+  return resolvedRoot;
 }
 
 export function resolveProfilesDir(env = process.env) {
@@ -318,25 +351,39 @@ export async function ensureProfileDirectories(profileId, env = process.env) {
   const profile = sanitizeProfileId(profileId);
   const profileRoot = resolveProfileRoot(profile, env);
   const codexHome = resolveProfileCodexHome(profile, env);
-  await fs.mkdir(profileRoot, { recursive: true });
-  await fs.mkdir(codexHome, { recursive: true });
-  await healProfileAuthFromLegacyDesktopRoot(profile, env);
-  try {
-    await syncProfileSystemSkills(codexHome, env);
-  } catch (error) {
-    if (!isMissingPathError(error)) {
-      throw error;
-    }
-    console.warn(
-      `[desktop:profile] Skipping transient system skill sync failure for profile "${profile}". ${error.message}`,
-    );
+  const cacheKey = `${profileRoot}::${codexHome}`;
+  const cached = ensuredProfileDirectoriesCache.get(cacheKey);
+  if (cached) {
+    return await cached;
   }
 
-  return {
-    profileId: profile,
-    profileRoot,
-    codexHome,
-  };
+  const ensurePromise = (async () => {
+    await fs.mkdir(profileRoot, { recursive: true });
+    await fs.mkdir(codexHome, { recursive: true });
+    await healProfileAuthFromLegacyDesktopRoot(profile, env);
+    try {
+      await syncProfileSystemSkills(codexHome, env);
+    } catch (error) {
+      if (!isMissingPathError(error)) {
+        throw error;
+      }
+      console.warn(
+        `[desktop:profile] Skipping transient system skill sync failure for profile "${profile}". ${error.message}`,
+      );
+    }
+
+    return {
+      profileId: profile,
+      profileRoot,
+      codexHome,
+    };
+  })().catch((error) => {
+    ensuredProfileDirectoriesCache.delete(cacheKey);
+    throw error;
+  });
+
+  ensuredProfileDirectoriesCache.set(cacheKey, ensurePromise);
+  return await ensurePromise;
 }
 
 function resolveArtifactRootFile(profileId, env = process.env) {

--- a/desktop/src/main/profile/profile-paths.test.js
+++ b/desktop/src/main/profile/profile-paths.test.js
@@ -84,6 +84,41 @@ test("ensureProfileDirectories tolerates a shared system skill entry disappearin
   }
 });
 
+test("ensureProfileDirectories reuses the initial profile setup work for repeated calls", async () => {
+  const runtimeStateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-runtime-state-"));
+  const sharedCodexHome = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-shared-codex-home-"));
+  const env = {
+    ...process.env,
+    CODEX_HOME: sharedCodexHome,
+    SENSE1_RUNTIME_STATE_ROOT: runtimeStateRoot,
+  };
+  const sharedSystemSkillsDir = path.join(sharedCodexHome, "skills", ".system");
+  const sharedPluginCreatorDir = path.join(sharedSystemSkillsDir, "plugin-creator");
+  const originalCopyFile = fs.copyFile;
+  let copyFileCalls = 0;
+
+  try {
+    await fs.mkdir(sharedPluginCreatorDir, { recursive: true });
+    await fs.writeFile(path.join(sharedSystemSkillsDir, ".codex-system-skills.marker"), "", "utf8");
+    await fs.writeFile(path.join(sharedPluginCreatorDir, "SKILL.md"), "# Plugin Creator\n", "utf8");
+    fs.copyFile = async (...args) => {
+      copyFileCalls += 1;
+      return await originalCopyFile.call(fs, ...args);
+    };
+
+    await ensureProfileDirectories("default", env);
+    const firstCopyFileCalls = copyFileCalls;
+    await ensureProfileDirectories("default", env);
+
+    assert.ok(firstCopyFileCalls > 0);
+    assert.equal(copyFileCalls, firstCopyFileCalls);
+  } finally {
+    fs.copyFile = originalCopyFile;
+    await fs.rm(runtimeStateRoot, { recursive: true, force: true });
+    await fs.rm(sharedCodexHome, { recursive: true, force: true });
+  }
+});
+
 test("ensureProfileDirectories repairs an invalid profile auth file from the legacy desktop auth store", async () => {
   const runtimeStateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-runtime-state-"));
   const sharedCodexHome = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-shared-codex-home-"));
@@ -152,6 +187,34 @@ test("resolveRuntimeStateRoot preserves an existing lowercase macOS app-support 
 
     try {
       assert.equal(resolveRuntimeStateRoot(process.env), legacyRoot);
+    } finally {
+      process.env.HOME = originalHome;
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  } finally {
+    await fs.rm(fakeHomeDir, { recursive: true, force: true });
+  }
+});
+
+test("resolveRuntimeStateRoot reuses the resolved macOS app-support directory within the same environment", async () => {
+  const fakeHomeDir = await fs.mkdtemp(path.join(os.tmpdir(), "sense1-home-"));
+  const brandedRoot = path.join(fakeHomeDir, "Library", "Application Support", "Sense-1");
+  const lowercaseRoot = path.join(fakeHomeDir, "Library", "Application Support", "sense-1");
+
+  try {
+    await fs.mkdir(brandedRoot, { recursive: true });
+    const originalPlatform = process.platform;
+    const originalHome = process.env.HOME;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    process.env.HOME = fakeHomeDir;
+
+    try {
+      const first = resolveRuntimeStateRoot(process.env);
+      await fs.rm(brandedRoot, { recursive: true, force: true });
+      await fs.mkdir(lowercaseRoot, { recursive: true });
+
+      assert.equal(first, brandedRoot);
+      assert.equal(resolveRuntimeStateRoot(process.env), brandedRoot);
     } finally {
       process.env.HOME = originalHome;
       Object.defineProperty(process, "platform", { value: originalPlatform });

--- a/desktop/src/main/runtime/live-thread-runtime-policy.js
+++ b/desktop/src/main/runtime/live-thread-runtime-policy.js
@@ -40,6 +40,7 @@ export const DEFAULT_DESKTOP_RUNTIME_INSTRUCTIONS = "Follow the Sense-1 desktop 
 const DEFAULT_DESKTOP_APPROVAL_POSTURE = "onRequest";
 const DEFAULT_DESKTOP_SANDBOX_POSTURE = "workspaceWrite";
 const DEFAULT_DESKTOP_OPERATING_MODE = "auto";
+const DEFAULT_DESKTOP_VERBOSITY = "balanced";
 const DESKTOP_THREAD_CONFIG = Object.freeze({
   developer_instructions: "",
   instructions: "",
@@ -145,10 +146,32 @@ function normalizeOperatingMode(value) {
   return DEFAULT_DESKTOP_OPERATING_MODE;
 }
 
-function resolvePolicyRuleSettings(settings = null, runtimeInstructions = null) {
+function normalizeDesktopVerbosity(value, fallback = DEFAULT_DESKTOP_VERBOSITY) {
+  const resolved = firstString(value);
+  if (resolved === "terse" || resolved === "balanced" || resolved === "detailed") {
+    return resolved;
+  }
+
+  if (resolved === "low") {
+    return "terse";
+  }
+
+  if (resolved === "medium") {
+    return "balanced";
+  }
+
+  if (resolved === "high") {
+    return "detailed";
+  }
+
+  return fallback;
+}
+
+function resolvePolicyRuleSettings(settings = null, runtimeInstructions = null, verbosity = null) {
   const record = asRecord(settings) ?? {};
   return {
     personality: normalizeDesktopPersonality(record.personality),
+    verbosity: normalizeDesktopVerbosity(verbosity ?? record.verbosity),
     defaultOperatingMode: normalizeOperatingMode(record.defaultOperatingMode),
     runtimeInstructions: resolveDesktopRuntimeInstructions(runtimeInstructions ?? record.runtimeInstructions),
     approvalPosture: normalizeApprovalPosture(record.approvalPosture),
@@ -174,6 +197,33 @@ function describePersonalityRule(personality) {
   return {
     currentValue: "Friendly",
     description: "Sense-1 uses a friendly, direct tone while still keeping answers calm and clear.",
+  };
+}
+
+function describeVerbosityRule(verbosity) {
+  if (verbosity === "terse") {
+    return {
+      currentValue: "Terse",
+      description: "Sense-1 keeps replies compact and expands only when accuracy or the user requires more detail.",
+      developerInstruction:
+        "Prefer short answers by default. Keep updates brief, skip unnecessary preamble, and expand only when needed for accuracy or when the user asks for more detail.",
+    };
+  }
+
+  if (verbosity === "detailed") {
+    return {
+      currentValue: "Detailed",
+      description: "Sense-1 includes more explanation and context by default when it helps the user follow the work.",
+      developerInstruction:
+        "When it helps, provide a bit more explanation and context so the user can follow the work and tradeoffs.",
+    };
+  }
+
+  return {
+    currentValue: "Balanced",
+    description: "Sense-1 aims for concise but sufficient detail by default.",
+    developerInstruction:
+      "Default to concise but sufficient answers. Use enough detail to be clear without over-explaining.",
   };
 }
 
@@ -237,13 +287,15 @@ function buildPolicyRuleGroups({
   cwd = null,
   runtimeInstructions = null,
   settings = null,
+  verbosity = null,
   workspaceContextInstruction = null,
   workspaceRoot = null,
 } = {}) {
   const resolvedWorkspaceRoot = firstString(workspaceRoot);
   const resolvedCwd = firstString(cwd);
-  const resolvedSettings = resolvePolicyRuleSettings(settings, runtimeInstructions);
+  const resolvedSettings = resolvePolicyRuleSettings(settings, runtimeInstructions, verbosity);
   const personalityRule = describePersonalityRule(resolvedSettings.personality);
+  const verbosityRule = describeVerbosityRule(resolvedSettings.verbosity);
   const approvalRule = describeApprovalPostureRule(resolvedSettings.approvalPosture);
   const sandboxRule = describeSandboxPostureRule(resolvedSettings.sandboxPosture);
   const operatingModeRule = describeOperatingModeRule(resolvedSettings.defaultOperatingMode);
@@ -254,13 +306,13 @@ function buildPolicyRuleGroups({
       rules: [
         {
           id: "runtime-guidance",
-          label: "Runtime guidance",
+          label: "Custom instructions",
           currentValue:
             resolvedSettings.runtimeInstructions === DEFAULT_DESKTOP_RUNTIME_INSTRUCTIONS ? "Default" : "Custom",
           description:
             resolvedSettings.runtimeInstructions === DEFAULT_DESKTOP_RUNTIME_INSTRUCTIONS
-              ? "Sense-1 follows the default desktop runtime contract unless extra guidance is configured."
-              : "Sense-1 follows custom desktop runtime guidance that has been configured for every run.",
+              ? "Sense-1 uses the default desktop custom-instruction contract unless extra guidance is configured."
+              : "Sense-1 merges custom user guidance into every run alongside the built-in workspace and safety rules.",
           developerInstruction: resolvedSettings.runtimeInstructions,
         },
         {
@@ -268,6 +320,13 @@ function buildPolicyRuleGroups({
           label: "Voice",
           currentValue: personalityRule.currentValue,
           description: personalityRule.description,
+        },
+        {
+          id: "verbosity",
+          label: "Response detail",
+          currentValue: verbosityRule.currentValue,
+          description: verbosityRule.description,
+          developerInstruction: verbosityRule.developerInstruction,
         },
       ],
     },
@@ -410,6 +469,7 @@ function collectDeveloperInstructions(groups) {
 
   return [
     "runtime-guidance",
+    "verbosity",
     "selected-folder-scope",
     "deliverable-formats",
     "file-names",
@@ -429,6 +489,7 @@ export function buildInstructionSet({
   cwd = null,
   runtimeInstructions = null,
   settings = null,
+  verbosity = null,
   workspaceContextInstruction = null,
   workspaceRoot = null,
 } = {}) {
@@ -453,6 +514,7 @@ export function buildInstructionSet({
       cwd: resolvedCwd,
       runtimeInstructions: resolvedRuntimeInstructions,
       settings,
+      verbosity,
       workspaceContextInstruction,
       workspaceRoot: resolvedWorkspaceRoot,
     }),

--- a/desktop/src/main/runtime/live-thread-runtime-policy.js
+++ b/desktop/src/main/runtime/live-thread-runtime-policy.js
@@ -40,7 +40,7 @@ export const DEFAULT_DESKTOP_RUNTIME_INSTRUCTIONS = "Follow the Sense-1 desktop 
 const DEFAULT_DESKTOP_APPROVAL_POSTURE = "onRequest";
 const DEFAULT_DESKTOP_SANDBOX_POSTURE = "workspaceWrite";
 const DEFAULT_DESKTOP_OPERATING_MODE = "auto";
-const DEFAULT_DESKTOP_VERBOSITY = "balanced";
+const DEFAULT_DESKTOP_VERBOSITY = "medium";
 const DESKTOP_THREAD_CONFIG = Object.freeze({
   developer_instructions: "",
   instructions: "",
@@ -146,22 +146,22 @@ function normalizeOperatingMode(value) {
   return DEFAULT_DESKTOP_OPERATING_MODE;
 }
 
-function normalizeDesktopVerbosity(value, fallback = DEFAULT_DESKTOP_VERBOSITY) {
+export function normalizeDesktopVerbosity(value, fallback = DEFAULT_DESKTOP_VERBOSITY) {
   const resolved = firstString(value);
-  if (resolved === "terse" || resolved === "balanced" || resolved === "detailed") {
+  if (resolved === "low" || resolved === "medium" || resolved === "high") {
     return resolved;
   }
 
-  if (resolved === "low") {
-    return "terse";
+  if (resolved === "terse") {
+    return "low";
   }
 
-  if (resolved === "medium") {
-    return "balanced";
+  if (resolved === "balanced") {
+    return "medium";
   }
 
-  if (resolved === "high") {
-    return "detailed";
+  if (resolved === "detailed") {
+    return "high";
   }
 
   return fallback;
@@ -201,18 +201,18 @@ function describePersonalityRule(personality) {
 }
 
 function describeVerbosityRule(verbosity) {
-  if (verbosity === "terse") {
+  if (verbosity === "low") {
     return {
-      currentValue: "Terse",
+      currentValue: "Low",
       description: "Sense-1 keeps replies compact and expands only when accuracy or the user requires more detail.",
       developerInstruction:
         "Prefer short answers by default. Keep updates brief, skip unnecessary preamble, and expand only when needed for accuracy or when the user asks for more detail.",
     };
   }
 
-  if (verbosity === "detailed") {
+  if (verbosity === "high") {
     return {
-      currentValue: "Detailed",
+      currentValue: "High",
       description: "Sense-1 includes more explanation and context by default when it helps the user follow the work.",
       developerInstruction:
         "When it helps, provide a bit more explanation and context so the user can follow the work and tradeoffs.",
@@ -220,7 +220,7 @@ function describeVerbosityRule(verbosity) {
   }
 
   return {
-    currentValue: "Balanced",
+    currentValue: "Medium",
     description: "Sense-1 aims for concise but sufficient detail by default.",
     developerInstruction:
       "Default to concise but sufficient answers. Use enough detail to be clear without over-explaining.",

--- a/desktop/src/main/runtime/live-thread-runtime-request.js
+++ b/desktop/src/main/runtime/live-thread-runtime-request.js
@@ -56,6 +56,23 @@ function cloneRunContext(runContext) {
 
 const DEFAULT_DESKTOP_SERVICE_NAME = "sense_1";
 
+function mapDesktopVerbosityToModelVerbosity(verbosity = null) {
+  const resolved = firstString(verbosity);
+  if (resolved === "terse" || resolved === "low") {
+    return "low";
+  }
+
+  if (resolved === "balanced" || resolved === "medium") {
+    return "medium";
+  }
+
+  if (resolved === "detailed" || resolved === "high") {
+    return "high";
+  }
+
+  return null;
+}
+
 export function buildCollaborationMode({
   mode = "default",
   model = null,
@@ -70,7 +87,7 @@ export function buildCollaborationMode({
       model: firstString(model) ?? "",
       reasoning_effort: firstString(reasoningEffort),
       service_tier: firstString(serviceTier),
-      verbosity: firstString(verbosity),
+      verbosity: mapDesktopVerbosityToModelVerbosity(verbosity),
     },
   };
 }
@@ -237,6 +254,7 @@ export function buildDesktopThreadRequest({
   runContext = null,
   runtimeInstructions = null,
   settings = null,
+  verbosity = null,
   workspaceRoot = null,
 } = {}) {
   const resolvedModel = firstString(model) || DEFAULT_DESKTOP_MODEL;
@@ -248,8 +266,10 @@ export function buildDesktopThreadRequest({
   const instructionSet = buildInstructionSet({
     authority: describeAuthority(runContext),
     cwd,
+    // The settings field is additive developer guidance, not an editor for the base product prompt.
     runtimeInstructions,
     settings,
+    verbosity,
     workspaceContextInstruction: firstString(workspaceRoot)
       ? buildWorkspaceContextInstruction(contextPaths, workspaceRoot)
       : null,
@@ -260,6 +280,7 @@ export function buildDesktopThreadRequest({
     baseInstructions: instructionSet.baseInstructions,
     config: {
       ...cloneDesktopThreadConfig(),
+      // Keep user guidance additive in developer_instructions while the base product prompt stays in instructions.
       developer_instructions: instructionSet.developerInstructions,
       instructions: instructionSet.baseInstructions,
       model: resolvedModel,

--- a/desktop/src/main/runtime/live-thread-runtime-request.js
+++ b/desktop/src/main/runtime/live-thread-runtime-request.js
@@ -58,15 +58,15 @@ const DEFAULT_DESKTOP_SERVICE_NAME = "sense_1";
 
 function mapDesktopVerbosityToModelVerbosity(verbosity = null) {
   const resolved = firstString(verbosity);
-  if (resolved === "terse" || resolved === "low") {
+  if (resolved === "low" || resolved === "terse") {
     return "low";
   }
 
-  if (resolved === "balanced" || resolved === "medium") {
+  if (resolved === "medium" || resolved === "balanced") {
     return "medium";
   }
 
-  if (resolved === "detailed" || resolved === "high") {
+  if (resolved === "high" || resolved === "detailed") {
     return "high";
   }
 

--- a/desktop/src/main/runtime/live-thread-runtime.d.ts
+++ b/desktop/src/main/runtime/live-thread-runtime.d.ts
@@ -131,6 +131,7 @@ export function ensureDesktopThread(
     runContext?: DesktopRunContext | null;
     runtimeInstructions?: string | null;
     settings?: Record<string, unknown> | null;
+    verbosity?: DesktopVerbosity | null;
     threadId?: string | null;
     workspaceRoot?: string | null;
   },

--- a/desktop/src/main/runtime/live-thread-runtime.js
+++ b/desktop/src/main/runtime/live-thread-runtime.js
@@ -1,4 +1,9 @@
-import { buildExecutionOverrides, DEFAULT_DESKTOP_MODEL, normalizeDesktopPersonality } from "./live-thread-runtime-policy.js";
+import {
+  buildExecutionOverrides,
+  DEFAULT_DESKTOP_MODEL,
+  normalizeDesktopPersonality,
+  normalizeDesktopVerbosity,
+} from "./live-thread-runtime-policy.js";
 import {
   buildCollaborationMode,
   buildDesktopThreadRequest,
@@ -279,7 +284,7 @@ export async function runDesktopTask(
           executionIntent,
           runContext: productRunContext,
           serviceTier: firstString(serviceTier) ?? "flex",
-          verbosity: firstString(verbosity, settings?.verbosity) ?? "balanced",
+          verbosity: normalizeDesktopVerbosity(firstString(verbosity, settings?.verbosity)),
         },
       },
     });
@@ -318,7 +323,7 @@ export async function runDesktopTask(
             executionIntent,
             runContext: productRunContext,
             serviceTier: firstString(serviceTier) ?? "flex",
-            verbosity: firstString(verbosity, settings?.verbosity) ?? "balanced",
+            verbosity: normalizeDesktopVerbosity(firstString(verbosity, settings?.verbosity)),
           },
         },
       });

--- a/desktop/src/main/runtime/live-thread-runtime.js
+++ b/desktop/src/main/runtime/live-thread-runtime.js
@@ -233,6 +233,7 @@ export async function runDesktopTask(
     runContext: productRunContext,
     runtimeInstructions,
     settings,
+    verbosity,
     threadId: resolvedThreadId,
     workspaceRoot: resolvedWorkspaceRoot,
   });
@@ -297,6 +298,7 @@ export async function runDesktopTask(
         runContext: productRunContext,
         runtimeInstructions,
         settings,
+        verbosity,
         workspaceRoot: resolvedWorkspaceRoot,
       });
       thread = restartedThread.thread;
@@ -381,6 +383,7 @@ export async function ensureDesktopThread(
     runContext = null,
     runtimeInstructions = null,
     settings = null,
+    verbosity = null,
     threadId = null,
     workspaceRoot = null,
   },
@@ -421,6 +424,7 @@ export async function ensureDesktopThread(
           runContext: productRunContext,
           runtimeInstructions,
           settings,
+          verbosity,
           workspaceRoot: resolvedWorkspaceRoot,
         }),
         threadId: nextThreadId,
@@ -443,6 +447,7 @@ export async function ensureDesktopThread(
         runContext: productRunContext,
         runtimeInstructions,
         settings,
+        verbosity,
         workspaceRoot: resolvedWorkspaceRoot,
       }),
       settings: {

--- a/desktop/src/main/runtime/live-thread-runtime.test.js
+++ b/desktop/src/main/runtime/live-thread-runtime.test.js
@@ -16,6 +16,7 @@ import {
 function buildSettings(overrides = {}) {
   return {
     personality: "friendly",
+    verbosity: "balanced",
     defaultOperatingMode: "auto",
     runtimeInstructions: DEFAULT_DESKTOP_RUNTIME_INSTRUCTIONS,
     approvalPosture: "onRequest",
@@ -24,16 +25,30 @@ function buildSettings(overrides = {}) {
   };
 }
 
+function buildExpectedVerbosityInstruction(verbosity = "balanced") {
+  if (verbosity === "terse") {
+    return "Prefer short answers by default. Keep updates brief, skip unnecessary preamble, and expand only when needed for accuracy or when the user asks for more detail.";
+  }
+
+  if (verbosity === "detailed") {
+    return "When it helps, provide a bit more explanation and context so the user can follow the work and tradeoffs.";
+  }
+
+  return "Default to concise but sufficient answers. Use enough detail to be clear without over-explaining.";
+}
+
 function buildExpectedInstructions({
   cwd = null,
   contextPaths = [],
   runContext = null,
   runtimeInstructions = DEFAULT_DESKTOP_RUNTIME_INSTRUCTIONS,
   settings = buildSettings(),
+  verbosity = null,
   workspaceRoot = null,
 }) {
   const actorLabel = runContext?.actor?.displayName ?? runContext?.actor?.email ?? "the signed-in user";
   const scopeLabel = runContext?.scope?.displayName ?? runContext?.scope?.id ?? "the private profile scope";
+  const resolvedVerbosity = verbosity ?? settings.verbosity ?? "balanced";
   const contextInstruction = workspaceRoot && Array.isArray(contextPaths) && contextPaths.length > 0
     ? `Key files in this workspace: ${contextPaths
       .slice(0, 10)
@@ -56,6 +71,7 @@ function buildExpectedInstructions({
       .join(" "),
     developerInstructions: [
       runtimeInstructions.trim() || DEFAULT_DESKTOP_RUNTIME_INSTRUCTIONS,
+      buildExpectedVerbosityInstruction(resolvedVerbosity),
       workspaceRoot
         ? `Work inside the granted workspace folder at ${workspaceRoot}. Do not create, modify, or delete files outside this folder. If the user asks to write to a path outside ${workspaceRoot}, refuse and explain that the current session is bound to this folder.`
         : "Do not describe the run as workspace-bound unless a workspaceRoot is explicitly provided.",
@@ -94,6 +110,7 @@ test("describePolicyRules returns stable grouped rules for the default desktop s
 test("describePolicyRules reflects behavior-affecting settings changes in plain English", () => {
   const groups = describePolicyRules(buildSettings({
     personality: "pragmatic",
+    verbosity: "detailed",
     runtimeInstructions: "Use the operator tone from the desktop playbook.",
     approvalPosture: "unlessTrusted",
     sandboxPosture: "readOnly",
@@ -106,6 +123,7 @@ test("describePolicyRules reflects behavior-affecting settings changes in plain 
 
   assert.equal(identity?.rules[0]?.currentValue, "Custom");
   assert.equal(identity?.rules[1]?.currentValue, "Pragmatic");
+  assert.equal(identity?.rules[2]?.currentValue, "Detailed");
   assert.match(approvals?.rules[0]?.description ?? "", /trusted contexts/i);
   assert.match(approvals?.rules[1]?.description ?? "", /read-only posture/i);
   assert.equal(workspace?.rules.at(-1)?.currentValue, "Preview");
@@ -493,6 +511,7 @@ test("runDesktopTask starts a new thread then starts a turn with prompt and cwd"
   const instructions = buildExpectedInstructions({
     cwd: workspaceRoot,
     runContext,
+    verbosity: "terse",
     workspaceRoot,
   });
   const manager = {
@@ -591,7 +610,7 @@ test("runDesktopTask starts a new thread then starts a turn with prompt and cwd"
             model: "gpt-5.4",
             reasoning_effort: null,
             service_tier: "fast",
-            verbosity: "terse",
+            verbosity: "low",
           },
         },
         model: "gpt-5.4",
@@ -627,6 +646,7 @@ test("runDesktopTask starts a new thread then starts a turn with prompt and cwd"
   assert.equal(result.thread.state, "running");
   assert.equal(result.thread.title, "New thread");
   assert.equal(result.thread.workspaceRoot, workspaceRoot);
+  assert.match(calls[0]?.params.developerInstructions ?? "", /Prefer short answers by default\./);
 });
 
 test("runDesktopTask sends attachments as turn/start input items", async () => {

--- a/desktop/src/main/runtime/live-thread-runtime.test.js
+++ b/desktop/src/main/runtime/live-thread-runtime.test.js
@@ -16,7 +16,7 @@ import {
 function buildSettings(overrides = {}) {
   return {
     personality: "friendly",
-    verbosity: "balanced",
+    verbosity: "medium",
     defaultOperatingMode: "auto",
     runtimeInstructions: DEFAULT_DESKTOP_RUNTIME_INSTRUCTIONS,
     approvalPosture: "onRequest",
@@ -25,12 +25,12 @@ function buildSettings(overrides = {}) {
   };
 }
 
-function buildExpectedVerbosityInstruction(verbosity = "balanced") {
-  if (verbosity === "terse") {
+function buildExpectedVerbosityInstruction(verbosity = "medium") {
+  if (verbosity === "low") {
     return "Prefer short answers by default. Keep updates brief, skip unnecessary preamble, and expand only when needed for accuracy or when the user asks for more detail.";
   }
 
-  if (verbosity === "detailed") {
+  if (verbosity === "high") {
     return "When it helps, provide a bit more explanation and context so the user can follow the work and tradeoffs.";
   }
 
@@ -48,7 +48,7 @@ function buildExpectedInstructions({
 }) {
   const actorLabel = runContext?.actor?.displayName ?? runContext?.actor?.email ?? "the signed-in user";
   const scopeLabel = runContext?.scope?.displayName ?? runContext?.scope?.id ?? "the private profile scope";
-  const resolvedVerbosity = verbosity ?? settings.verbosity ?? "balanced";
+  const resolvedVerbosity = verbosity ?? settings.verbosity ?? "medium";
   const contextInstruction = workspaceRoot && Array.isArray(contextPaths) && contextPaths.length > 0
     ? `Key files in this workspace: ${contextPaths
       .slice(0, 10)
@@ -110,7 +110,7 @@ test("describePolicyRules returns stable grouped rules for the default desktop s
 test("describePolicyRules reflects behavior-affecting settings changes in plain English", () => {
   const groups = describePolicyRules(buildSettings({
     personality: "pragmatic",
-    verbosity: "detailed",
+    verbosity: "high",
     runtimeInstructions: "Use the operator tone from the desktop playbook.",
     approvalPosture: "unlessTrusted",
     sandboxPosture: "readOnly",
@@ -123,7 +123,7 @@ test("describePolicyRules reflects behavior-affecting settings changes in plain 
 
   assert.equal(identity?.rules[0]?.currentValue, "Custom");
   assert.equal(identity?.rules[1]?.currentValue, "Pragmatic");
-  assert.equal(identity?.rules[2]?.currentValue, "Detailed");
+  assert.equal(identity?.rules[2]?.currentValue, "High");
   assert.match(approvals?.rules[0]?.description ?? "", /trusted contexts/i);
   assert.match(approvals?.rules[1]?.description ?? "", /read-only posture/i);
   assert.equal(workspace?.rules.at(-1)?.currentValue, "Preview");
@@ -511,7 +511,7 @@ test("runDesktopTask starts a new thread then starts a turn with prompt and cwd"
   const instructions = buildExpectedInstructions({
     cwd: workspaceRoot,
     runContext,
-    verbosity: "terse",
+    verbosity: "low",
     workspaceRoot,
   });
   const manager = {
@@ -632,7 +632,7 @@ test("runDesktopTask starts a new thread then starts a turn with prompt and cwd"
             executionIntent,
             runContext,
             serviceTier: "fast",
-            verbosity: "terse",
+            verbosity: "low",
           },
         },
       },
@@ -1007,7 +1007,7 @@ test("runDesktopTask does not bind a new chat-only thread to the desktop cwd", a
             },
             runContext,
             serviceTier: "flex",
-            verbosity: "balanced",
+            verbosity: "medium",
           },
         },
       },
@@ -1579,7 +1579,7 @@ test("runDesktopTask resumes an existing thread before starting a turn", async (
             },
             runContext,
             serviceTier: "flex",
-            verbosity: "balanced",
+            verbosity: "medium",
           },
         },
       },

--- a/desktop/src/main/session-controller.ts
+++ b/desktop/src/main/session-controller.ts
@@ -41,6 +41,7 @@ import type {
   DesktopMcpServerAuthRequest,
   DesktopMcpServerAuthResult,
   DesktopMcpServerEnabledRequest,
+  DesktopInteractionState,
   DesktopRuntimeEvent,
   DesktopRunContext,
   DesktopPolicyRulesResult,
@@ -820,6 +821,14 @@ export class DesktopSessionController {
   async rememberWorkspaceFolder(folderPath: string): Promise<void> {
     await this.#workspacePermissionRestoreReady;
     await this.#workspaceService.rememberWorkspaceFolder(folderPath);
+  }
+
+  async rememberThreadInteractionState(
+    threadId: string,
+    interactionState: DesktopInteractionState,
+  ): Promise<void> {
+    await this.#workspacePermissionRestoreReady;
+    await this.#workspaceService.rememberThreadInteractionState(threadId, interactionState);
   }
 
   async getWorkspacePolicy(rootPath: string): Promise<DesktopWorkspacePolicyResult> {

--- a/desktop/src/main/session/desktop-approval-service.ts
+++ b/desktop/src/main/session/desktop-approval-service.ts
@@ -110,6 +110,7 @@ export class DesktopApprovalService {
   readonly #trustedSkillApprovals = new Set<string>();
   readonly #approvalResolutionCache = new DesktopApprovalResolutionCache();
   readonly #locallyResolvedRuntimeApprovalIds = new Set<number>();
+  #pendingApprovalPersistQueue: Promise<void> = Promise.resolve();
   #approvalRestoreReady: Promise<void> = Promise.resolve();
   #nextSyntheticApprovalId = -1;
 
@@ -335,11 +336,16 @@ export class DesktopApprovalService {
   }
 
   async #persistApprovals(): Promise<void> {
-    try {
-      await this.#persistPendingApprovals(Array.from(this.#pendingApprovalsById.values()));
-    } catch {
-      // Non-fatal — best-effort durability.
-    }
+    const approvals = Array.from(this.#pendingApprovalsById.values());
+    const nextPersist = this.#pendingApprovalPersistQueue.then(async () => {
+      try {
+        await this.#persistPendingApprovals(approvals);
+      } catch {
+        // Non-fatal — best-effort durability.
+      }
+    });
+    this.#pendingApprovalPersistQueue = nextPersist;
+    await nextPersist;
   }
 
   async #persistTrustedApprovals(): Promise<void> {

--- a/desktop/src/main/session/desktop-run-start-service.ts
+++ b/desktop/src/main/session/desktop-run-start-service.ts
@@ -215,10 +215,16 @@ function mergeRuntimeInstructions(baseInstructions: string, extraInstruction: st
 
 function resolveVerbosity(value: string | null | undefined): DesktopVerbosity {
   switch (value) {
-    case "terse":
-    case "balanced":
-    case "detailed":
+    case "low":
+    case "medium":
+    case "high":
       return value;
+    case "terse":
+      return "low";
+    case "balanced":
+      return "medium";
+    case "detailed":
+      return "high";
     default:
       return DESKTOP_DEFAULT_SETTINGS.verbosity;
   }

--- a/desktop/src/main/session/desktop-run-start-settings.ts
+++ b/desktop/src/main/session/desktop-run-start-settings.ts
@@ -38,7 +38,7 @@ const DESKTOP_SETTING_LABELS: Record<string, string> = Object.freeze({
   personality: "personality",
   reasoningEffort: "reasoning effort",
   runtimeInstructions: "custom instructions",
-  verbosity: "codex settings",
+  verbosity: "verbosity",
   roleApprovalLevel: "role approval level",
   sandboxPosture: "sandbox posture",
   workspaceFolderBinding: "folder-bound thread behavior",

--- a/desktop/src/main/session/desktop-run-start-settings.ts
+++ b/desktop/src/main/session/desktop-run-start-settings.ts
@@ -38,7 +38,7 @@ const DESKTOP_SETTING_LABELS: Record<string, string> = Object.freeze({
   personality: "personality",
   reasoningEffort: "reasoning effort",
   runtimeInstructions: "custom instructions",
-  verbosity: "verbosity",
+  verbosity: "codex settings",
   roleApprovalLevel: "role approval level",
   sandboxPosture: "sandbox posture",
   workspaceFolderBinding: "folder-bound thread behavior",

--- a/desktop/src/main/session/desktop-run-start-settings.ts
+++ b/desktop/src/main/session/desktop-run-start-settings.ts
@@ -37,7 +37,7 @@ const DESKTOP_SETTING_LABELS: Record<string, string> = Object.freeze({
   model: "model",
   personality: "personality",
   reasoningEffort: "reasoning effort",
-  runtimeInstructions: "runtime instructions",
+  runtimeInstructions: "custom instructions",
   verbosity: "verbosity",
   roleApprovalLevel: "role approval level",
   sandboxPosture: "sandbox posture",

--- a/desktop/src/main/session/session-controller.test.js
+++ b/desktop/src/main/session/session-controller.test.js
@@ -1679,6 +1679,7 @@ test("runDesktopTask applies persisted workspace policy defaults to the runtime 
   assert.equal(turnStart?.params.model, "gpt-5.4-mini");
   assert.equal(turnStart?.params.personality, "pragmatic");
   assert.equal(turnStart?.params.reasoningEffort, "high");
+  assert.equal(turnStart?.params.collaborationMode?.settings?.verbosity, "high");
   assert.equal(turnStart?.params.settings?.sense1?.verbosity, "detailed");
   assert.deepEqual(turnStart?.params.sandboxPolicy, {
     type: "workspaceWrite",

--- a/desktop/src/main/session/session-controller.test.js
+++ b/desktop/src/main/session/session-controller.test.js
@@ -1124,7 +1124,7 @@ test("getDesktopSettings resolves legacy flat settings into the current policy-b
   const result = await controller.getDesktopSettings();
   assert.equal(result.settings.model, "gpt-5.4");
   assert.equal(result.settings.reasoningEffort, "high");
-  assert.equal(result.settings.verbosity, "detailed");
+  assert.equal(result.settings.verbosity, "high");
   assert.equal(result.settings.personality, "pragmatic");
   assert.equal(result.settings.runtimeInstructions, DesktopSessionController.DEFAULT_SETTINGS.runtimeInstructions);
   assert.equal(result.settings.sandboxPosture, "readOnly");
@@ -1651,7 +1651,7 @@ test("runDesktopTask applies persisted workspace policy defaults to the runtime 
   await controller.updateDesktopSettings({
     model: "gpt-5.4-mini",
     reasoningEffort: "high",
-    verbosity: "detailed",
+    verbosity: "high",
     personality: "formal",
     runtimeInstructions: "Keep outputs crisp for this desktop runtime.",
     sandboxPosture: "readOnly",
@@ -1680,7 +1680,7 @@ test("runDesktopTask applies persisted workspace policy defaults to the runtime 
   assert.equal(turnStart?.params.personality, "pragmatic");
   assert.equal(turnStart?.params.reasoningEffort, "high");
   assert.equal(turnStart?.params.collaborationMode?.settings?.verbosity, "high");
-  assert.equal(turnStart?.params.settings?.sense1?.verbosity, "detailed");
+  assert.equal(turnStart?.params.settings?.sense1?.verbosity, "high");
   assert.deepEqual(turnStart?.params.sandboxPolicy, {
     type: "workspaceWrite",
     networkAccess: true,

--- a/desktop/src/main/settings/desktop-extension-service.ts
+++ b/desktop/src/main/settings/desktop-extension-service.ts
@@ -126,6 +126,23 @@ function firstString(...values: Array<unknown>): string | null {
   return null;
 }
 
+function logSlowExtensionOperation(
+  operation: string,
+  startedAt: number,
+  details: Record<string, unknown>,
+): void {
+  const durationMs = Date.now() - startedAt;
+  if (durationMs < 100) {
+    return;
+  }
+
+  console.warn("[sense1:perf:main]", {
+    operation,
+    durationMs,
+    ...details,
+  });
+}
+
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
     ? value as Record<string, unknown>
@@ -766,6 +783,7 @@ async function readPluginLocalMetadata(
   plugin: DesktopPluginRecord,
   profileCodexHome: string,
 ): Promise<LocalPluginMetadata> {
+  const startedAt = Date.now();
   const sourcePath = await resolveInstalledPluginSourcePath(plugin, profileCodexHome);
   if (!sourcePath) {
     return {
@@ -846,7 +864,7 @@ async function readPluginLocalMetadata(
     }));
   } catch {}
 
-  return {
+  const metadata = {
     appIds,
     mcpServerIds,
     mcpServers,
@@ -854,6 +872,17 @@ async function readPluginLocalMetadata(
     skills,
     invalidMcpEntries,
   };
+
+  logSlowExtensionOperation("extensions.readPluginLocalMetadata", startedAt, {
+    appIdCount: metadata.appIds.length,
+    mcpServerCount: metadata.mcpServerIds.length,
+    pluginId: plugin.id,
+    pluginName: plugin.name,
+    skillCount: metadata.skills.length,
+    sourcePath,
+  });
+
+  return metadata;
 }
 
 async function readPluginReadmeContent(sourcePath: string | null): Promise<string> {
@@ -1571,6 +1600,7 @@ export class DesktopExtensionService {
     request: DesktopExtensionOverviewRequest,
     runtimeError: string | null,
   ): Promise<DesktopExtensionOverviewResult> {
+    const startedAt = Date.now();
     const profile = await this.#resolveProfile();
     const profileCodexHome = resolveProfileCodexHome(profile.id, this.#env);
     const failedReads: DesktopExtensionBackendFailure[] = [];
@@ -1714,7 +1744,7 @@ export class DesktopExtensionService {
       },
     };
 
-    return {
+    const result: DesktopExtensionOverviewResult = {
       contractVersion: 1,
       provider,
       managedExtensions,
@@ -1724,6 +1754,19 @@ export class DesktopExtensionService {
       skills,
       health,
     };
+
+    logSlowExtensionOperation("extensions.buildOverview", startedAt, {
+      appCount: result.apps.length,
+      failedReadCount: result.health.backend.failedReads.length,
+      forceRefetch: Boolean(request.forceRefetch),
+      managedExtensionCount: result.managedExtensions.length,
+      mcpServerCount: result.mcpServers.length,
+      pluginCount: result.plugins.length,
+      profileId: profile.id,
+      skillCount: result.skills.length,
+    });
+
+    return result;
   }
 
   async readPluginDetail(request: DesktopPluginDetailRequest): Promise<DesktopPluginDetailResult> {

--- a/desktop/src/main/settings/desktop-settings.js
+++ b/desktop/src/main/settings/desktop-settings.js
@@ -4,7 +4,7 @@ export const DEFAULT_DESKTOP_SETTINGS = Object.freeze({
   model: "gpt-5.4-mini",
   reasoningEffort: "xhigh",
   serviceTier: "flex",
-  verbosity: "balanced",
+  verbosity: "medium",
   personality: "friendly",
   defaultOperatingMode: "auto",
   runtimeInstructions: DEFAULT_DESKTOP_RUNTIME_INSTRUCTIONS,
@@ -66,18 +66,18 @@ function normalizeServiceTier(value) {
 
 function normalizeVerbosity(value) {
   const resolved = firstString(value);
-  if (resolved === "terse" || resolved === "balanced" || resolved === "detailed") {
+  if (resolved === "low" || resolved === "medium" || resolved === "high") {
     return resolved;
   }
 
-  if (resolved === "low") {
-    return "terse";
+  if (resolved === "terse") {
+    return "low";
   }
-  if (resolved === "medium") {
-    return "balanced";
+  if (resolved === "balanced") {
+    return "medium";
   }
-  if (resolved === "high") {
-    return "detailed";
+  if (resolved === "detailed") {
+    return "high";
   }
 
   return undefined;

--- a/desktop/src/main/settings/desktop-settings.test.js
+++ b/desktop/src/main/settings/desktop-settings.test.js
@@ -24,7 +24,7 @@ test("resolveDesktopSettings lifts legacy flat settings into effective desktop d
     model: "gpt-5.4",
     reasoningEffort: "high",
     serviceTier: "fast",
-    verbosity: "detailed",
+    verbosity: "high",
     personality: "pragmatic",
     approvalPosture: "onRequest",
     sandboxPosture: "readOnly",
@@ -74,7 +74,7 @@ test("resolveDesktopSettingsState layers workspace defaults and model restrictio
     model: "gpt-5.4-mini",
     reasoningEffort: "medium",
     serviceTier: "fast",
-    verbosity: "terse",
+    verbosity: "low",
     personality: "pragmatic",
     approvalPosture: "onRequest",
     sandboxPosture: "readOnly",
@@ -208,16 +208,16 @@ test("applyDesktopSettingsPatch persists the default verbosity under workspace d
       },
     },
     {
-      verbosity: "terse",
+      verbosity: "low",
     },
   );
 
   assert.deepEqual(next.policy.profile, {
     workspaceDefaults: {
-      verbosity: "terse",
+      verbosity: "low",
     },
   });
-  assert.equal(resolveDesktopSettings(next).verbosity, "terse");
+  assert.equal(resolveDesktopSettings(next).verbosity, "low");
 });
 
 test("applyDesktopSettingsPatch persists the default operating mode under general defaults", () => {

--- a/desktop/src/main/settings/policy-settings.js
+++ b/desktop/src/main/settings/policy-settings.js
@@ -63,20 +63,20 @@ function normalizeOperatingMode(value, fallback = "auto") {
   return fallback;
 }
 
-function normalizeVerbosity(value, fallback = "balanced") {
+function normalizeVerbosity(value, fallback = "medium") {
   const resolved = firstString(value);
-  if (resolved === "terse" || resolved === "balanced" || resolved === "detailed") {
+  if (resolved === "low" || resolved === "medium" || resolved === "high") {
     return resolved;
   }
 
-  if (resolved === "low") {
-    return "terse";
+  if (resolved === "terse") {
+    return "low";
   }
-  if (resolved === "medium") {
-    return "balanced";
+  if (resolved === "balanced") {
+    return "medium";
   }
-  if (resolved === "high") {
-    return "detailed";
+  if (resolved === "detailed") {
+    return "high";
   }
 
   return fallback;

--- a/desktop/src/main/settings/policy.test.js
+++ b/desktop/src/main/settings/policy.test.js
@@ -384,7 +384,7 @@ test("resolveDesktopSettings applies precedence from platform defaults through p
     platformDefaults: {
       model: "gpt-5.4-mini",
       reasoningEffort: "xhigh",
-      verbosity: "balanced",
+      verbosity: "medium",
       personality: "friendly",
       approvalPosture: "never",
       sandboxPosture: "workspaceWrite",
@@ -410,7 +410,7 @@ test("resolveDesktopSettings applies precedence from platform defaults through p
     personality: "pragmatic",
     reasoningEffort: "xhigh",
     sandboxPosture: "readOnly",
-    verbosity: "terse",
+    verbosity: "low",
   });
   assert.deepEqual(resolved.sources, {
     approvalPosture: "rolePolicy",

--- a/desktop/src/main/workspace/workspace-policy-hydrator.ts
+++ b/desktop/src/main/workspace/workspace-policy-hydrator.ts
@@ -32,6 +32,23 @@ export type WorkspaceHydrationOptions = {
   readonly suppressErrors?: boolean;
 };
 
+function logSlowWorkspaceHydration(
+  operation: string,
+  startedAt: number,
+  details: Record<string, unknown>,
+): void {
+  const durationMs = Date.now() - startedAt;
+  if (durationMs < 100) {
+    return;
+  }
+
+  console.warn("[sense1:perf:main]", {
+    operation,
+    durationMs,
+    ...details,
+  });
+}
+
 async function loadDefaultOperatingMode(profileId: string, env: NodeJS.ProcessEnv): Promise<DesktopOperatingMode> {
   const storedSettings = await loadDesktopSettings(profileId, env);
   return resolveStoredDesktopSettings(storedSettings as unknown as Record<string, unknown>).defaultOperatingMode ?? "auto";
@@ -80,6 +97,7 @@ export async function hydrateWorkspacePolicyRecord(
   workspaceRoot: string,
   options: WorkspaceHydrationOptions = {},
 ): Promise<DesktopWorkspacePolicyRecord> {
+  const startedAt = Date.now();
   const resolvedWorkspaceRoot = path.resolve(workspaceRoot);
   const dbPath = resolveProfileSubstrateDbPath(profileId, env);
   await ensureProfileSubstrate({
@@ -115,10 +133,11 @@ export async function hydrateWorkspacePolicyRecord(
   }
 
   try {
+    const readDirectoryStartedAt = Date.now();
     const directoryResult = await readWorkspaceDirectory(resolvedWorkspaceRoot);
     const knownStructure = normalizeWorkspaceDirectoryEntries(resolvedWorkspaceRoot, directoryResult);
     const now = new Date().toISOString();
-    return await upsertWorkspacePolicy({
+    const policy = await upsertWorkspacePolicy({
       contextPaths: collectWorkspaceContextPaths(resolvedWorkspaceRoot, knownStructure),
       dbPath,
       knownStructure,
@@ -129,6 +148,19 @@ export async function hydrateWorkspacePolicyRecord(
       readGrantedAt: options.readGrantedAt,
       workspaceRoot: resolvedWorkspaceRoot,
     });
+    logSlowWorkspaceHydration("workspace.readDirectory", readDirectoryStartedAt, {
+      contextPathCount: policy.context_paths.length,
+      force: options.force === true,
+      knownStructureCount: policy.known_structure.length,
+      workspaceRoot: resolvedWorkspaceRoot,
+    });
+    logSlowWorkspaceHydration("workspace.hydratePolicyRecord", startedAt, {
+      contextPathCount: policy.context_paths.length,
+      force: options.force === true,
+      knownStructureCount: policy.known_structure.length,
+      workspaceRoot: resolvedWorkspaceRoot,
+    });
+    return policy;
   } catch (error) {
     if (options.suppressErrors === true) {
       console.warn(
@@ -142,7 +174,7 @@ export async function hydrateWorkspacePolicyRecord(
         return existingPolicy;
       }
 
-      return await upsertWorkspacePolicy({
+      const policy = await upsertWorkspacePolicy({
         dbPath,
         operatingMode: seededOperatingMode,
         readGrantMode: options.readGrantMode,
@@ -150,6 +182,13 @@ export async function hydrateWorkspacePolicyRecord(
         readGrantedAt: options.readGrantedAt,
         workspaceRoot: resolvedWorkspaceRoot,
       });
+      logSlowWorkspaceHydration("workspace.hydratePolicyRecord", startedAt, {
+        force: options.force === true,
+        knownStructureCount: policy.known_structure.length,
+        suppressedError: true,
+        workspaceRoot: resolvedWorkspaceRoot,
+      });
+      return policy;
     }
     throw error;
   }

--- a/desktop/src/main/workspace/workspace-state-service.test.js
+++ b/desktop/src/main/workspace/workspace-state-service.test.js
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs/promises";
+
+import { loadThreadInteractionStates } from "../profile/profile-state.js";
+import { DesktopWorkspaceStateService } from "./workspace-state-service.ts";
+
+function createEnv() {
+  return {
+    ...process.env,
+    SENSE1_RUNTIME_STATE_ROOT: path.join(os.tmpdir(), `sense1-workspace-state-${Date.now()}-${Math.random().toString(16).slice(2)}`),
+  };
+}
+
+test("rememberThreadInteractionState skips duplicate writes for the same thread state", async () => {
+  const env = createEnv();
+  const service = new DesktopWorkspaceStateService({
+    env,
+    resolveProfile: async () => ({ id: "default" }),
+  });
+
+  await service.rememberThreadInteractionState("thread-1", "running");
+  const firstState = await loadThreadInteractionStates("default", env);
+  const firstUpdatedAt = firstState[0]?.updatedAt ?? null;
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  await service.rememberThreadInteractionState("thread-1", "running");
+  const secondState = await loadThreadInteractionStates("default", env);
+  const secondUpdatedAt = secondState[0]?.updatedAt ?? null;
+
+  assert.equal(secondState[0]?.interactionState, "running");
+  assert.equal(secondUpdatedAt, firstUpdatedAt);
+
+  await fs.rm(env.SENSE1_RUNTIME_STATE_ROOT, { recursive: true, force: true });
+});
+
+test("rememberThreadInteractionState serializes quick successive state changes", async () => {
+  const env = createEnv();
+  const service = new DesktopWorkspaceStateService({
+    env,
+    resolveProfile: async () => ({ id: "default" }),
+  });
+
+  await Promise.all([
+    service.rememberThreadInteractionState("thread-2", "running"),
+    service.rememberThreadInteractionState("thread-2", "review"),
+  ]);
+
+  const states = await loadThreadInteractionStates("default", env);
+  assert.deepEqual(states, [
+    {
+      threadId: "thread-2",
+      interactionState: "review",
+      updatedAt: states[0]?.updatedAt ?? null,
+    },
+  ]);
+
+  await fs.rm(env.SENSE1_RUNTIME_STATE_ROOT, { recursive: true, force: true });
+});

--- a/desktop/src/main/workspace/workspace-state-service.test.js
+++ b/desktop/src/main/workspace/workspace-state-service.test.js
@@ -14,6 +14,14 @@ function createEnv() {
   };
 }
 
+function createDeferred() {
+  let resolve;
+  const promise = new Promise((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
 test("rememberThreadInteractionState skips duplicate writes for the same thread state", async () => {
   const env = createEnv();
   const service = new DesktopWorkspaceStateService({
@@ -58,4 +66,44 @@ test("rememberThreadInteractionState serializes quick successive state changes",
   ]);
 
   await fs.rm(env.SENSE1_RUNTIME_STATE_ROOT, { recursive: true, force: true });
+});
+
+test("loadThreadInteractionStates preserves pending desired writes during reload", async () => {
+  const writeGate = createDeferred();
+  const persistedStates = new Map([
+    [
+      "thread-3",
+      {
+        interactionState: "running",
+        updatedAt: "2026-04-08T10:00:00.000Z",
+      },
+    ],
+  ]);
+  const service = new DesktopWorkspaceStateService({
+    env: createEnv(),
+    resolveProfile: async () => ({ id: "default" }),
+    loadThreadInteractionStates: async () =>
+      [...persistedStates.entries()].map(([threadId, entry]) => ({
+        threadId,
+        interactionState: entry.interactionState,
+        updatedAt: entry.updatedAt,
+      })),
+    rememberThreadInteractionState: async (_profileId, threadId, interactionState) => {
+      await writeGate.promise;
+      persistedStates.set(threadId, {
+        interactionState,
+        updatedAt: "2026-04-08T12:00:00.000Z",
+      });
+    },
+  });
+
+  const pendingRemember = service.rememberThreadInteractionState("thread-3", "review");
+  await Promise.resolve();
+
+  assert.deepEqual(await service.loadThreadInteractionStates(), { "thread-3": "running" });
+
+  writeGate.resolve();
+  await pendingRemember;
+
+  assert.deepEqual(await service.loadThreadInteractionStates(), { "thread-3": "review" });
 });

--- a/desktop/src/main/workspace/workspace-state-service.ts
+++ b/desktop/src/main/workspace/workspace-state-service.ts
@@ -22,6 +22,9 @@ import type { DesktopInteractionState } from "../contracts.ts";
 export class DesktopWorkspaceStateService {
   readonly #env: NodeJS.ProcessEnv;
   readonly #resolveProfile: () => Promise<{ id: string }>;
+  readonly #threadInteractionStateCache = new Map<string, DesktopInteractionState>();
+  readonly #threadInteractionStateDesired = new Map<string, DesktopInteractionState>();
+  readonly #threadInteractionStateWriteQueue = new Map<string, Promise<void>>();
 
   constructor(
     options:
@@ -83,6 +86,13 @@ export class DesktopWorkspaceStateService {
   async loadThreadInteractionStates(): Promise<Record<string, DesktopInteractionState>> {
     const profile = await this.#profile();
     const states = await loadThreadInteractionStates(profile.id, this.#env);
+    clearInteractionStateCacheForProfile(this.#threadInteractionStateCache, profile.id);
+    clearInteractionStateCacheForProfile(this.#threadInteractionStateDesired, profile.id);
+    for (const entry of states) {
+      const cacheKey = buildInteractionStateCacheKey(profile.id, entry.threadId);
+      this.#threadInteractionStateCache.set(cacheKey, entry.interactionState as DesktopInteractionState);
+      this.#threadInteractionStateDesired.set(cacheKey, entry.interactionState as DesktopInteractionState);
+    }
     return Object.fromEntries(
       states.map((entry) => [entry.threadId, entry.interactionState as DesktopInteractionState]),
     );
@@ -90,13 +100,61 @@ export class DesktopWorkspaceStateService {
 
   async rememberThreadInteractionState(threadId: string, interactionState: DesktopInteractionState): Promise<string> {
     const profile = await this.#profile();
-    await rememberThreadInteractionState(profile.id, threadId, interactionState, this.#env);
+    const resolvedThreadId = threadId.trim();
+    if (!resolvedThreadId) {
+      return profile.id;
+    }
+    const cacheKey = buildInteractionStateCacheKey(profile.id, resolvedThreadId);
+    const previousDesiredState = this.#threadInteractionStateDesired.get(cacheKey);
+    if (previousDesiredState === interactionState) {
+      return profile.id;
+    }
+
+    this.#threadInteractionStateDesired.set(cacheKey, interactionState);
+    const previousQueue = this.#threadInteractionStateWriteQueue.get(cacheKey) ?? Promise.resolve();
+    const nextQueue = previousQueue
+      .catch(() => {})
+      .then(async () => {
+        const desiredState = this.#threadInteractionStateDesired.get(cacheKey);
+        if (!desiredState || this.#threadInteractionStateCache.get(cacheKey) === desiredState) {
+          return;
+        }
+
+        await rememberThreadInteractionState(profile.id, resolvedThreadId, desiredState, this.#env);
+        this.#threadInteractionStateCache.set(cacheKey, desiredState);
+      })
+      .finally(() => {
+        if (this.#threadInteractionStateWriteQueue.get(cacheKey) === nextQueue) {
+          this.#threadInteractionStateWriteQueue.delete(cacheKey);
+        }
+      });
+    this.#threadInteractionStateWriteQueue.set(cacheKey, nextQueue);
+    await nextQueue;
     return profile.id;
   }
 
   async forgetThreadInteractionState(threadId: string): Promise<string> {
     const profile = await this.#profile();
-    await forgetThreadInteractionState(profile.id, threadId, this.#env);
+    const resolvedThreadId = threadId.trim();
+    if (!resolvedThreadId) {
+      return profile.id;
+    }
+    const cacheKey = buildInteractionStateCacheKey(profile.id, resolvedThreadId);
+    this.#threadInteractionStateDesired.delete(cacheKey);
+    const previousQueue = this.#threadInteractionStateWriteQueue.get(cacheKey) ?? Promise.resolve();
+    const nextQueue = previousQueue
+      .catch(() => {})
+      .then(async () => {
+        await forgetThreadInteractionState(profile.id, resolvedThreadId, this.#env);
+        this.#threadInteractionStateCache.delete(cacheKey);
+      })
+      .finally(() => {
+        if (this.#threadInteractionStateWriteQueue.get(cacheKey) === nextQueue) {
+          this.#threadInteractionStateWriteQueue.delete(cacheKey);
+        }
+      });
+    this.#threadInteractionStateWriteQueue.set(cacheKey, nextQueue);
+    await nextQueue;
     return profile.id;
   }
 
@@ -145,4 +203,20 @@ function isWorkspaceStateServiceOptions(
   value: NodeJS.ProcessEnv | { env?: NodeJS.ProcessEnv; resolveProfile?: () => Promise<{ id: string }> },
 ): value is { env?: NodeJS.ProcessEnv; resolveProfile?: () => Promise<{ id: string }> } {
   return Boolean(value) && typeof value === "object" && ("env" in value || "resolveProfile" in value);
+}
+
+function buildInteractionStateCacheKey(profileId: string, threadId: string): string {
+  return `${profileId}:${threadId}`;
+}
+
+function clearInteractionStateCacheForProfile(
+  cache: Map<string, DesktopInteractionState>,
+  profileId: string,
+): void {
+  const cachePrefix = `${profileId}:`;
+  for (const key of cache.keys()) {
+    if (key.startsWith(cachePrefix)) {
+      cache.delete(key);
+    }
+  }
 }

--- a/desktop/src/main/workspace/workspace-state-service.ts
+++ b/desktop/src/main/workspace/workspace-state-service.ts
@@ -4,44 +4,54 @@ import {
   forgetPendingApprovalsForThread,
   forgetRecentWorkspaceFolder,
   forgetThreadWorkspaceRoot,
-  forgetThreadInteractionState,
+  forgetThreadInteractionState as deletePersistedThreadInteractionState,
   forgetWorkspaceSidebarRoot,
   loadWorkspaceSidebarOrder,
   loadPendingApprovals,
-  loadThreadInteractionStates,
+  loadThreadInteractionStates as loadPersistedThreadInteractionStates,
   loadThreadWorkspaceRoot,
   persistLastSelectedThreadId,
   persistPendingApprovals,
   rememberRecentWorkspaceFolder,
   rememberWorkspaceSidebarOrder,
-  rememberThreadInteractionState,
+  rememberThreadInteractionState as persistThreadInteractionState,
   rememberThreadWorkspaceRoot,
 } from "../profile/profile-state.js";
 import type { DesktopInteractionState } from "../contracts.ts";
 
+type WorkspaceStateServiceOptions = {
+  env?: NodeJS.ProcessEnv;
+  resolveProfile?: () => Promise<{ id: string }>;
+  loadThreadInteractionStates?: typeof loadPersistedThreadInteractionStates;
+  rememberThreadInteractionState?: typeof persistThreadInteractionState;
+  forgetThreadInteractionState?: typeof deletePersistedThreadInteractionState;
+};
+
 export class DesktopWorkspaceStateService {
   readonly #env: NodeJS.ProcessEnv;
   readonly #resolveProfile: () => Promise<{ id: string }>;
+  readonly #loadThreadInteractionStates: typeof loadPersistedThreadInteractionStates;
+  readonly #rememberThreadInteractionState: typeof persistThreadInteractionState;
+  readonly #forgetThreadInteractionState: typeof deletePersistedThreadInteractionState;
   readonly #threadInteractionStateCache = new Map<string, DesktopInteractionState>();
   readonly #threadInteractionStateDesired = new Map<string, DesktopInteractionState>();
   readonly #threadInteractionStateWriteQueue = new Map<string, Promise<void>>();
 
-  constructor(
-    options:
-      | NodeJS.ProcessEnv
-      | {
-          env?: NodeJS.ProcessEnv;
-          resolveProfile?: () => Promise<{ id: string }>;
-        } = process.env,
-  ) {
+  constructor(options: NodeJS.ProcessEnv | WorkspaceStateServiceOptions = process.env) {
     if (isWorkspaceStateServiceOptions(options)) {
       this.#env = options.env ?? process.env;
       this.#resolveProfile = options.resolveProfile ?? (async () => await resolveDesktopProfile(this.#env));
+      this.#loadThreadInteractionStates = options.loadThreadInteractionStates ?? loadPersistedThreadInteractionStates;
+      this.#rememberThreadInteractionState = options.rememberThreadInteractionState ?? persistThreadInteractionState;
+      this.#forgetThreadInteractionState = options.forgetThreadInteractionState ?? deletePersistedThreadInteractionState;
       return;
     }
 
     this.#env = options ?? process.env;
     this.#resolveProfile = async () => await resolveDesktopProfile(this.#env);
+    this.#loadThreadInteractionStates = loadPersistedThreadInteractionStates;
+    this.#rememberThreadInteractionState = persistThreadInteractionState;
+    this.#forgetThreadInteractionState = deletePersistedThreadInteractionState;
   }
 
   async #profile(): Promise<{ id: string }> {
@@ -85,13 +95,24 @@ export class DesktopWorkspaceStateService {
 
   async loadThreadInteractionStates(): Promise<Record<string, DesktopInteractionState>> {
     const profile = await this.#profile();
-    const states = await loadThreadInteractionStates(profile.id, this.#env);
+    const states = await this.#loadThreadInteractionStates(profile.id, this.#env);
+    const pendingDesiredStates = collectUnsyncedInteractionStatesForProfile(
+      this.#threadInteractionStateCache,
+      this.#threadInteractionStateDesired,
+      this.#threadInteractionStateWriteQueue,
+      profile.id,
+    );
     clearInteractionStateCacheForProfile(this.#threadInteractionStateCache, profile.id);
     clearInteractionStateCacheForProfile(this.#threadInteractionStateDesired, profile.id);
     for (const entry of states) {
       const cacheKey = buildInteractionStateCacheKey(profile.id, entry.threadId);
-      this.#threadInteractionStateCache.set(cacheKey, entry.interactionState as DesktopInteractionState);
-      this.#threadInteractionStateDesired.set(cacheKey, entry.interactionState as DesktopInteractionState);
+      const interactionState = entry.interactionState as DesktopInteractionState;
+      this.#threadInteractionStateCache.set(cacheKey, interactionState);
+      this.#threadInteractionStateDesired.set(cacheKey, pendingDesiredStates.get(cacheKey) ?? interactionState);
+      pendingDesiredStates.delete(cacheKey);
+    }
+    for (const [cacheKey, interactionState] of pendingDesiredStates) {
+      this.#threadInteractionStateDesired.set(cacheKey, interactionState);
     }
     return Object.fromEntries(
       states.map((entry) => [entry.threadId, entry.interactionState as DesktopInteractionState]),
@@ -106,7 +127,11 @@ export class DesktopWorkspaceStateService {
     }
     const cacheKey = buildInteractionStateCacheKey(profile.id, resolvedThreadId);
     const previousDesiredState = this.#threadInteractionStateDesired.get(cacheKey);
-    if (previousDesiredState === interactionState) {
+    if (
+      previousDesiredState === interactionState
+      && this.#threadInteractionStateCache.get(cacheKey) === interactionState
+      && !this.#threadInteractionStateWriteQueue.has(cacheKey)
+    ) {
       return profile.id;
     }
 
@@ -120,7 +145,7 @@ export class DesktopWorkspaceStateService {
           return;
         }
 
-        await rememberThreadInteractionState(profile.id, resolvedThreadId, desiredState, this.#env);
+        await this.#rememberThreadInteractionState(profile.id, resolvedThreadId, desiredState, this.#env);
         this.#threadInteractionStateCache.set(cacheKey, desiredState);
       })
       .finally(() => {
@@ -145,7 +170,7 @@ export class DesktopWorkspaceStateService {
     const nextQueue = previousQueue
       .catch(() => {})
       .then(async () => {
-        await forgetThreadInteractionState(profile.id, resolvedThreadId, this.#env);
+        await this.#forgetThreadInteractionState(profile.id, resolvedThreadId, this.#env);
         this.#threadInteractionStateCache.delete(cacheKey);
       })
       .finally(() => {
@@ -200,13 +225,40 @@ export class DesktopWorkspaceStateService {
 }
 
 function isWorkspaceStateServiceOptions(
-  value: NodeJS.ProcessEnv | { env?: NodeJS.ProcessEnv; resolveProfile?: () => Promise<{ id: string }> },
-): value is { env?: NodeJS.ProcessEnv; resolveProfile?: () => Promise<{ id: string }> } {
-  return Boolean(value) && typeof value === "object" && ("env" in value || "resolveProfile" in value);
+  value: NodeJS.ProcessEnv | WorkspaceStateServiceOptions,
+): value is WorkspaceStateServiceOptions {
+  return Boolean(value)
+    && typeof value === "object"
+    && (
+      "env" in value
+      || "resolveProfile" in value
+      || "loadThreadInteractionStates" in value
+      || "rememberThreadInteractionState" in value
+      || "forgetThreadInteractionState" in value
+    );
 }
 
 function buildInteractionStateCacheKey(profileId: string, threadId: string): string {
   return `${profileId}:${threadId}`;
+}
+
+function collectUnsyncedInteractionStatesForProfile(
+  cache: Map<string, DesktopInteractionState>,
+  desired: Map<string, DesktopInteractionState>,
+  writeQueue: Map<string, Promise<void>>,
+  profileId: string,
+): Map<string, DesktopInteractionState> {
+  const pendingStates = new Map<string, DesktopInteractionState>();
+  const cachePrefix = `${profileId}:`;
+  for (const [key, desiredState] of desired) {
+    if (!key.startsWith(cachePrefix)) {
+      continue;
+    }
+    if (writeQueue.has(key) || cache.get(key) !== desiredState) {
+      pendingStates.set(key, desiredState);
+    }
+  }
+  return pendingStates;
 }
 
 function clearInteractionStateCacheForProfile(

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -6,7 +6,7 @@ import { useAuthenticatedDesktopApp } from "./features/app/use-authenticated-des
 import { useDesktopManagement } from "./features/management/use-desktop-management.js";
 import { useDesktopAutomations } from "./features/automation/use-desktop-automations.js";
 import { useReportBugController } from "./features/bug-report/use-report-bug-controller.js";
-import { perfCount } from "./lib/perf-debug.ts";
+import { installPerfTraceMonitor, perfCount } from "./lib/perf-debug.ts";
 
 import { AutomationsPage } from "./components/AutomationsPage";
 import { AuthScreens } from "./components/AuthScreens";
@@ -34,6 +34,7 @@ export default function App() {
   perfCount("render.App");
   // ── Local UI state ──
   const previousSelectedThreadIdRef = useRef<string | null>(null);
+  const perfTraceContextRef = useRef<Record<string, unknown>>({});
   const [activeView, setActiveView] = useState<"home" | "plugins" | "automations">("home");
   const [leftRailOpen, setLeftRailOpen] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
@@ -121,6 +122,16 @@ export default function App() {
   const createPluginPrompt = "$plugin-creator scaffold a new Sense-1 Workspace profile plugin and explain the inputs you need.";
   const createSkillPrompt = "$skill-creator create a new Sense-1 Workspace profile skill and keep the flow native to Codex.";
   const showHomeRightRail = shouldShowHomeRightRail(activeView, sessionState.showRightRail);
+  perfTraceContextRef.current = {
+    activeView,
+    pendingApprovalCount: sessionState.pendingApprovals.length,
+    selectedThreadId: sessionState.selectedThreadId,
+    showRightRail: sessionState.showRightRail,
+    taskPending: sessionState.taskPending,
+    threadCount: sessionState.threads.length,
+  };
+
+  useEffect(() => installPerfTraceMonitor(() => perfTraceContextRef.current), []);
 
   const mainContent = useMemo(() => {
     if (activeView === "plugins") {

--- a/desktop/src/renderer/components/LeftSidebar.tsx
+++ b/desktop/src/renderer/components/LeftSidebar.tsx
@@ -4,7 +4,7 @@ import { Bug, ChevronDown, Plus, PlugZap, CalendarClock, Settings, LogOut, UserC
 import { Button } from "./ui/button";
 import { cn } from "../lib/cn";
 import type { ThreadRenameTarget } from "../features/threads/use-thread-shell.js";
-import { type DesktopBootstrapTeamSetup, type DesktopBootstrapTenant, type DesktopThreadSnapshot } from "../../main/contracts";
+import { type DesktopBootstrapTeamSetup, type DesktopBootstrapTenant } from "../../main/contracts";
 import { ThreadSidebarItem } from "./left-sidebar/thread-sidebar-item.js";
 import { WorkspaceSidebarGroup } from "./left-sidebar/workspace-sidebar-group.js";
 import {
@@ -18,7 +18,7 @@ export type LeftSidebarProps = {
   leftRailOpen: boolean;
   searchQuery: string;
   setSearchQuery: (value: string) => void;
-  filteredThreads: DesktopThreadSnapshot[];
+  filteredThreadCount: number;
   noThreadSearchMatches: boolean;
   trimmedSearchQuery: string;
   workspaceThreadGroups: {
@@ -28,7 +28,7 @@ export type LeftSidebarProps = {
   expandedWorkspaces: Record<string, boolean>;
   toggleWorkspaceExpanded: (root: string) => void;
   activeWorkspaceRoot: string | null;
-  selectedThread: DesktopThreadSnapshot | null;
+  selectedThreadId: string | null;
   selectThread: (threadId: string) => Promise<void> | void;
   openThreadRename: (thread: ThreadRenameTarget) => void;
   threadRenameId: string | null;
@@ -89,14 +89,14 @@ function resolveAccountLabel(accountEmail: string | null | undefined, accountTyp
 export const LeftSidebar = memo(function LeftSidebar({
   activeView,
   leftRailOpen,
-  filteredThreads,
+  filteredThreadCount,
   noThreadSearchMatches,
   trimmedSearchQuery,
   workspaceThreadGroups,
   expandedWorkspaces,
   toggleWorkspaceExpanded,
   activeWorkspaceRoot,
-  selectedThread,
+  selectedThreadId,
   selectThread,
   openThreadRename,
   threadRenameId,
@@ -173,7 +173,7 @@ export const LeftSidebar = memo(function LeftSidebar({
 
         <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain pr-1">
           <div className="space-y-1 pb-2">
-            {filteredThreads.length === 0 && workspaceThreadGroups.workspaces.length === 0 ? (
+            {filteredThreadCount === 0 && workspaceThreadGroups.workspaces.length === 0 ? (
               noThreadSearchMatches ? (
                 <p className="rounded-xl bg-surface-strong px-3 py-2 text-sm text-muted">No recent threads match &quot;{trimmedSearchQuery}&quot;.</p>
               ) : (
@@ -204,7 +204,7 @@ export const LeftSidebar = memo(function LeftSidebar({
                           onNewThreadInWorkspace={onNewThreadInWorkspace}
                           openThreadRename={openThreadRename}
                           selectThread={selectThread}
-                          selectedThread={selectedThread}
+                          selectedThreadId={selectedThreadId}
                           setThreadMenuOpenId={setThreadMenuOpenId}
                           setThreadRenameDraft={setThreadRenameDraft}
                           setWorkspaceMenuOpenId={setWorkspaceMenuOpenId}
@@ -236,7 +236,7 @@ export const LeftSidebar = memo(function LeftSidebar({
                       <ThreadSidebarItem
                         archivePending={threadArchivePendingId === thread.id}
                         deletePending={threadDeletePendingId === thread.id}
-                        isSelected={selectedThread?.id === thread.id}
+                        isSelected={selectedThreadId === thread.id}
                         key={thread.id}
                         menuOpen={threadMenuOpenId === thread.id}
                         onArchive={() => void handleArchiveThread(thread.id)}

--- a/desktop/src/renderer/components/left-sidebar/workspace-sidebar-group.tsx
+++ b/desktop/src/renderer/components/left-sidebar/workspace-sidebar-group.tsx
@@ -9,7 +9,6 @@ import {
   type WorkspaceSidebarGroup,
   type WorkspaceSidebarThreadSummary,
 } from "../../features/workspace/workspace-sidebar.js";
-import { type DesktopThreadSnapshot } from "../../../main/contracts";
 import { ThreadSidebarItem } from "./thread-sidebar-item.js";
 
 export type WorkspaceSidebarGroupProps = {
@@ -17,7 +16,7 @@ export type WorkspaceSidebarGroupProps = {
   expandedWorkspaces: Record<string, boolean>;
   toggleWorkspaceExpanded: (root: string) => void;
   activeWorkspaceRoot: string | null;
-  selectedThread: DesktopThreadSnapshot | null;
+  selectedThreadId: string | null;
   workspaceMenuOpenId: string | null;
   setWorkspaceMenuOpenId: (value: string | null | ((current: string | null) => string | null)) => void;
   handleArchiveWorkspace: (workspaceId: string, workspaceRoot: string) => Promise<void> | void;
@@ -52,7 +51,7 @@ export function WorkspaceSidebarGroup({
   expandedWorkspaces,
   toggleWorkspaceExpanded,
   activeWorkspaceRoot,
-  selectedThread,
+  selectedThreadId,
   workspaceMenuOpenId,
   setWorkspaceMenuOpenId,
   handleArchiveWorkspace,
@@ -186,7 +185,7 @@ export function WorkspaceSidebarGroup({
               archivePending={threadArchivePendingId === thread.id}
               deletePending={threadDeletePendingId === thread.id}
               isNested
-              isSelected={selectedThread?.id === thread.id}
+              isSelected={selectedThreadId === thread.id}
               key={thread.id}
               menuOpen={threadMenuOpenId === thread.id}
               onArchive={() => void handleArchiveThread(thread.id)}

--- a/desktop/src/renderer/components/right-rail/RightRailContentSection.tsx
+++ b/desktop/src/renderer/components/right-rail/RightRailContentSection.tsx
@@ -5,6 +5,7 @@ import { cn } from "../../lib/cn";
 import { getFileIcon, getFileLabel } from "../../lib/file-icons";
 import { filterVisibleRightRailArtifactPaths, isVisibleRightRailArtifactPath } from "../../lib/right-rail-artifacts";
 import { extractArtifactPathsFromText } from "../../lib/thread-artifacts";
+import { perfMeasure } from "../../lib/perf-debug.ts";
 import type {
   DesktopInteractionState,
   DesktopThreadChangeGroup,
@@ -49,6 +50,10 @@ export function RightRailContentSection({
 }: RightRailContentSectionProps) {
   const contentOpen = isRightRailSectionOpen("content");
   const folderRoot = selectedThread?.workspaceRoot ?? selectedThread?.cwd ?? "";
+  const transcriptWorkspaceRoot = folderRoot || null;
+  const selectedThreadEntries = selectedThread?.entries ?? [];
+  const selectedThreadState = selectedThread?.state ?? null;
+  const reviewSummary = rightRailThread?.reviewSummary ?? null;
   const artifactRoots = useMemo(
     () =>
       [selectedThread?.workspaceRoot, selectedThread?.cwd].filter(
@@ -56,28 +61,50 @@ export function RightRailContentSection({
       ),
     [selectedThread?.cwd, selectedThread?.workspaceRoot],
   );
-  const changedFiles = useMemo(() => {
-    if (!contentOpen) {
-      return [];
-    }
+  const changedFiles = useMemo(
+    () => perfMeasure(
+      "right-rail.changed-files",
+      () => {
+        if (!contentOpen) {
+          return [];
+        }
 
-    return buildRightRailChangedFiles({
+        return buildRightRailChangedFiles({
+          artifactRoots,
+          extractArtifactPathsFromText,
+          isVisibleRightRailArtifactPath,
+          persistedSessionWrittenPaths,
+          rightRailChangeGroups,
+          reviewSummary,
+          selectedThreadEntries,
+          selectedThreadState,
+          transcriptWorkspaceRoot,
+        });
+      },
+      {
+        logThresholdMs: 16,
+        details: () => ({
+          artifactRootCount: artifactRoots.length,
+          changeGroupCount: rightRailChangeGroups.length,
+          contentOpen,
+          entryCount: selectedThreadEntries.length,
+          hasReviewSummary: Boolean(reviewSummary),
+          persistedSessionWrittenPathCount: persistedSessionWrittenPaths.length,
+          selectedThreadState,
+        }),
+      },
+    ),
+    [
       artifactRoots,
-      extractArtifactPathsFromText,
-      isVisibleRightRailArtifactPath,
+      contentOpen,
       persistedSessionWrittenPaths,
+      reviewSummary,
       rightRailChangeGroups,
-      rightRailThread,
-      selectedThread,
-    });
-  }, [
-    artifactRoots,
-    contentOpen,
-    persistedSessionWrittenPaths,
-    rightRailChangeGroups,
-    rightRailThread,
-    selectedThread,
-  ]);
+      selectedThreadEntries,
+      selectedThreadState,
+      transcriptWorkspaceRoot,
+    ],
+  );
   const recentFilePaths = useMemo(() => {
     if (!contentOpen) {
       return [];
@@ -241,9 +268,16 @@ export function RightRailContentSection({
             ) : null}
           </>
         ) : showEmptyWorkspaceState ? (
-          <p className="rounded-lg bg-surface-soft px-3 py-2 text-sm text-muted">
-            Workspace structure is ready to load once permissions are granted.
-          </p>
+          <div className="rounded-lg bg-surface-soft px-3 py-2 text-sm text-muted">
+            <p>Workspace structure is available on demand.</p>
+            <button
+              className="mt-2 rounded-md border border-line px-2 py-1.5 text-xs text-ink-muted transition-colors hover:bg-surface hover:text-ink"
+              onClick={() => void refreshWorkspaceStructure()}
+              type="button"
+            >
+              Load workspace structure
+            </button>
+          </div>
         ) : null}
       </div>
     </RightRailSection>

--- a/desktop/src/renderer/components/right-rail/right-rail-content.test.js
+++ b/desktop/src/renderer/components/right-rail/right-rail-content.test.js
@@ -63,7 +63,7 @@ test("buildRightRailChangedFiles skips transcript rescans while the thread is li
         files: ["/tmp/project/from-change-group.md"],
       },
     ],
-    rightRailThread: createThread({
+    reviewSummary: createThread({
       reviewSummary: {
         summary: "Done",
         outputArtifacts: [],
@@ -82,8 +82,10 @@ test("buildRightRailChangedFiles skips transcript rescans while the thread is li
         ],
         updatedAt: null,
       },
-    }),
-    selectedThread,
+    }).reviewSummary,
+    selectedThreadEntries: selectedThread.entries,
+    selectedThreadState: selectedThread.state,
+    transcriptWorkspaceRoot: selectedThread.workspaceRoot,
   });
 
   assert.deepEqual(
@@ -103,8 +105,8 @@ test("buildRightRailChangedFiles falls back to transcript artifacts after the ru
     isVisibleRightRailArtifactPath,
     persistedSessionWrittenPaths: [],
     rightRailChangeGroups: [],
-    rightRailThread: null,
-    selectedThread: createThread({
+    reviewSummary: null,
+    selectedThreadEntries: createThread({
       entries: [
         {
           id: "entry-1",
@@ -114,7 +116,9 @@ test("buildRightRailChangedFiles falls back to transcript artifacts after the ru
           status: "completed",
         },
       ],
-    }),
+    }).entries,
+    selectedThreadState: "idle",
+    transcriptWorkspaceRoot: "/tmp/project",
   });
 
   assert.deepEqual(changedFiles, [

--- a/desktop/src/renderer/components/right-rail/right-rail-content.ts
+++ b/desktop/src/renderer/components/right-rail/right-rail-content.ts
@@ -1,5 +1,7 @@
 import type {
   DesktopThreadChangeGroup,
+  DesktopThreadEntry,
+  DesktopThreadReviewSummary,
   DesktopThreadSnapshot,
 } from "../../../main/contracts";
 
@@ -11,30 +13,51 @@ type BuildRightRailChangedFilesArgs = {
   isVisibleRightRailArtifactPath: (filePath: string, workspaceRoots: string[] | string | null | undefined) => boolean;
   persistedSessionWrittenPaths: string[];
   rightRailChangeGroups: DesktopThreadChangeGroup[];
-  rightRailThread: DesktopThreadSnapshot | null;
-  selectedThread: DesktopThreadSnapshot | null;
+  reviewSummary: DesktopThreadReviewSummary | null;
+  selectedThreadEntries: DesktopThreadEntry[];
+  selectedThreadState: DesktopThreadSnapshot["state"] | null;
+  transcriptWorkspaceRoot: string | null;
 };
 
-function isLiveThread(thread: DesktopThreadSnapshot | null): boolean {
-  return thread?.state === "active" || thread?.state === "running";
+type TranscriptArtifactCacheEntry = {
+  artifactPaths: string[];
+  workspaceRoot: string;
+};
+
+const transcriptArtifactCache = new WeakMap<DesktopThreadEntry[], TranscriptArtifactCacheEntry>();
+
+function isLiveThread(threadState: DesktopThreadSnapshot["state"] | null): boolean {
+  return threadState === "active" || threadState === "running";
 }
 
 function collectTranscriptArtifacts(
-  selectedThread: DesktopThreadSnapshot | null,
+  entries: DesktopThreadEntry[],
+  workspaceRoot: string | null,
   extractArtifactPathsFromText: BuildRightRailChangedFilesArgs["extractArtifactPathsFromText"],
 ): string[] {
-  const folderRoot = selectedThread?.workspaceRoot ?? selectedThread?.cwd ?? null;
-  if (!selectedThread || !folderRoot) {
+  if (!workspaceRoot) {
     return [];
   }
 
-  return selectedThread.entries.flatMap((entry) => {
+  const cachedEntry = transcriptArtifactCache.get(entries);
+  if (cachedEntry?.workspaceRoot === workspaceRoot) {
+    return cachedEntry.artifactPaths;
+  }
+
+  const artifactPaths = entries.flatMap((entry) => {
     if (!("body" in entry) || typeof entry.body !== "string") {
       return [];
     }
 
-    return extractArtifactPathsFromText(entry.body, folderRoot);
+    return extractArtifactPathsFromText(entry.body, workspaceRoot);
   });
+
+  transcriptArtifactCache.set(entries, {
+    artifactPaths,
+    workspaceRoot,
+  });
+
+  return artifactPaths;
 }
 
 export function buildRightRailChangedFiles({
@@ -43,15 +66,17 @@ export function buildRightRailChangedFiles({
   isVisibleRightRailArtifactPath,
   persistedSessionWrittenPaths,
   rightRailChangeGroups,
-  rightRailThread,
-  selectedThread,
+  reviewSummary,
+  selectedThreadEntries,
+  selectedThreadState,
+  transcriptWorkspaceRoot,
 }: BuildRightRailChangedFilesArgs): ChangedFileEntry[] {
   const changedFileMap = new Map<string, string | null>();
   const persistedChangedFiles = persistedSessionWrittenPaths.map((filePath) => [filePath, null] as const);
   const changeGroupFiles = rightRailChangeGroups.flatMap((group) => group.files);
-  const reviewArtifacts = rightRailThread?.reviewSummary?.changedArtifacts ?? [];
-  const reviewOutputArtifacts = rightRailThread?.reviewSummary?.outputArtifacts ?? [];
-  const reviewCreatedFiles = rightRailThread?.reviewSummary?.createdFiles ?? [];
+  const reviewArtifacts = reviewSummary?.changedArtifacts ?? [];
+  const reviewOutputArtifacts = reviewSummary?.outputArtifacts ?? [];
+  const reviewCreatedFiles = reviewSummary?.createdFiles ?? [];
 
   for (const [filePath, action] of persistedChangedFiles) {
     if (!changedFileMap.has(filePath)) {
@@ -71,8 +96,8 @@ export function buildRightRailChangedFiles({
     }
   }
 
-  if (changedFileMap.size === 0 && !isLiveThread(selectedThread)) {
-    for (const filePath of collectTranscriptArtifacts(selectedThread, extractArtifactPathsFromText)) {
+  if (changedFileMap.size === 0 && !isLiveThread(selectedThreadState)) {
+    for (const filePath of collectTranscriptArtifacts(selectedThreadEntries, transcriptWorkspaceRoot, extractArtifactPathsFromText)) {
       if (!changedFileMap.has(filePath)) {
         changedFileMap.set(filePath, "created");
       }

--- a/desktop/src/renderer/components/settings/GeneralSettingsSection.tsx
+++ b/desktop/src/renderer/components/settings/GeneralSettingsSection.tsx
@@ -269,7 +269,7 @@ export function GeneralSettingsSection({
           </label>
 
           <label className="flex flex-col gap-[0.4rem]">
-            <span className="text-[0.75rem] font-medium uppercase leading-[1.2] tracking-[0.05em] text-ink-faint">Codex settings</span>
+            <span className="text-[0.75rem] font-medium uppercase leading-[1.2] tracking-[0.05em] text-ink-faint">Response verbosity</span>
             <select
               className="rounded-md bg-surface-high px-[0.65rem] py-[0.4rem] text-[0.875rem] leading-[1.6] text-ink outline-none focus:ring-1 focus:ring-line"
               onChange={(e) => void saveSettings({ verbosity: e.target.value as DesktopVerbosity })}
@@ -285,7 +285,7 @@ export function GeneralSettingsSection({
               <p className="mt-[0.1rem] text-[0.8125rem] leading-[1.5] text-danger">{settingsError.message}</p>
             ) : (
               <p className="mt-[0.1rem] text-[0.8125rem] leading-[1.5] text-ink-muted">
-                {VERBOSITY_HELP[settingsData.verbosity]} These settings affect answer length and style, not the model or its capabilities.
+                {VERBOSITY_HELP[settingsData.verbosity]} Affects answer length and style, not the model or its capabilities.
               </p>
             )}
           </label>

--- a/desktop/src/renderer/components/settings/GeneralSettingsSection.tsx
+++ b/desktop/src/renderer/components/settings/GeneralSettingsSection.tsx
@@ -23,15 +23,15 @@ const REASONING_LABELS: Record<string, string> = {
 };
 
 const VERBOSITY_OPTIONS: { value: DesktopVerbosity; label: string }[] = [
-  { value: "terse", label: "Terse" },
-  { value: "balanced", label: "Balanced" },
-  { value: "detailed", label: "Detailed" },
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
 ];
 
 const VERBOSITY_HELP: Record<DesktopVerbosity, string> = {
-  terse: "Short answers. Sense-1 trims context and caveats — best when you just want the result.",
-  balanced: "Moderate explanations alongside the result. Good default for most work.",
-  detailed: "Longer, more thorough responses with explanations and context. Uses more tokens.",
+  low: "Short answers. Sense-1 trims context and caveats — best when you just want the result.",
+  medium: "Moderate explanations alongside the result. Good default for most work.",
+  high: "Longer, more thorough responses with explanations and context. Uses more tokens.",
 };
 
 type SectionProps = {

--- a/desktop/src/renderer/components/settings/GeneralSettingsSection.tsx
+++ b/desktop/src/renderer/components/settings/GeneralSettingsSection.tsx
@@ -269,7 +269,7 @@ export function GeneralSettingsSection({
           </label>
 
           <label className="flex flex-col gap-[0.4rem]">
-            <span className="text-[0.75rem] font-medium uppercase leading-[1.2] tracking-[0.05em] text-ink-faint">Response verbosity</span>
+            <span className="text-[0.75rem] font-medium uppercase leading-[1.2] tracking-[0.05em] text-ink-faint">Codex settings</span>
             <select
               className="rounded-md bg-surface-high px-[0.65rem] py-[0.4rem] text-[0.875rem] leading-[1.6] text-ink outline-none focus:ring-1 focus:ring-line"
               onChange={(e) => void saveSettings({ verbosity: e.target.value as DesktopVerbosity })}
@@ -285,7 +285,7 @@ export function GeneralSettingsSection({
               <p className="mt-[0.1rem] text-[0.8125rem] leading-[1.5] text-danger">{settingsError.message}</p>
             ) : (
               <p className="mt-[0.1rem] text-[0.8125rem] leading-[1.5] text-ink-muted">
-                {VERBOSITY_HELP[settingsData.verbosity]} Affects answer length and style, not the model or its capabilities.
+                {VERBOSITY_HELP[settingsData.verbosity]} These settings affect answer length and style, not the model or its capabilities.
               </p>
             )}
           </label>

--- a/desktop/src/renderer/components/settings/GeneralSettingsSection.tsx
+++ b/desktop/src/renderer/components/settings/GeneralSettingsSection.tsx
@@ -31,7 +31,7 @@ const VERBOSITY_OPTIONS: { value: DesktopVerbosity; label: string }[] = [
 const VERBOSITY_HELP: Record<DesktopVerbosity, string> = {
   terse: "Short answers. Sense-1 trims context and caveats — best when you just want the result.",
   balanced: "Moderate explanations alongside the result. Good default for most work.",
-  detailed: "Longer, more thorough responses with reasoning and context. Uses more tokens.",
+  detailed: "Longer, more thorough responses with explanations and context. Uses more tokens.",
 };
 
 type SectionProps = {

--- a/desktop/src/renderer/components/settings/SettingsSections.tsx
+++ b/desktop/src/renderer/components/settings/SettingsSections.tsx
@@ -14,15 +14,15 @@ export function ConfigurationSettingsSection({ saveSettings, settingsData, setti
   return (
     <>
       <h2 className="font-display text-[1.05rem] font-semibold leading-[1.35] tracking-[-0.015em]">Configuration</h2>
-      <p className="mt-[0.1rem] text-[0.8125rem] leading-[1.55] text-ink-muted">Session startup defaults, workspace attachment behavior, and runtime instructions.</p>
+      <p className="mt-[0.1rem] text-[0.8125rem] leading-[1.55] text-ink-muted">Session startup defaults, workspace attachment behavior, and custom instructions.</p>
       {settingsData ? (
         <div className="mt-[0.75rem] flex flex-col gap-[0.75rem]">
           <label className="flex flex-col gap-[0.4rem]">
-            <span className="text-[0.75rem] font-medium uppercase leading-[1.2] tracking-[0.05em] text-ink-faint">Runtime instructions</span>
+            <span className="text-[0.75rem] font-medium uppercase leading-[1.2] tracking-[0.05em] text-ink-faint">Custom Instructions</span>
             <textarea
               className="min-h-[8rem] rounded-md bg-surface-high px-[0.65rem] py-[0.55rem] font-mono text-[0.8125rem] leading-[1.5] text-ink outline-none placeholder:text-ink-muted focus:ring-1 focus:ring-line"
               onChange={(e) => void saveSettings({ runtimeInstructions: e.target.value })}
-              placeholder="Leave blank to use the built-in runtime contract."
+              placeholder="Your guidance for Sense-1. Leave blank to rely on just the built-in workspace and safety rules."
               spellCheck={false}
               value={settingsData.runtimeInstructions ?? ""}
             />
@@ -30,7 +30,7 @@ export function ConfigurationSettingsSection({ saveSettings, settingsData, setti
               <p className="mt-[0.1rem] text-[0.8125rem] leading-[1.5] text-danger">{settingsError.message}</p>
             ) : (
               <p className="mt-[0.1rem] text-[0.8125rem] leading-[1.5] text-ink-muted">
-                Custom instructions prepended to the built-in workspace and safety rules for each run.
+                Added to every run alongside the built-in workspace and safety rules — it does not replace them. For durable project-level guidance, use AGENTS.md or .codex/config.toml in the workspace.
               </p>
             )}
           </label>

--- a/desktop/src/renderer/components/thread-view/streaming-assistant-preview.test.js
+++ b/desktop/src/renderer/components/thread-view/streaming-assistant-preview.test.js
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildStreamingAssistantPreview } from "./streaming-assistant-preview.ts";
+
+test("buildStreamingAssistantPreview leaves modest streaming bodies untouched", () => {
+  const preview = buildStreamingAssistantPreview("short reply");
+
+  assert.equal(preview.truncated, false);
+  assert.equal(preview.hiddenCharacterCount, 0);
+  assert.equal(preview.visibleText, "short reply");
+});
+
+test("buildStreamingAssistantPreview keeps only the latest tail for very large bodies", () => {
+  const source = `${"A".repeat(6_000)}${"B".repeat(8_500)}`;
+  const preview = buildStreamingAssistantPreview(source);
+
+  assert.equal(preview.truncated, true);
+  assert.equal(preview.visibleText, "B".repeat(8_000));
+  assert.equal(preview.hiddenCharacterCount, 6_500);
+});

--- a/desktop/src/renderer/components/thread-view/streaming-assistant-preview.ts
+++ b/desktop/src/renderer/components/thread-view/streaming-assistant-preview.ts
@@ -1,0 +1,25 @@
+export type StreamingAssistantPreview = {
+  hiddenCharacterCount: number;
+  truncated: boolean;
+  visibleText: string;
+};
+
+const STREAMING_PREVIEW_THRESHOLD_CHARS = 12_000;
+const STREAMING_PREVIEW_TAIL_CHARS = 8_000;
+
+export function buildStreamingAssistantPreview(text: string): StreamingAssistantPreview {
+  if (text.length <= STREAMING_PREVIEW_THRESHOLD_CHARS) {
+    return {
+      hiddenCharacterCount: 0,
+      truncated: false,
+      visibleText: text,
+    };
+  }
+
+  const visibleText = text.slice(-STREAMING_PREVIEW_TAIL_CHARS).trimStart();
+  return {
+    hiddenCharacterCount: Math.max(text.length - visibleText.length, 0),
+    truncated: true,
+    visibleText,
+  };
+}

--- a/desktop/src/renderer/components/thread-view/thread-entry-list.tsx
+++ b/desktop/src/renderer/components/thread-view/thread-entry-list.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef, useState } from "react";
+import { memo, useDeferredValue, useRef, useState } from "react";
 import { Blocks, Check, ChevronRight, Copy, PlugZap, Sparkles } from "lucide-react";
 
 import { ThreadMarkdown } from "../../thread-markdown.js";
@@ -18,6 +18,7 @@ import { resolveWorkspaceFilePath } from "../right-rail/RightRailSection";
 import { useStreamingEntryBody } from "../../state/session/session-stream-live-bodies.ts";
 import type { DesktopExtensionOverviewResult } from "../../../main/contracts";
 import { stripResolvedPromptShortcutText } from "../../../shared/prompt-shortcuts.ts";
+import { buildStreamingAssistantPreview } from "./streaming-assistant-preview.js";
 
 type ThreadEntryListProps = {
   entries: DesktopThreadEntry[];
@@ -203,6 +204,29 @@ function ActivityGroupCard({
   );
 }
 
+function areThreadEntryCardPropsEqual(
+  previousProps: {
+    entry: DesktopThreadEntry;
+    extensionOverview: Pick<DesktopExtensionOverviewResult, "apps" | "plugins" | "skills"> | null;
+    threadId: string;
+    workspaceRoot: string | null;
+  },
+  nextProps: {
+    entry: DesktopThreadEntry;
+    extensionOverview: Pick<DesktopExtensionOverviewResult, "apps" | "plugins" | "skills"> | null;
+    threadId: string;
+    workspaceRoot: string | null;
+  },
+): boolean {
+  return previousProps.entry === nextProps.entry
+    && previousProps.threadId === nextProps.threadId
+    && previousProps.workspaceRoot === nextProps.workspaceRoot
+    && (
+      previousProps.entry.kind !== "user"
+      || previousProps.extensionOverview === nextProps.extensionOverview
+    );
+}
+
 const ThreadEntryCard = memo(function ThreadEntryCard({
   entry,
   extensionOverview,
@@ -221,6 +245,7 @@ const ThreadEntryCard = memo(function ThreadEntryCard({
       : "body" in entry
         ? coerceDisplayText(entry.body)
         : "";
+  const deferredEntryBody = useDeferredValue(entryBody);
   const visibleUserBody = entry.kind === "user" && extensionOverview
     ? stripResolvedPromptShortcutText(entryBody, extensionOverview)
     : entryBody;
@@ -242,14 +267,29 @@ const ThreadEntryCard = memo(function ThreadEntryCard({
   }
 
   if (entry.kind === "assistant") {
+    const isStreamingAssistant = "status" in entry && entry.status === "streaming";
+    const assistantBody = isStreamingAssistant ? deferredEntryBody : entryBody;
+    const streamingPreview = isStreamingAssistant
+      ? buildStreamingAssistantPreview(assistantBody)
+      : null;
+
     return (
       <article className="mr-auto w-full px-4 py-2">
-        {"status" in entry && entry.status === "streaming" ? (
-          <div className="text-sm leading-[1.6] whitespace-pre-wrap text-ink">{entryBody}</div>
+        {isStreamingAssistant ? (
+          <>
+            {streamingPreview?.truncated ? (
+              <div className="mb-2 rounded-lg bg-surface-soft px-3 py-2 text-xs text-muted">
+                Showing the latest part of this streaming reply to keep Sense-1 responsive.
+              </div>
+            ) : null}
+            <div className="text-sm leading-[1.6] whitespace-pre-wrap text-ink">
+              {streamingPreview?.visibleText ?? assistantBody}
+            </div>
+          </>
         ) : (
           <ThreadMarkdown workspaceRoot={workspaceRoot}>{entryBody}</ThreadMarkdown>
         )}
-        {entryBody.trim() ? (
+        {!isStreamingAssistant && entryBody.trim() ? (
           <div className="mt-1 flex items-center justify-start">
             <EntryCopyButton text={entryBody} />
           </div>
@@ -412,7 +452,7 @@ const ThreadEntryCard = memo(function ThreadEntryCard({
       </ThreadMarkdown>
     </article>
   );
-});
+}, areThreadEntryCardPropsEqual);
 
 function ThreadEntryListInner({
   entries,

--- a/desktop/src/renderer/components/thread-view/thread-transcript.tsx
+++ b/desktop/src/renderer/components/thread-view/thread-transcript.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type Dispatch, type SetStateAction, type RefObject } from "react";
+import { memo, useEffect, useState, type Dispatch, type SetStateAction, type RefObject } from "react";
 import { Asterisk, ChevronDown, Folder, Sparkles } from "lucide-react";
 
 import { Button } from "../ui/button";
@@ -176,7 +176,7 @@ function StatusFooter({
   );
 }
 
-export function ThreadTranscript({
+function ThreadTranscriptInner({
   selectedThread,
   extensionOverview,
   threadInteractionState,
@@ -296,3 +296,73 @@ export function ThreadTranscript({
     </>
   );
 }
+
+function areArraysShallowEqual<T>(
+  previousItems: readonly T[],
+  nextItems: readonly T[],
+): boolean {
+  return previousItems.length === nextItems.length
+    && previousItems.every((item, index) => item === nextItems[index]);
+}
+
+function areConfigNoticesEqual(
+  previousNotices: ThreadTranscriptProps["configNotices"],
+  nextNotices: ThreadTranscriptProps["configNotices"],
+): boolean {
+  return previousNotices.length === nextNotices.length
+    && previousNotices.every((notice, index) => (
+      notice.id === nextNotices[index]?.id
+      && notice.text === nextNotices[index]?.text
+    ));
+}
+
+function areTranscriptThreadsEquivalent(
+  previousThread: ThreadTranscriptProps["selectedThread"],
+  nextThread: ThreadTranscriptProps["selectedThread"],
+): boolean {
+  return previousThread === nextThread || (
+    previousThread.id === nextThread.id
+    && previousThread.title === nextThread.title
+    && previousThread.workspaceRoot === nextThread.workspaceRoot
+    && previousThread.cwd === nextThread.cwd
+    && previousThread.entries === nextThread.entries
+    && previousThread.reviewSummary === nextThread.reviewSummary
+    && previousThread.hasLoadedDetails === nextThread.hasLoadedDetails
+  );
+}
+
+function areThreadTranscriptPropsEqual(
+  previousProps: ThreadTranscriptProps,
+  nextProps: ThreadTranscriptProps,
+): boolean {
+  return previousProps === nextProps || (
+    areTranscriptThreadsEquivalent(previousProps.selectedThread, nextProps.selectedThread)
+    && previousProps.extensionOverview === nextProps.extensionOverview
+    && previousProps.threadInteractionState === nextProps.threadInteractionState
+    && areArraysShallowEqual(previousProps.selectedThreadApprovals, nextProps.selectedThreadApprovals)
+    && previousProps.respondToApproval === nextProps.respondToApproval
+    && areArraysShallowEqual(previousProps.processingApprovalIds, nextProps.processingApprovalIds)
+    && previousProps.clarificationAnswer === nextProps.clarificationAnswer
+    && previousProps.setClarificationAnswer === nextProps.setClarificationAnswer
+    && previousProps.clarificationPending === nextProps.clarificationPending
+    && previousProps.setClarificationPending === nextProps.setClarificationPending
+    && previousProps.selectedChipIndex === nextProps.selectedChipIndex
+    && previousProps.setSelectedChipIndex === nextProps.setSelectedChipIndex
+    && previousProps.structuredQuestions === nextProps.structuredQuestions
+    && previousProps.hasStructuredQuestions === nextProps.hasStructuredQuestions
+    && previousProps.isClarifying === nextProps.isClarifying
+    && previousProps.threadInputRequest === nextProps.threadInputRequest
+    && previousProps.respondToInputRequest === nextProps.respondToInputRequest
+    && previousProps.rightRailChangeGroups === nextProps.rightRailChangeGroups
+    && previousProps.transcriptContainerRef === nextProps.transcriptContainerRef
+    && previousProps.transcriptEndRef === nextProps.transcriptEndRef
+    && areConfigNoticesEqual(previousProps.configNotices, nextProps.configNotices)
+    && previousProps.footerStatusText === nextProps.footerStatusText
+    && previousProps.effectiveThreadBusy === nextProps.effectiveThreadBusy
+    && previousProps.pendingPermission === nextProps.pendingPermission
+    && previousProps.grantWorkspacePermission === nextProps.grantWorkspacePermission
+    && previousProps.cancelWorkspacePermission === nextProps.cancelWorkspacePermission
+  );
+}
+
+export const ThreadTranscript = memo(ThreadTranscriptInner, areThreadTranscriptPropsEqual);

--- a/desktop/src/renderer/features/app/transcript-scroll.test.js
+++ b/desktop/src/renderer/features/app/transcript-scroll.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildTranscriptScrollAnchor,
+  resolveTranscriptScrollBucketChars,
+} from "./transcript-scroll.ts";
+
+test("resolveTranscriptScrollBucketChars grows for large streaming bodies", () => {
+  assert.equal(resolveTranscriptScrollBucketChars(4_000), 1024);
+  assert.equal(resolveTranscriptScrollBucketChars(20_000), 4096);
+  assert.equal(resolveTranscriptScrollBucketChars(80_000), 8192);
+});
+
+test("buildTranscriptScrollAnchor buckets very large streams more coarsely", () => {
+  const entry = {
+    id: "entry-1",
+    status: "streaming",
+  };
+
+  assert.equal(
+    buildTranscriptScrollAnchor(entry, "x".repeat(20_000)),
+    buildTranscriptScrollAnchor(entry, "x".repeat(20_400)),
+  );
+  assert.notEqual(
+    buildTranscriptScrollAnchor(entry, "x".repeat(20_000)),
+    buildTranscriptScrollAnchor(entry, "x".repeat(21_000)),
+  );
+});

--- a/desktop/src/renderer/features/app/transcript-scroll.ts
+++ b/desktop/src/renderer/features/app/transcript-scroll.ts
@@ -2,9 +2,23 @@ import type { DesktopThreadSnapshot } from "../../../main/contracts";
 
 const TRANSCRIPT_AUTO_FOLLOW_DISTANCE_PX = 8;
 const TRANSCRIPT_STREAM_SCROLL_BUCKET_CHARS = 1024;
+const LARGE_TRANSCRIPT_STREAM_SCROLL_BUCKET_CHARS = 4096;
+const HUGE_TRANSCRIPT_STREAM_SCROLL_BUCKET_CHARS = 8192;
 
 export function shouldAutoFollowTranscript(distanceFromBottom: number): boolean {
   return distanceFromBottom <= TRANSCRIPT_AUTO_FOLLOW_DISTANCE_PX;
+}
+
+export function resolveTranscriptScrollBucketChars(entryBodyLength: number): number {
+  if (entryBodyLength >= 64_000) {
+    return HUGE_TRANSCRIPT_STREAM_SCROLL_BUCKET_CHARS;
+  }
+
+  if (entryBodyLength >= 16_000) {
+    return LARGE_TRANSCRIPT_STREAM_SCROLL_BUCKET_CHARS;
+  }
+
+  return TRANSCRIPT_STREAM_SCROLL_BUCKET_CHARS;
 }
 
 export function buildTranscriptScrollAnchor(
@@ -23,7 +37,7 @@ export function buildTranscriptScrollAnchor(
         ? entry.body.length
       : 0;
   const entryScrollBucket = entryStatus === "streaming"
-    ? Math.floor(entryBodyLength / TRANSCRIPT_STREAM_SCROLL_BUCKET_CHARS)
+    ? Math.floor(entryBodyLength / resolveTranscriptScrollBucketChars(entryBodyLength))
     : 0;
   return `${entry.id}:${entryStatus}:${entryScrollBucket}`;
 }

--- a/desktop/src/renderer/features/app/use-app-right-rail.ts
+++ b/desktop/src/renderer/features/app/use-app-right-rail.ts
@@ -12,7 +12,10 @@ import type {
 import type { RightRailProps } from "../../components/RightRail";
 import { buildTranscriptScrollAnchor, shouldAutoFollowTranscript } from "./transcript-scroll.js";
 import { perfCount, perfMeasure } from "../../lib/perf-debug.ts";
-import { useStreamingEntryBody } from "../../state/session/session-stream-live-bodies.ts";
+import {
+  readStreamingEntryBody,
+  subscribeStreamingEntryBody,
+} from "../../state/session/session-stream-live-bodies.ts";
 
 const PRE_EXECUTION_STATES = new Set<DesktopInteractionState>(["conversation", "clarification"]);
 
@@ -100,6 +103,7 @@ export function useAppRightRail({
     DEFAULT_RIGHT_RAIL_SECTIONS_OPEN,
   );
   const autoFollowFrameRef = useRef<number | null>(null);
+  const lastAutoFollowAnchorRef = useRef("");
 
   const rightRailChangeGroups = useMemo(
     () => (Array.isArray(rightRailThread?.changeGroups) ? rightRailThread.changeGroups : []),
@@ -135,15 +139,11 @@ export function useAppRightRail({
 
   const entryCount = selectedThread?.entries.length ?? 0;
   const lastEntry = selectedThread?.entries[entryCount - 1];
-  const lastEntryLiveBody = useStreamingEntryBody(selectedThread?.id ?? "", lastEntry?.id ?? "");
   const lastEntryAnchor = perfMeasure(
     "right-rail.build-scroll-anchor",
-    () => buildTranscriptScrollAnchor(lastEntry, lastEntryLiveBody),
+    () => buildTranscriptScrollAnchor(lastEntry),
   );
-  useEffect(() => {
-    if (!entryCount) {
-      return;
-    }
+  const scheduleTranscriptAutoFollow = useCallback(() => {
     const container = transcriptContainerRef.current;
     if (!container) {
       return;
@@ -159,13 +159,60 @@ export function useAppRightRail({
       container.scrollTop = container.scrollHeight;
       autoFollowFrameRef.current = null;
     });
+  }, [transcriptContainerRef]);
+
+  useEffect(() => {
+    if (!entryCount) {
+      lastAutoFollowAnchorRef.current = "";
+      return;
+    }
+
+    if (lastEntryAnchor === lastAutoFollowAnchorRef.current) {
+      return;
+    }
+
+    lastAutoFollowAnchorRef.current = lastEntryAnchor;
+    scheduleTranscriptAutoFollow();
+  }, [entryCount, lastEntryAnchor, scheduleTranscriptAutoFollow]);
+
+  useEffect(() => {
+    const threadId = selectedThread?.id ?? "";
+    const entryId = lastEntry?.id ?? "";
+    if (
+      !threadId
+      || !entryId
+      || !lastEntry
+      || !("status" in lastEntry)
+      || lastEntry.status !== "streaming"
+    ) {
+      return;
+    }
+
+    function maybeFollowStreamingEntry() {
+      const nextAnchor = buildTranscriptScrollAnchor(
+        lastEntry,
+        readStreamingEntryBody(threadId, entryId),
+      );
+      if (nextAnchor === lastAutoFollowAnchorRef.current) {
+        return;
+      }
+
+      lastAutoFollowAnchorRef.current = nextAnchor;
+      scheduleTranscriptAutoFollow();
+    }
+
+    maybeFollowStreamingEntry();
+    return subscribeStreamingEntryBody(threadId, entryId, maybeFollowStreamingEntry);
+  }, [lastEntry, scheduleTranscriptAutoFollow, selectedThread?.id]);
+
+  useEffect(() => {
     return () => {
       if (autoFollowFrameRef.current !== null) {
         window.cancelAnimationFrame(autoFollowFrameRef.current);
         autoFollowFrameRef.current = null;
       }
     };
-  }, [entryCount, lastEntryAnchor, transcriptContainerRef]);
+  }, []);
 
   const rightRailProps: RightRailProps = useMemo(() => ({
     showRightRail,

--- a/desktop/src/renderer/features/app/use-app-shell-props.ts
+++ b/desktop/src/renderer/features/app/use-app-shell-props.ts
@@ -26,7 +26,7 @@ type BuildAppShellPropsArgs = {
     openReportBug: () => void;
   };
   search: {
-    filteredThreads: LeftSidebarProps["filteredThreads"];
+    filteredThreadCount: LeftSidebarProps["filteredThreadCount"];
     leftRailOpen: LeftSidebarProps["leftRailOpen"];
     noThreadSearchMatches: LeftSidebarProps["noThreadSearchMatches"];
     searchQuery: LeftSidebarProps["searchQuery"];
@@ -66,7 +66,7 @@ type BuildAppShellPropsArgs = {
     openThreadRename: LeftSidebarProps["openThreadRename"];
     resetThreadShell: () => void;
     selectThread: LeftSidebarProps["selectThread"];
-    selectedThread: LeftSidebarProps["selectedThread"];
+    selectedThreadId: LeftSidebarProps["selectedThreadId"];
     setSidebarThreadMenu: LeftSidebarProps["setThreadMenuOpenId"];
     setThreadRenameDraft: LeftSidebarProps["setThreadRenameDraft"];
     sidebarThreadMenuOpenId: LeftSidebarProps["threadMenuOpenId"];
@@ -131,14 +131,14 @@ export function useAppShellProps({
     leftRailOpen: search.leftRailOpen,
     searchQuery: search.searchQuery,
     setSearchQuery: search.setSearchQuery,
-    filteredThreads: search.filteredThreads,
+    filteredThreadCount: search.filteredThreadCount,
     noThreadSearchMatches: search.noThreadSearchMatches,
     trimmedSearchQuery: search.trimmedSearchQuery,
     workspaceThreadGroups: workspace.visibleWorkspaceThreadGroups,
     expandedWorkspaces: workspace.expandedWorkspaces,
     toggleWorkspaceExpanded: workspace.toggleWorkspaceExpanded,
     activeWorkspaceRoot: workspace.activeWorkspaceRoot,
-    selectedThread: threadShell.selectedThread,
+    selectedThreadId: threadShell.selectedThreadId,
     selectThread: threadShell.selectThread,
     openThreadRename: threadShell.openThreadRename,
     threadRenameId: threadShell.threadRenameId,
@@ -194,7 +194,7 @@ export function useAppShellProps({
     navigation.openAutomations,
     navigation.openPlugins,
     resetToStartSurface,
-    search.filteredThreads,
+    search.filteredThreadCount,
     search.leftRailOpen,
     search.noThreadSearchMatches,
     search.searchQuery,
@@ -204,7 +204,7 @@ export function useAppShellProps({
     threadShell.handleArchiveThread,
     threadShell.handleDeleteThread,
     threadShell.openThreadRename,
-    threadShell.selectedThread,
+    threadShell.selectedThreadId,
     threadShell.selectThread,
     threadShell.setSidebarThreadMenu,
     threadShell.setThreadRenameDraft,

--- a/desktop/src/renderer/features/app/use-authenticated-desktop-app.ts
+++ b/desktop/src/renderer/features/app/use-authenticated-desktop-app.ts
@@ -89,7 +89,7 @@ export function useAuthenticatedDesktopApp({
       openReportBug: reportBug.openModal,
     },
     search: {
-      filteredThreads: content.filteredThreads,
+      filteredThreadCount: content.filteredThreads.length,
       leftRailOpen: ui.leftRailOpen,
       noThreadSearchMatches: content.noThreadSearchMatches,
       searchQuery: ui.searchQuery,
@@ -129,7 +129,7 @@ export function useAuthenticatedDesktopApp({
       openThreadRename: content.threadShell.openThreadRename,
       resetThreadShell: content.threadShell.resetThreadShell,
       selectThread: sessionState.selectThread,
-      selectedThread: sessionState.selectedThread,
+      selectedThreadId: sessionState.selectedThreadId,
       setSidebarThreadMenu: content.threadShell.setSidebarThreadMenu,
       setThreadRenameDraft: content.threadShell.setThreadRenameDraft,
       sidebarThreadMenuOpenId: content.threadShell.sidebarThreadMenuOpenId,

--- a/desktop/src/renderer/features/management/use-desktop-management.ts
+++ b/desktop/src/renderer/features/management/use-desktop-management.ts
@@ -16,6 +16,7 @@ import type {
 } from "../../../main/contracts";
 import { requireDesktopBridge } from "../../state/session/desktop-bridge.js";
 import { shouldReloadManagementOverviewForRuntimeEvent } from "./management-runtime-events.ts";
+import { tracePerfEvent } from "../../lib/perf-debug.ts";
 
 export function useDesktopManagement({
   enabled,
@@ -34,10 +35,26 @@ export function useDesktopManagement({
       return null;
     }
     setLoading(true);
+    const startedAt = performance.now();
     try {
       const bridge = requireDesktopBridge();
       const nextOverview = await bridge.management.getOverview({
         forceRefetch,
+      });
+      const durationMs = Number((performance.now() - startedAt).toFixed(2));
+      tracePerfEvent("management-overview", {
+        appCount: nextOverview.apps.length,
+        forceRefetch,
+        loading: true,
+        managedExtensionCount: nextOverview.managedExtensions.length,
+        mcpServerCount: nextOverview.mcpServers.length,
+        pluginCount: nextOverview.plugins.length,
+        skillCount: nextOverview.skills.length,
+        durationMs,
+      }, {
+        level: durationMs >= 100 ? "warn" : "info",
+        minIntervalMs: 250,
+        throttleKey: `management-overview:${forceRefetch ? "force" : "cached"}`,
       });
       setOverview(nextOverview);
       setError(null);
@@ -62,6 +79,13 @@ export function useDesktopManagement({
     const bridge = requireDesktopBridge();
     const unsubscribe = bridge.session.onRuntimeEvent((event) => {
       if (shouldReloadManagementOverviewForRuntimeEvent(event)) {
+        tracePerfEvent("management-runtime-event", {
+          eventKind: event.kind,
+        }, {
+          level: "warn",
+          minIntervalMs: 250,
+          throttleKey: "management-runtime-event",
+        });
         void loadOverview(true);
       }
     });

--- a/desktop/src/renderer/features/workspace/use-workspace-activity.ts
+++ b/desktop/src/renderer/features/workspace/use-workspace-activity.ts
@@ -159,31 +159,6 @@ export function useWorkspaceActivity({
     };
   }, [selectedThreadId, selectedWorkspaceSessionId]);
 
-  useEffect(() => {
-    const rootPath = selectedThreadWorkspaceRoot;
-    if (!rootPath || workspaceStructureRefreshing) {
-      return;
-    }
-    if (workspacePolicy && workspacePolicy.known_structure.length > 0) {
-      return;
-    }
-    if (workspacePolicy && workspacePolicy.read_granted !== 1) {
-      return;
-    }
-
-    let cancelled = false;
-    setWorkspaceStructureRefreshing(true);
-    perfCount("workspace-activity.hydrate-structure");
-    void hydrateWorkspace(rootPath).finally(() => {
-      if (!cancelled) {
-        setWorkspaceStructureRefreshing(false);
-      }
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [hydrateWorkspace, selectedThreadWorkspaceRoot, workspacePolicy?.known_structure?.length, workspacePolicy?.read_granted]);
-
   const refreshWorkspaceStructure = useCallback(async () => {
     if (!selectedThreadWorkspaceRoot) {
       return;

--- a/desktop/src/renderer/features/workspace/use-workspace-shell.ts
+++ b/desktop/src/renderer/features/workspace/use-workspace-shell.ts
@@ -23,6 +23,7 @@ import {
   resolveActiveWorkspaceOperatingMode,
 } from "./workspace-shell-state.ts";
 import { useWorkspaceNavigation } from "./use-workspace-navigation.ts";
+import { perfMeasure } from "../../lib/perf-debug.ts";
 
 type UseWorkspaceShellArgs = {
   archiveWorkspace: (workspaceId: string) => Promise<boolean>;
@@ -130,6 +131,7 @@ export function useWorkspaceShell({
   const [workspaceDeletePendingId, setWorkspaceDeletePendingId] = useState<string | null>(null);
   const [dragOverRoot, setDragOverRoot] = useState<string | null>(null);
   const draggedWorkspaceRef = useRef<string | null>(null);
+  const previousSidebarThreadSummariesRef = useRef<WorkspaceSidebarThreadSummary[]>([]);
 
   const activeWorkspaceRoot = selectedThread?.workspaceRoot ?? (workInFolder ? workspaceFolder : null);
   const workspaceIdByRoot = useMemo(
@@ -166,32 +168,93 @@ export function useWorkspaceShell({
   });
 
   const filteredSidebarThreads = useMemo(
-    () => filteredThreads.map((thread) => toWorkspaceSidebarThreadSummary(thread)),
+    () => perfMeasure(
+      "workspace-sidebar.thread-summary",
+      () => {
+        const previousSummaries = previousSidebarThreadSummariesRef.current;
+        const previousSummariesById = new Map(previousSummaries.map((summary) => [summary.id, summary]));
+        const nextSummaries = filteredThreads.map((thread) => (
+          toWorkspaceSidebarThreadSummary(thread, previousSummariesById.get(thread.id))
+        ));
+        const isUnchanged = previousSummaries.length === nextSummaries.length
+          && previousSummaries.every((summary, index) => summary === nextSummaries[index]);
+        if (isUnchanged) {
+          return previousSummaries;
+        }
+        previousSidebarThreadSummariesRef.current = nextSummaries;
+        return nextSummaries;
+      },
+      {
+        logThresholdMs: 16,
+        details: () => ({
+          filteredThreadCount: filteredThreads.length,
+        }),
+      },
+    ),
     [filteredThreads],
   );
   const workspaceThreadGroups = useMemo(
-    () => buildWorkspaceSidebarGroups({
-      threads: filteredSidebarThreads,
-      savedOrder: workspaceSidebarOrder,
-      activeWorkspaceRoot,
-    }),
+    () => {
+      let traceDetails: Record<string, unknown> | null = null;
+      return perfMeasure(
+        "workspace-sidebar.groups",
+        () => {
+          const groups = buildWorkspaceSidebarGroups({
+            threads: filteredSidebarThreads,
+            savedOrder: workspaceSidebarOrder,
+            activeWorkspaceRoot,
+          });
+          traceDetails = {
+            activeWorkspaceRoot,
+            baseOrderCount: groups.baseOrder.length,
+            displayOrderCount: groups.displayOrder.length,
+            filteredThreadCount: filteredSidebarThreads.length,
+            savedOrderCount: workspaceSidebarOrder.length,
+            standaloneCount: groups.standalone.length,
+            workspaceCount: groups.workspaces.length,
+          };
+          return groups;
+        },
+        {
+          logThresholdMs: 24,
+          details: () => traceDetails ?? {
+            activeWorkspaceRoot,
+            filteredThreadCount: filteredSidebarThreads.length,
+            savedOrderCount: workspaceSidebarOrder.length,
+          },
+        },
+      );
+    },
     [activeWorkspaceRoot, filteredSidebarThreads, workspaceSidebarOrder],
   );
   const hideWorkspaceSidebarGroups = shouldHideWorkspaceSidebarGroups(
     selectedThread?.id ?? null,
     selectedThread?.workspaceRoot ?? null,
   );
-  const visibleWorkspaceThreadGroups = useMemo(() => ({
-    ...workspaceThreadGroups,
-    workspaces: hideWorkspaceSidebarGroups
-      ? []
-      : resolveVisibleWorkspaceSidebarGroups(workspaceThreadGroups.workspaces, activeWorkspaceRoot),
-    standalone: resolveVisibleStandaloneSidebarThreads(
-      workspaceThreadGroups.standalone,
-      selectedThread?.id ?? null,
-      selectedThread?.workspaceRoot ?? null,
-    ),
-  }), [
+  const visibleWorkspaceThreadGroups = useMemo(() => perfMeasure(
+    "workspace-sidebar.visible-groups",
+    () => ({
+      ...workspaceThreadGroups,
+      workspaces: hideWorkspaceSidebarGroups
+        ? []
+        : resolveVisibleWorkspaceSidebarGroups(workspaceThreadGroups.workspaces, activeWorkspaceRoot),
+      standalone: resolveVisibleStandaloneSidebarThreads(
+        workspaceThreadGroups.standalone,
+        selectedThread?.id ?? null,
+        selectedThread?.workspaceRoot ?? null,
+      ),
+    }),
+    {
+      logThresholdMs: 16,
+      details: () => ({
+        activeWorkspaceRoot,
+        hideWorkspaceSidebarGroups,
+        selectedThreadId: selectedThread?.id ?? null,
+        standaloneCount: workspaceThreadGroups.standalone.length,
+        workspaceCount: workspaceThreadGroups.workspaces.length,
+      }),
+    },
+  ), [
     activeWorkspaceRoot,
     hideWorkspaceSidebarGroups,
     selectedThread?.id,

--- a/desktop/src/renderer/features/workspace/workspace-sidebar.test.js
+++ b/desktop/src/renderer/features/workspace/workspace-sidebar.test.js
@@ -207,3 +207,58 @@ test("toWorkspaceSidebarThreadSummary keeps only the fields the shell needs", ()
   assert.equal("entries" in summary, false);
   assert.equal("reviewSummary" in summary, false);
 });
+
+test("toWorkspaceSidebarThreadSummary reuses the previous summary when list-facing fields are unchanged", () => {
+  const previousSummary = toWorkspaceSidebarThreadSummary({
+    id: "thread-1",
+    title: "Alpha",
+    updatedAt: "2026-03-26T10:00:00.000Z",
+    updatedLabel: "just now",
+    workspaceRoot: "/tmp/alpha",
+    state: "running",
+    threadInputState: null,
+  });
+
+  const nextSummary = toWorkspaceSidebarThreadSummary(
+    {
+      id: "thread-1",
+      title: "Alpha",
+      updatedAt: "2026-03-26T10:00:00.000Z",
+      updatedLabel: "just now",
+      workspaceRoot: "/tmp/alpha",
+      state: "running",
+      threadInputState: null,
+    },
+    previousSummary,
+  );
+
+  assert.equal(nextSummary, previousSummary);
+});
+
+test("toWorkspaceSidebarThreadSummary returns a new summary when list-facing fields change", () => {
+  const previousSummary = toWorkspaceSidebarThreadSummary({
+    id: "thread-1",
+    title: "Alpha",
+    updatedAt: "2026-03-26T10:00:00.000Z",
+    updatedLabel: "just now",
+    workspaceRoot: "/tmp/alpha",
+    state: "running",
+    threadInputState: null,
+  });
+
+  const nextSummary = toWorkspaceSidebarThreadSummary(
+    {
+      id: "thread-1",
+      title: "Alpha renamed",
+      updatedAt: "2026-03-26T10:00:00.000Z",
+      updatedLabel: "just now",
+      workspaceRoot: "/tmp/alpha",
+      state: "running",
+      threadInputState: null,
+    },
+    previousSummary,
+  );
+
+  assert.notEqual(nextSummary, previousSummary);
+  assert.equal(nextSummary.title, "Alpha renamed");
+});

--- a/desktop/src/renderer/features/workspace/workspace-sidebar.ts
+++ b/desktop/src/renderer/features/workspace/workspace-sidebar.ts
@@ -1,5 +1,6 @@
 import type { DesktopThreadSnapshot } from "../../../main/contracts";
 import { normalizeUserFacingWorkspaceRoot } from "../../../shared/workspace-roots.ts";
+import { perfMeasure } from "../../lib/perf-debug.ts";
 
 export type WorkspaceSidebarThread = {
   readonly id: string;
@@ -15,13 +16,28 @@ export type WorkspaceSidebarThreadSummary = Pick<
 
 export function toWorkspaceSidebarThreadSummary(
   thread: WorkspaceSidebarThreadSummary,
+  previousSummary?: WorkspaceSidebarThreadSummary,
 ): WorkspaceSidebarThreadSummary {
+  const normalizedWorkspaceRoot = normalizeUserFacingWorkspaceRoot(thread.workspaceRoot);
+  if (
+    previousSummary
+    && previousSummary.id === thread.id
+    && previousSummary.title === thread.title
+    && previousSummary.updatedAt === thread.updatedAt
+    && previousSummary.updatedLabel === thread.updatedLabel
+    && previousSummary.workspaceRoot === normalizedWorkspaceRoot
+    && previousSummary.state === thread.state
+    && previousSummary.threadInputState === thread.threadInputState
+  ) {
+    return previousSummary;
+  }
+
   return {
     id: thread.id,
     title: thread.title,
     updatedAt: thread.updatedAt,
     updatedLabel: thread.updatedLabel,
-    workspaceRoot: normalizeUserFacingWorkspaceRoot(thread.workspaceRoot),
+    workspaceRoot: normalizedWorkspaceRoot,
     state: thread.state,
     threadInputState: thread.threadInputState,
   };
@@ -244,40 +260,83 @@ export function buildWorkspaceSidebarGroups<T extends WorkspaceSidebarThread>(pa
   baseOrder: string[];
   displayOrder: string[];
 } {
-  const groups = new Map<string, T[]>();
-  const standalone: T[] = [];
+  const { groups, standalone } = perfMeasure(
+    "workspace-sidebar.bucket-threads",
+    () => {
+      const groupedThreads = new Map<string, T[]>();
+      const standaloneThreads: T[] = [];
 
-  for (const thread of params.threads) {
-    const root = normalizeUserFacingWorkspaceRoot(thread.workspaceRoot) ?? "";
-    if (!root) {
-      standalone.push(thread);
-      continue;
-    }
+      for (const thread of params.threads) {
+        const root = normalizeUserFacingWorkspaceRoot(thread.workspaceRoot) ?? "";
+        if (!root) {
+          standaloneThreads.push(thread);
+          continue;
+        }
 
-    const existing = groups.get(root);
-    if (existing) {
-      existing.push(thread);
-    } else {
-      groups.set(root, [thread]);
-    }
-  }
+        const existing = groupedThreads.get(root);
+        if (existing) {
+          existing.push(thread);
+        } else {
+          groupedThreads.set(root, [thread]);
+        }
+      }
+
+      return {
+        groups: groupedThreads,
+        standalone: standaloneThreads,
+      };
+    },
+    {
+      logThresholdMs: 12,
+      details: () => ({
+        threadCount: params.threads.length,
+      }),
+    },
+  );
 
   const activeRoot = typeof params.activeWorkspaceRoot === "string" ? params.activeWorkspaceRoot.trim() : "";
-  const visibleRoots = uniqueRoots([
-    ...groups.keys(),
-    activeRoot || null,
-  ]);
-  const baseOrder = resolveWorkspaceBaseOrder(visibleRoots, params.savedOrder);
-  const displayOrder = resolveWorkspaceDisplayOrder(baseOrder, activeRoot || null);
+  const { baseOrder, displayOrder } = perfMeasure(
+    "workspace-sidebar.resolve-order",
+    () => {
+      const visibleRoots = uniqueRoots([
+        ...groups.keys(),
+        activeRoot || null,
+      ]);
+      const nextBaseOrder = resolveWorkspaceBaseOrder(visibleRoots, params.savedOrder);
+      return {
+        baseOrder: nextBaseOrder,
+        displayOrder: resolveWorkspaceDisplayOrder(nextBaseOrder, activeRoot || null),
+      };
+    },
+    {
+      logThresholdMs: 8,
+      details: () => ({
+        activeWorkspaceRoot: activeRoot || null,
+        savedOrderCount: params.savedOrder.length,
+        workspaceCount: groups.size,
+      }),
+    },
+  );
 
-  return {
-    workspaces: displayOrder.map((root) => ({
-      root,
-      threads: groups.get(root) ?? [],
-      isActive: Boolean(activeRoot) && root === activeRoot,
-    })),
-    standalone,
-    baseOrder,
-    displayOrder,
-  };
+  return perfMeasure(
+    "workspace-sidebar.materialize-groups",
+    () => ({
+      workspaces: displayOrder.map((root) => ({
+        root,
+        threads: groups.get(root) ?? [],
+        isActive: Boolean(activeRoot) && root === activeRoot,
+      })),
+      standalone,
+      baseOrder,
+      displayOrder,
+    }),
+    {
+      logThresholdMs: 12,
+      details: () => ({
+        displayOrderCount: displayOrder.length,
+        standaloneCount: standalone.length,
+        workspaceCount: groups.size,
+      }),
+    },
+  );
 }

--- a/desktop/src/renderer/lib/perf-debug.ts
+++ b/desktop/src/renderer/lib/perf-debug.ts
@@ -9,14 +9,36 @@ type PerfStore = {
   lastFlushAt: number;
 };
 
+type PerfTraceEvent = {
+  at: string;
+  details?: Record<string, unknown>;
+  level: "info" | "warn";
+  name: string;
+};
+
+type PerfMeasureOptions = {
+  details?: Record<string, unknown> | (() => Record<string, unknown>);
+  logThresholdMs?: number;
+};
+
+type PerfTraceOptions = {
+  level?: "info" | "warn";
+  minIntervalMs?: number;
+  throttleKey?: string;
+};
+
 declare global {
   interface Window {
     __SENSE1_DEBUG_PERF__?: boolean;
     __SENSE1_PERF__?: PerfStore;
+    __SENSE1_PERF_TRACE__?: PerfTraceEvent[];
+    __SENSE1_PERF_TRACE_LAST_AT__?: Record<string, number>;
+    __SENSE1_TRACE_PERF__?: boolean;
   }
 }
 
 const PERF_FLUSH_INTERVAL_MS = 2000;
+const PERF_TRACE_BUFFER_LIMIT = 200;
 
 function isPerfDebugEnabled(): boolean {
   if (typeof window === "undefined") {
@@ -32,6 +54,208 @@ function isPerfDebugEnabled(): boolean {
   } catch {
     return false;
   }
+}
+
+export function isPerfTraceEnabled(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  if (window.__SENSE1_TRACE_PERF__ === true || window.__SENSE1_DEBUG_PERF__ === true) {
+    return true;
+  }
+
+  try {
+    if (window.localStorage.getItem("sense1:trace-perf") === "1") {
+      return true;
+    }
+  } catch {
+    // Ignore localStorage access failures and fall back to runtime heuristics.
+  }
+
+  return false;
+}
+
+function getPerfTraceBuffer(): PerfTraceEvent[] {
+  if (!window.__SENSE1_PERF_TRACE__) {
+    window.__SENSE1_PERF_TRACE__ = [];
+  }
+  return window.__SENSE1_PERF_TRACE__;
+}
+
+function getPerfTraceThrottleStore(): Record<string, number> {
+  if (!window.__SENSE1_PERF_TRACE_LAST_AT__) {
+    window.__SENSE1_PERF_TRACE_LAST_AT__ = {};
+  }
+  return window.__SENSE1_PERF_TRACE_LAST_AT__;
+}
+
+function resolvePerfDetails(
+  details: PerfMeasureOptions["details"],
+): Record<string, unknown> | undefined {
+  if (!details) {
+    return undefined;
+  }
+
+  try {
+    return typeof details === "function" ? details() : details;
+  } catch (error) {
+    return {
+      detailError: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function maybeTraceSlowPerf(
+  name: string,
+  durationMs: number,
+  options?: PerfMeasureOptions,
+): void {
+  const thresholdMs = options?.logThresholdMs;
+  if (typeof thresholdMs !== "number" || durationMs < thresholdMs) {
+    return;
+  }
+
+  tracePerfEvent("slow", {
+    durationMs: Number(durationMs.toFixed(2)),
+    source: name,
+    ...(resolvePerfDetails(options?.details) ?? {}),
+  }, {
+    level: "warn",
+  });
+}
+
+export function tracePerfEvent(
+  name: string,
+  details?: Record<string, unknown>,
+  options: PerfTraceOptions = {},
+): void {
+  if (!isPerfTraceEnabled()) {
+    return;
+  }
+
+  const throttleKey = options.throttleKey ?? name;
+  const minIntervalMs = options.minIntervalMs ?? 0;
+  const now = Date.now();
+  if (minIntervalMs > 0) {
+    const traceThrottleStore = getPerfTraceThrottleStore();
+    const lastLoggedAt = traceThrottleStore[throttleKey] ?? 0;
+    if (now - lastLoggedAt < minIntervalMs) {
+      return;
+    }
+    traceThrottleStore[throttleKey] = now;
+  }
+
+  const event: PerfTraceEvent = {
+    at: new Date(now).toISOString(),
+    details,
+    level: options.level ?? "info",
+    name,
+  };
+
+  const traceBuffer = getPerfTraceBuffer();
+  traceBuffer.push(event);
+  if (traceBuffer.length > PERF_TRACE_BUFFER_LIMIT) {
+    traceBuffer.splice(0, traceBuffer.length - PERF_TRACE_BUFFER_LIMIT);
+  }
+
+  const traceLabel = event.level === "warn" ? "[sense1:perf:warn]" : "[sense1:perf:trace]";
+  if (event.level === "warn") {
+    console.warn(traceLabel, event);
+    return;
+  }
+
+  console.info(traceLabel, event);
+}
+
+export function installPerfTraceMonitor(getContext?: () => Record<string, unknown>): () => void {
+  if (!isPerfTraceEnabled() || typeof window === "undefined") {
+    return () => {};
+  }
+
+  const resolveContext = (): Record<string, unknown> => {
+    if (!getContext) {
+      return {};
+    }
+
+    try {
+      return getContext();
+    } catch (error) {
+      return {
+        contextError: error instanceof Error ? error.message : String(error),
+      };
+    }
+  };
+
+  tracePerfEvent("monitor-started", {
+    hostname: window.location.hostname,
+    ...resolveContext(),
+  });
+
+  let cancelled = false;
+  let frameRequestId: number | null = null;
+
+  const performanceObserver = typeof PerformanceObserver === "function"
+    ? new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          if (entry.duration < 50) {
+            continue;
+          }
+
+          tracePerfEvent("longtask", {
+            durationMs: Number(entry.duration.toFixed(2)),
+            entryName: entry.name,
+            entryType: entry.entryType,
+            startTimeMs: Number(entry.startTime.toFixed(2)),
+            ...resolveContext(),
+          }, {
+            level: "warn",
+            minIntervalMs: 250,
+            throttleKey: "longtask",
+          });
+        }
+      })
+    : null;
+
+  try {
+    performanceObserver?.observe({ entryTypes: ["longtask"] });
+  } catch {
+    performanceObserver?.disconnect();
+  }
+
+  if (typeof window.requestAnimationFrame === "function") {
+    let previousFrameAt = performance.now();
+    const trackFrame = (now: number) => {
+      if (cancelled) {
+        return;
+      }
+
+      const frameGapMs = now - previousFrameAt;
+      previousFrameAt = now;
+      if (frameGapMs >= 120) {
+        tracePerfEvent("frame-gap", {
+          frameGapMs: Number(frameGapMs.toFixed(2)),
+          ...resolveContext(),
+        }, {
+          level: "warn",
+          minIntervalMs: 500,
+          throttleKey: "frame-gap",
+        });
+      }
+
+      frameRequestId = window.requestAnimationFrame(trackFrame);
+    };
+
+    frameRequestId = window.requestAnimationFrame(trackFrame);
+  }
+
+  return () => {
+    cancelled = true;
+    if (frameRequestId !== null && typeof window.cancelAnimationFrame === "function") {
+      window.cancelAnimationFrame(frameRequestId);
+    }
+    performanceObserver?.disconnect();
+  };
 }
 
 function getPerfStore(): PerfStore {
@@ -96,27 +320,27 @@ export function perfCount(name: string): void {
   flushPerfCounters();
 }
 
-export function perfMeasure<T>(name: string, fn: () => T): T {
-  if (!isPerfDebugEnabled()) {
-    return fn();
-  }
-
+export function perfMeasure<T>(name: string, fn: () => T, options?: PerfMeasureOptions): T {
+  const shouldCollectCounters = isPerfDebugEnabled();
   const startedAt = performance.now();
   try {
     return fn();
   } finally {
-    const store = getPerfStore();
-    const counter = store.counters[name] ?? {
-      count: 0,
-      maxMs: 0,
-      totalMs: 0,
-    };
     const durationMs = performance.now() - startedAt;
-    counter.count += 1;
-    counter.maxMs = Math.max(counter.maxMs, durationMs);
-    counter.totalMs += durationMs;
-    store.counters[name] = counter;
-    flushPerfCounters();
+    maybeTraceSlowPerf(name, durationMs, options);
+
+    if (shouldCollectCounters) {
+      const store = getPerfStore();
+      const counter = store.counters[name] ?? {
+        count: 0,
+        maxMs: 0,
+        totalMs: 0,
+      };
+      counter.count += 1;
+      counter.maxMs = Math.max(counter.maxMs, durationMs);
+      counter.totalMs += durationMs;
+      store.counters[name] = counter;
+      flushPerfCounters();
+    }
   }
 }
-

--- a/desktop/src/renderer/lib/thread-markdown-performance.test.js
+++ b/desktop/src/renderer/lib/thread-markdown-performance.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import { stripTypeScriptTypes } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const helperSourcePath = fileURLToPath(new URL("./thread-markdown-performance.ts", import.meta.url));
+const helperSource = await fs.readFile(helperSourcePath, "utf8");
+const helperModuleUrl = `data:text/javascript;base64,${Buffer.from(
+  stripTypeScriptTypes(helperSource, { mode: "transform" }),
+).toString("base64")}`;
+const {
+  hasFencedCodeBlocks,
+  shouldDeferRichMarkdown,
+  shouldUseVirtualizedMarkdown,
+} = await import(helperModuleUrl);
+
+test("hasFencedCodeBlocks only enables highlighting for fenced code blocks", () => {
+  assert.equal(hasFencedCodeBlocks("Plain text only"), false);
+  assert.equal(hasFencedCodeBlocks("```ts\nconst answer = 42;\n```"), true);
+  assert.equal(hasFencedCodeBlocks("~~~js\nconsole.log('hi')\n~~~"), true);
+});
+
+test("shouldUseVirtualizedMarkdown stays off for short answers", () => {
+  assert.equal(shouldUseVirtualizedMarkdown("1. Small item\n2. Another one"), false);
+});
+
+test("shouldUseVirtualizedMarkdown turns on for very long numbered lists", () => {
+  const longList = Array.from({ length: 90 }, (_, index) => `${index + 1}. Item ${index + 1}`).join("\n");
+  assert.equal(shouldUseVirtualizedMarkdown(longList), true);
+});
+
+test("shouldUseVirtualizedMarkdown turns on for very large markdown bodies", () => {
+  assert.equal(shouldUseVirtualizedMarkdown("Paragraph\n".repeat(700)), true);
+});
+
+test("shouldDeferRichMarkdown stays off for normal answers", () => {
+  assert.equal(shouldDeferRichMarkdown("Paragraph\n".repeat(12)), false);
+});
+
+test("shouldDeferRichMarkdown turns on for huge numbered lists", () => {
+  const hugeList = Array.from({ length: 180 }, (_, index) => `${index + 1}. Item ${index + 1}`).join("\n");
+  assert.equal(shouldDeferRichMarkdown(hugeList), true);
+});

--- a/desktop/src/renderer/lib/thread-markdown-performance.ts
+++ b/desktop/src/renderer/lib/thread-markdown-performance.ts
@@ -1,0 +1,60 @@
+const FENCED_CODE_BLOCK_PATTERN = /(^|\n)\s*(`{3,}|~{3,})/;
+const LIST_ITEM_PATTERN = /^\s*(?:[-*+]|\d+[.)])\s+/;
+
+const LARGE_MARKDOWN_CHARACTER_THRESHOLD = 6_000;
+const LARGE_MARKDOWN_LINE_THRESHOLD = 120;
+const LARGE_MARKDOWN_LIST_ITEM_THRESHOLD = 80;
+const DEFERRED_RICH_MARKDOWN_CHARACTER_THRESHOLD = 12_000;
+const DEFERRED_RICH_MARKDOWN_LINE_THRESHOLD = 220;
+const DEFERRED_RICH_MARKDOWN_LIST_ITEM_THRESHOLD = 140;
+
+function countListItems(lines: string[]): number {
+  let listItemCount = 0;
+  for (const line of lines) {
+    if (!LIST_ITEM_PATTERN.test(line)) {
+      continue;
+    }
+
+    listItemCount += 1;
+  }
+
+  return listItemCount;
+}
+
+export function hasFencedCodeBlocks(markdown: string): boolean {
+  return FENCED_CODE_BLOCK_PATTERN.test(markdown);
+}
+
+export function shouldUseVirtualizedMarkdown(markdown: string): boolean {
+  if (!markdown.trim()) {
+    return false;
+  }
+
+  if (markdown.length >= LARGE_MARKDOWN_CHARACTER_THRESHOLD) {
+    return true;
+  }
+
+  const lines = markdown.split(/\r?\n/);
+  if (lines.length >= LARGE_MARKDOWN_LINE_THRESHOLD) {
+    return true;
+  }
+
+  return countListItems(lines) >= LARGE_MARKDOWN_LIST_ITEM_THRESHOLD;
+}
+
+export function shouldDeferRichMarkdown(markdown: string): boolean {
+  if (!markdown.trim()) {
+    return false;
+  }
+
+  if (markdown.length >= DEFERRED_RICH_MARKDOWN_CHARACTER_THRESHOLD) {
+    return true;
+  }
+
+  const lines = markdown.split(/\r?\n/);
+  if (lines.length >= DEFERRED_RICH_MARKDOWN_LINE_THRESHOLD) {
+    return true;
+  }
+
+  return countListItems(lines) >= DEFERRED_RICH_MARKDOWN_LIST_ITEM_THRESHOLD;
+}

--- a/desktop/src/renderer/state/session/session-stream-delta.test.js
+++ b/desktop/src/renderer/state/session/session-stream-delta.test.js
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
+import { formatUpdatedLabel } from "../../lib/live-thread-data.js";
 import { applyThreadDelta } from "./session-stream-delta.ts";
 import { createThreadDeltaBuffer } from "./session-stream-buffer.ts";
 
@@ -333,20 +334,20 @@ test("applyThreadDelta clears streaming body overlays once an entry completes", 
   assert.equal(thread.updatedLabel, "just now");
 });
 
-test("applyThreadDelta keeps thread ordering stable for interaction and metadata updates", () => {
+test("applyThreadDelta keeps thread ordering stable for interaction updates", () => {
   const harness = createDeps([
+    createThread({
+      id: "thread-2",
+      title: "Newer thread",
+      updatedAt: "2026-04-08T11:00:00.000Z",
+      updatedLabel: "5 min ago",
+    }),
     createThread({
       id: "thread-1",
       title: "Older thread",
       updatedAt: "2026-04-08T10:00:00.000Z",
       updatedLabel: "10 min ago",
       interactionState: "conversation",
-    }),
-    createThread({
-      id: "thread-2",
-      title: "Newer thread",
-      updatedAt: "2026-04-08T11:00:00.000Z",
-      updatedLabel: "5 min ago",
     }),
   ]);
 
@@ -360,6 +361,29 @@ test("applyThreadDelta keeps thread ordering stable for interaction and metadata
     harness.deps,
   );
 
+  const [, thread] = harness.getState().threads;
+  assert.deepEqual(harness.getState().threads.map((currentThread) => currentThread.id), ["thread-2", "thread-1"]);
+  assert.equal(thread.interactionState, "review");
+  assert.equal(thread.updatedAt, "2026-04-08T10:00:00.000Z");
+  assert.equal(thread.updatedLabel, "10 min ago");
+});
+
+test("applyThreadDelta refreshes recency metadata for thread title changes", () => {
+  const harness = createDeps([
+    createThread({
+      id: "thread-2",
+      title: "Newer thread",
+      updatedAt: "2026-04-08T11:00:00.000Z",
+      updatedLabel: "5 min ago",
+    }),
+    createThread({
+      id: "thread-1",
+      title: "Older thread",
+      updatedAt: "2026-04-08T10:00:00.000Z",
+      updatedLabel: "10 min ago",
+    }),
+  ]);
+
   applyThreadDelta(
     {
       kind: "threadMetadataChanged",
@@ -372,8 +396,7 @@ test("applyThreadDelta keeps thread ordering stable for interaction and metadata
 
   const [thread] = harness.getState().threads;
   assert.deepEqual(harness.getState().threads.map((currentThread) => currentThread.id), ["thread-1", "thread-2"]);
-  assert.equal(thread.interactionState, "review");
   assert.equal(thread.title, "Renamed thread");
-  assert.equal(thread.updatedAt, "2026-04-08T10:00:00.000Z");
-  assert.equal(thread.updatedLabel, "10 min ago");
+  assert.equal(thread.updatedAt, "2026-04-08T12:30:00.000Z");
+  assert.equal(thread.updatedLabel, formatUpdatedLabel("2026-04-08T12:30:00.000Z"));
 });

--- a/desktop/src/renderer/state/session/session-stream-delta.test.js
+++ b/desktop/src/renderer/state/session/session-stream-delta.test.js
@@ -110,8 +110,21 @@ function createDeps(initialThreads) {
   };
 }
 
-test("applyThreadDelta updates threadInputState and refreshed updated label", () => {
-  const harness = createDeps([createThread()]);
+test("applyThreadDelta updates threadInputState without refreshing recency metadata", () => {
+  const harness = createDeps([
+    createThread({
+      id: "thread-1",
+      title: "Older thread",
+      updatedAt: "2026-04-08T10:00:00.000Z",
+      updatedLabel: "10 min ago",
+    }),
+    createThread({
+      id: "thread-2",
+      title: "Newer thread",
+      updatedAt: "2026-04-08T11:00:00.000Z",
+      updatedLabel: "5 min ago",
+    }),
+  ]);
 
   applyThreadDelta(
     {
@@ -137,7 +150,9 @@ test("applyThreadDelta updates threadInputState and refreshed updated label", ()
   const [thread] = harness.getState().threads;
   assert.equal(thread.threadInputState?.queuedMessages.length, 1);
   assert.equal(thread.threadInputState?.hasUnseenCompletion, true);
-  assert.notEqual(thread.updatedLabel, "just now");
+  assert.equal(thread.updatedAt, "2026-04-08T10:00:00.000Z");
+  assert.equal(thread.updatedLabel, "10 min ago");
+  assert.deepEqual(harness.getState().threads.map((currentThread) => currentThread.id), ["thread-1", "thread-2"]);
 });
 
 test("applyThreadDelta keeps updated labels in sync for thread state changes", () => {
@@ -232,6 +247,45 @@ test("applyThreadDelta keeps thread ordering stable for streaming entry appends"
   assert.equal(harness.getState().streamingEntryBodiesByThread["thread-1"]?.["entry-1"], " world");
 });
 
+test("applyThreadDelta keeps thread ordering stable when a streaming entry starts", () => {
+  const harness = createDeps([
+    createThread({
+      id: "thread-1",
+      title: "Older running thread",
+      updatedAt: "2026-04-08T10:00:00.000Z",
+      updatedLabel: "10 min ago",
+    }),
+    createThread({
+      id: "thread-2",
+      title: "Newer idle thread",
+      updatedAt: "2026-04-08T11:00:00.000Z",
+      updatedLabel: "5 min ago",
+    }),
+  ]);
+
+  applyThreadDelta(
+    {
+      kind: "entryStarted",
+      threadId: "thread-1",
+      entry: {
+        id: "entry-1",
+        kind: "assistant",
+        title: "Sense-1 activity",
+        body: "Hello",
+        status: "streaming",
+      },
+      updatedAt: "2026-04-08T12:00:00.000Z",
+    },
+    harness.deps,
+  );
+
+  const [thread] = harness.getState().threads;
+  assert.deepEqual(harness.getState().threads.map((currentThread) => currentThread.id), ["thread-1", "thread-2"]);
+  assert.equal(thread.entries[0]?.id, "entry-1");
+  assert.equal(thread.updatedAt, "2026-04-08T10:00:00.000Z");
+  assert.equal(thread.updatedLabel, "10 min ago");
+});
+
 test("applyThreadDelta clears streaming body overlays once an entry completes", () => {
   const initialThread = createThread({
     entries: [
@@ -275,4 +329,51 @@ test("applyThreadDelta clears streaming body overlays once an entry completes", 
   const [thread] = harness.getState().threads;
   assert.equal(thread.entries[0]?.body, "Hello world");
   assert.deepEqual(harness.getState().streamingEntryBodiesByThread["thread-1"], {});
+  assert.equal(thread.updatedAt, "2026-04-08T10:00:00.000Z");
+  assert.equal(thread.updatedLabel, "just now");
+});
+
+test("applyThreadDelta keeps thread ordering stable for interaction and metadata updates", () => {
+  const harness = createDeps([
+    createThread({
+      id: "thread-1",
+      title: "Older thread",
+      updatedAt: "2026-04-08T10:00:00.000Z",
+      updatedLabel: "10 min ago",
+      interactionState: "conversation",
+    }),
+    createThread({
+      id: "thread-2",
+      title: "Newer thread",
+      updatedAt: "2026-04-08T11:00:00.000Z",
+      updatedLabel: "5 min ago",
+    }),
+  ]);
+
+  applyThreadDelta(
+    {
+      kind: "interactionStateChanged",
+      threadId: "thread-1",
+      interactionState: "review",
+      updatedAt: "2026-04-08T12:00:00.000Z",
+    },
+    harness.deps,
+  );
+
+  applyThreadDelta(
+    {
+      kind: "threadMetadataChanged",
+      threadId: "thread-1",
+      title: "Renamed thread",
+      updatedAt: "2026-04-08T12:30:00.000Z",
+    },
+    harness.deps,
+  );
+
+  const [thread] = harness.getState().threads;
+  assert.deepEqual(harness.getState().threads.map((currentThread) => currentThread.id), ["thread-1", "thread-2"]);
+  assert.equal(thread.interactionState, "review");
+  assert.equal(thread.title, "Renamed thread");
+  assert.equal(thread.updatedAt, "2026-04-08T10:00:00.000Z");
+  assert.equal(thread.updatedLabel, "10 min ago");
 });

--- a/desktop/src/renderer/state/session/session-stream-delta.ts
+++ b/desktop/src/renderer/state/session/session-stream-delta.ts
@@ -188,10 +188,16 @@ export function applyThreadDelta(
 
   if (delta.kind === "threadMetadataChanged") {
     deps.setThreads((current) => {
-      return replaceThreadWithoutReordering(current, delta.threadId, (thread) => ({
+      const thread = current.find((candidate) => candidate.id === delta.threadId);
+      if (!thread) {
+        return current;
+      }
+      return upsertThread(current, {
         ...thread,
         title: delta.title,
-      }));
+        updatedAt: delta.updatedAt,
+        updatedLabel: formatUpdatedLabel(delta.updatedAt),
+      });
     });
     return;
   }

--- a/desktop/src/renderer/state/session/session-stream-delta.ts
+++ b/desktop/src/renderer/state/session/session-stream-delta.ts
@@ -103,21 +103,17 @@ export function applyThreadDelta(
 
   if (delta.kind === "entryStarted") {
     deps.setThreads((current) => {
-      const thread = current.find((t) => t.id === delta.threadId);
-      if (!thread) {
-        return current;
-      }
-      const entries = thread.entries.some((e) => e.id === delta.entry.id)
-        ? thread.entries.map((e) => (e.id === delta.entry.id ? delta.entry : e))
-        : [...thread.entries, delta.entry];
-      const updatedAt = new Date().toISOString();
-      return upsertThread(current, {
-        ...thread,
-        entries,
-        changeGroups: buildChangeGroups(entries),
-        progressSummary: buildProgressSummary(entries, thread.state),
-        updatedAt,
-        updatedLabel: formatUpdatedLabel(updatedAt),
+      return replaceThreadWithoutReordering(current, delta.threadId, (thread) => {
+        const entries = thread.entries.some((entry) => entry.id === delta.entry.id)
+          ? thread.entries.map((entry) => (entry.id === delta.entry.id ? delta.entry : entry))
+          : [...thread.entries, delta.entry];
+
+        return {
+          ...thread,
+          entries,
+          changeGroups: buildChangeGroups(entries),
+          progressSummary: buildProgressSummary(entries, thread.state),
+        };
       });
     });
     return;
@@ -126,24 +122,17 @@ export function applyThreadDelta(
   if (delta.kind === "entryCompleted") {
     deps.clearStreamingEntryBody(delta.threadId, delta.entryId);
     deps.setThreads((current) => {
-      const thread = current.find((t) => t.id === delta.threadId);
-      if (!thread) {
-        return current;
-      }
-      const entries = thread.entries.some((e) => e.id === delta.entryId)
-        ? thread.entries.map((e) => (e.id === delta.entryId ? delta.entry : e))
-        : [...thread.entries, delta.entry];
-      const updatedAt =
-        "status" in delta.entry && delta.entry.status === "streaming"
-          ? thread.updatedAt
-          : new Date().toISOString();
-      return upsertThread(current, {
-        ...thread,
-        entries,
-        changeGroups: buildChangeGroups(entries),
-        progressSummary: buildProgressSummary(entries, thread.state),
-        updatedAt,
-        updatedLabel: formatUpdatedLabel(updatedAt),
+      return replaceThreadWithoutReordering(current, delta.threadId, (thread) => {
+        const entries = thread.entries.some((entry) => entry.id === delta.entryId)
+          ? thread.entries.map((entry) => (entry.id === delta.entryId ? delta.entry : entry))
+          : [...thread.entries, delta.entry];
+
+        return {
+          ...thread,
+          entries,
+          changeGroups: buildChangeGroups(entries),
+          progressSummary: buildProgressSummary(entries, thread.state),
+        };
       });
     });
     return;
@@ -189,32 +178,20 @@ export function applyThreadDelta(
 
   if (delta.kind === "interactionStateChanged") {
     deps.setThreads((current) => {
-      const thread = current.find((t) => t.id === delta.threadId);
-      if (!thread) {
-        return current;
-      }
-      return upsertThread(current, {
+      return replaceThreadWithoutReordering(current, delta.threadId, (thread) => ({
         ...thread,
         interactionState: delta.interactionState,
-        updatedAt: delta.updatedAt,
-        updatedLabel: formatUpdatedLabel(delta.updatedAt),
-      });
+      }));
     });
     return;
   }
 
   if (delta.kind === "threadMetadataChanged") {
     deps.setThreads((current) => {
-      const thread = current.find((t) => t.id === delta.threadId);
-      if (!thread) {
-        return current;
-      }
-      return upsertThread(current, {
+      return replaceThreadWithoutReordering(current, delta.threadId, (thread) => ({
         ...thread,
         title: delta.title,
-        updatedAt: delta.updatedAt,
-        updatedLabel: formatUpdatedLabel(delta.updatedAt),
-      });
+      }));
     });
     return;
   }
@@ -283,17 +260,10 @@ export function applyThreadDelta(
 
   if (delta.kind === "threadInputStateChanged") {
     deps.setThreads((current) => {
-      const thread = current.find((item) => item.id === delta.threadId);
-      if (!thread) {
-        return current;
-      }
-
-      return upsertThread(current, {
+      return replaceThreadWithoutReordering(current, delta.threadId, (thread) => ({
         ...thread,
-        updatedAt: delta.updatedAt,
-        updatedLabel: formatUpdatedLabel(delta.updatedAt),
         threadInputState: delta.threadInputState,
-      });
+      }));
     });
   }
 }

--- a/desktop/src/renderer/state/session/session-stream-live-bodies.test.js
+++ b/desktop/src/renderer/state/session/session-stream-live-bodies.test.js
@@ -1,0 +1,75 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import { stripTypeScriptTypes } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const sourcePath = fileURLToPath(new URL("./session-stream-live-bodies.ts", import.meta.url));
+const source = await fs.readFile(sourcePath, "utf8");
+const reactStubUrl = `data:text/javascript;base64,${Buffer.from("export const useSyncExternalStore = (_subscribe, getSnapshot) => getSnapshot();").toString("base64")}`;
+const perfDebugStubUrl = `data:text/javascript;base64,${Buffer.from("export const perfMeasure = (_name, fn) => fn();").toString("base64")}`;
+const compiledSource = stripTypeScriptTypes(source, { mode: "transform" })
+  .replace(`from "react";`, `from "${reactStubUrl}";`)
+  .replace(`from "../../lib/perf-debug.ts";`, `from "${perfDebugStubUrl}";`);
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(compiledSource).toString("base64")}`;
+const {
+  appendStreamingEntryBody,
+  clearStreamingThreadBodies,
+  readStreamingEntryBody,
+  subscribeStreamingEntryBody,
+} = await import(moduleUrl);
+
+async function waitForFlush() {
+  await new Promise((resolve) => setTimeout(resolve, 120));
+}
+
+test("subscribeStreamingEntryBody only notifies the subscribed entry", async () => {
+  const calls = [];
+  const unsubscribeTarget = subscribeStreamingEntryBody("thread-1", "entry-1", () => {
+    calls.push("entry-1");
+  });
+  const unsubscribeOther = subscribeStreamingEntryBody("thread-1", "entry-2", () => {
+    calls.push("entry-2");
+  });
+
+  appendStreamingEntryBody("thread-1", "entry-1", "Hello");
+  appendStreamingEntryBody("thread-1", "entry-2", "World");
+  await waitForFlush();
+
+  assert.deepEqual(calls, ["entry-1", "entry-2"]);
+
+  unsubscribeTarget();
+  unsubscribeOther();
+  clearStreamingThreadBodies("thread-1");
+});
+
+test("readStreamingEntryBody exposes imperatively readable live text", async () => {
+  const unsubscribe = subscribeStreamingEntryBody("thread-2", "entry-9", () => {});
+
+  appendStreamingEntryBody("thread-2", "entry-9", "Hel");
+  appendStreamingEntryBody("thread-2", "entry-9", "lo");
+  await waitForFlush();
+
+  assert.equal(readStreamingEntryBody("thread-2", "entry-9"), "Hello");
+
+  unsubscribe();
+  clearStreamingThreadBodies("thread-2");
+  assert.equal(readStreamingEntryBody("thread-2", "entry-9"), null);
+});
+
+test("appendStreamingEntryBody coalesces bursty appends into a single notification", async () => {
+  const calls = [];
+  const unsubscribe = subscribeStreamingEntryBody("thread-3", "entry-7", () => {
+    calls.push(readStreamingEntryBody("thread-3", "entry-7"));
+  });
+
+  appendStreamingEntryBody("thread-3", "entry-7", "a");
+  appendStreamingEntryBody("thread-3", "entry-7", "b");
+  appendStreamingEntryBody("thread-3", "entry-7", "c");
+  await waitForFlush();
+
+  assert.deepEqual(calls, ["abc"]);
+
+  unsubscribe();
+  clearStreamingThreadBodies("thread-3");
+});

--- a/desktop/src/renderer/state/session/session-stream-live-bodies.ts
+++ b/desktop/src/renderer/state/session/session-stream-live-bodies.ts
@@ -1,10 +1,34 @@
 import { useSyncExternalStore } from "react";
 
 import type { DesktopThreadEntry } from "../../../main/contracts";
+import { perfMeasure } from "../../lib/perf-debug.ts";
 
-type ThreadEntryBodies = Record<string, string>;
+type ScheduledFlush =
+  | {
+      id: number;
+      kind: "raf";
+    }
+  | {
+      id: ReturnType<typeof setTimeout>;
+      kind: "timeout";
+    };
 
-const EMPTY_THREAD_ENTRY_BODIES: ThreadEntryBodies = Object.freeze({});
+type ThreadEntryBodyRecord = {
+  body: string;
+  pendingAppends: string[];
+  pendingBytes: number;
+  scheduledFlush: ScheduledFlush | null;
+};
+
+type ThreadEntryBodies = Map<string, ThreadEntryBodyRecord>;
+
+const EMPTY_THREAD_ENTRY_BODIES: ThreadEntryBodies = new Map();
+const LARGE_STREAMING_BODY_THRESHOLD = 16_000;
+const HUGE_STREAMING_BODY_THRESHOLD = 64_000;
+const STREAMING_BODY_DEFAULT_FLUSH_MS = 16;
+const STREAMING_BODY_LARGE_FLUSH_MS = 48;
+const STREAMING_BODY_HUGE_FLUSH_MS = 96;
+
 const threadEntryBodies = new Map<string, ThreadEntryBodies>();
 const threadEntryListeners = new Map<string, Map<string, Set<() => void>>>();
 
@@ -32,50 +56,166 @@ function getThreadBodies(threadId: string): ThreadEntryBodies {
   return threadEntryBodies.get(threadId) ?? EMPTY_THREAD_ENTRY_BODIES;
 }
 
-function getThreadEntryBody(threadId: string, entryId: string): string | null {
-  return getThreadBodies(threadId)[entryId] ?? null;
+function getOrCreateThreadBodies(threadId: string): ThreadEntryBodies {
+  const existingBodies = threadEntryBodies.get(threadId);
+  if (existingBodies) {
+    return existingBodies;
+  }
+
+  const nextBodies = new Map<string, ThreadEntryBodyRecord>();
+  threadEntryBodies.set(threadId, nextBodies);
+  return nextBodies;
+}
+
+function createThreadEntryBodyRecord(body = ""): ThreadEntryBodyRecord {
+  return {
+    body,
+    pendingAppends: [],
+    pendingBytes: 0,
+    scheduledFlush: null,
+  };
+}
+
+function resolveBufferedEntryBody(record: ThreadEntryBodyRecord): string {
+  if (record.pendingAppends.length === 0) {
+    return record.body;
+  }
+
+  const append = record.pendingAppends.length === 1
+    ? record.pendingAppends[0]
+    : record.pendingAppends.join("");
+  return record.body + append;
+}
+
+export function readStreamingEntryBody(threadId: string, entryId: string): string | null {
+  return getThreadBodies(threadId).get(entryId)?.body ?? null;
 }
 
 function areThreadBodiesEqual(left: ThreadEntryBodies, right: ThreadEntryBodies): boolean {
-  const leftKeys = Object.keys(left);
-  const rightKeys = Object.keys(right);
-  if (leftKeys.length !== rightKeys.length) {
+  if (left.size !== right.size) {
     return false;
   }
-  for (const key of leftKeys) {
-    if (left[key] !== right[key]) {
+
+  for (const [entryId, leftRecord] of left) {
+    const rightRecord = right.get(entryId);
+    if (!rightRecord || resolveBufferedEntryBody(leftRecord) !== resolveBufferedEntryBody(rightRecord)) {
       return false;
     }
   }
   return true;
 }
 
+function cancelScheduledFlush(record: ThreadEntryBodyRecord): void {
+  if (!record.scheduledFlush) {
+    return;
+  }
+
+  if (record.scheduledFlush.kind === "raf" && typeof window !== "undefined" && typeof window.cancelAnimationFrame === "function") {
+    window.cancelAnimationFrame(record.scheduledFlush.id);
+  } else {
+    clearTimeout(record.scheduledFlush.id);
+  }
+
+  record.scheduledFlush = null;
+}
+
+function resolveStreamingBodyFlushMs(record: ThreadEntryBodyRecord): number {
+  const nextLength = record.body.length + record.pendingBytes;
+  if (nextLength >= HUGE_STREAMING_BODY_THRESHOLD) {
+    return STREAMING_BODY_HUGE_FLUSH_MS;
+  }
+  if (nextLength >= LARGE_STREAMING_BODY_THRESHOLD) {
+    return STREAMING_BODY_LARGE_FLUSH_MS;
+  }
+  return STREAMING_BODY_DEFAULT_FLUSH_MS;
+}
+
+function flushStreamingEntryBody(threadId: string, entryId: string): void {
+  const record = getThreadBodies(threadId).get(entryId);
+  if (!record || record.pendingAppends.length === 0) {
+    return;
+  }
+
+  const pendingAppendCount = record.pendingAppends.length;
+  const pendingBytes = record.pendingBytes;
+  perfMeasure(
+    "session-stream.live-body.flush",
+    () => {
+      const nextAppend = pendingAppendCount === 1
+        ? record.pendingAppends[0]
+        : record.pendingAppends.join("");
+      record.pendingAppends = [];
+      record.pendingBytes = 0;
+      record.body += nextAppend;
+    },
+    {
+      logThresholdMs: 16,
+      details: () => ({
+        bodyLength: record.body.length,
+        entryId,
+        pendingAppendCount,
+        pendingBytes,
+        threadId,
+      }),
+    },
+  );
+
+  notifyThreadEntry(threadId, entryId);
+}
+
+function scheduleStreamingEntryFlush(threadId: string, entryId: string, record: ThreadEntryBodyRecord): void {
+  if (record.scheduledFlush) {
+    return;
+  }
+
+  const flushDelayMs = resolveStreamingBodyFlushMs(record);
+  const flush = () => {
+    record.scheduledFlush = null;
+    flushStreamingEntryBody(threadId, entryId);
+  };
+
+  if (
+    flushDelayMs <= STREAMING_BODY_DEFAULT_FLUSH_MS
+    && typeof window !== "undefined"
+    && typeof window.requestAnimationFrame === "function"
+  ) {
+    record.scheduledFlush = {
+      id: window.requestAnimationFrame(flush),
+      kind: "raf",
+    };
+    return;
+  }
+
+  record.scheduledFlush = {
+    id: setTimeout(flush, flushDelayMs),
+    kind: "timeout",
+  };
+}
+
 export function appendStreamingEntryBody(threadId: string, entryId: string, append: string): void {
   if (!append) {
     return;
   }
-  const currentBodies = getThreadBodies(threadId);
-  const nextBodies = {
-    ...currentBodies,
-    [entryId]: `${currentBodies[entryId] ?? ""}${append}`,
-  };
-  if (areThreadBodiesEqual(currentBodies, nextBodies)) {
-    return;
-  }
-  threadEntryBodies.set(threadId, nextBodies);
-  notifyThreadEntry(threadId, entryId);
+
+  const threadBodies = getOrCreateThreadBodies(threadId);
+  const record = threadBodies.get(entryId) ?? createThreadEntryBodyRecord();
+  record.pendingAppends.push(append);
+  record.pendingBytes += append.length;
+  threadBodies.set(entryId, record);
+  scheduleStreamingEntryFlush(threadId, entryId, record);
 }
 
 export function clearStreamingEntryBody(threadId: string, entryId: string): void {
-  const currentBodies = getThreadBodies(threadId);
-  if (!(entryId in currentBodies)) {
+  const currentBodies = threadEntryBodies.get(threadId);
+  const record = currentBodies?.get(entryId);
+  if (!currentBodies || !record) {
     return;
   }
-  const { [entryId]: _ignored, ...remainingBodies } = currentBodies;
-  if (Object.keys(remainingBodies).length === 0) {
+
+  cancelScheduledFlush(record);
+  currentBodies.delete(entryId);
+  if (currentBodies.size === 0) {
     threadEntryBodies.delete(threadId);
-  } else {
-    threadEntryBodies.set(threadId, remainingBodies);
   }
   notifyThreadEntry(threadId, entryId);
 }
@@ -85,57 +225,74 @@ export function clearStreamingThreadBodies(threadId: string): void {
   if (!currentBodies) {
     return;
   }
+
+  for (const record of currentBodies.values()) {
+    cancelScheduledFlush(record);
+  }
+
+  const entryIds = [...currentBodies.keys()];
   threadEntryBodies.delete(threadId);
-  notifyThreadEntries(threadId, Object.keys(currentBodies));
+  notifyThreadEntries(threadId, entryIds);
 }
 
 export function seedStreamingThreadBodies(threadId: string, entries: DesktopThreadEntry[]): void {
-  const nextBodies: ThreadEntryBodies = {};
+  const nextBodies: ThreadEntryBodies = new Map();
   for (const entry of entries) {
     if (entry.kind === "assistant" && "status" in entry && entry.status === "streaming" && "body" in entry) {
-      nextBodies[entry.id] = entry.body;
+      nextBodies.set(entry.id, createThreadEntryBodyRecord(entry.body));
     }
   }
   const currentBodies = getThreadBodies(threadId);
-  if (Object.keys(nextBodies).length === 0) {
+  if (nextBodies.size === 0) {
     clearStreamingThreadBodies(threadId);
     return;
   }
   if (areThreadBodiesEqual(currentBodies, nextBodies)) {
     return;
   }
+
+  for (const record of currentBodies.values()) {
+    cancelScheduledFlush(record);
+  }
+
   threadEntryBodies.set(threadId, nextBodies);
   const changedEntryIds = new Set([
-    ...Object.keys(currentBodies),
-    ...Object.keys(nextBodies),
-  ].filter((entryId) => currentBodies[entryId] !== nextBodies[entryId]));
+    ...currentBodies.keys(),
+    ...nextBodies.keys(),
+  ].filter((entryId) => resolveBufferedEntryBody(currentBodies.get(entryId) ?? createThreadEntryBodyRecord()) !== resolveBufferedEntryBody(nextBodies.get(entryId) ?? createThreadEntryBodyRecord())));
   notifyThreadEntries(threadId, changedEntryIds);
 }
 
 export function useStreamingEntryBody(threadId: string, entryId: string): string | null {
   return useSyncExternalStore(
-    (listener) => {
-      const entryListenersByThread = threadEntryListeners.get(threadId) ?? new Map<string, Set<() => void>>();
-      const entryListeners = entryListenersByThread.get(entryId) ?? new Set<() => void>();
-      entryListeners.add(listener);
-      entryListenersByThread.set(entryId, entryListeners);
-      threadEntryListeners.set(threadId, entryListenersByThread);
-      return () => {
-        const currentEntryListenersByThread = threadEntryListeners.get(threadId);
-        const currentEntryListeners = currentEntryListenersByThread?.get(entryId);
-        if (!currentEntryListenersByThread || !currentEntryListeners) {
-          return;
-        }
-        currentEntryListeners.delete(listener);
-        if (currentEntryListeners.size === 0) {
-          currentEntryListenersByThread.delete(entryId);
-        }
-        if (currentEntryListenersByThread.size === 0) {
-          threadEntryListeners.delete(threadId);
-        }
-      };
-    },
-    () => getThreadEntryBody(threadId, entryId),
-    () => getThreadEntryBody(threadId, entryId),
+    (listener) => subscribeStreamingEntryBody(threadId, entryId, listener),
+    () => readStreamingEntryBody(threadId, entryId),
+    () => readStreamingEntryBody(threadId, entryId),
   );
+}
+
+export function subscribeStreamingEntryBody(
+  threadId: string,
+  entryId: string,
+  listener: () => void,
+): () => void {
+  const entryListenersByThread = threadEntryListeners.get(threadId) ?? new Map<string, Set<() => void>>();
+  const entryListeners = entryListenersByThread.get(entryId) ?? new Set<() => void>();
+  entryListeners.add(listener);
+  entryListenersByThread.set(entryId, entryListeners);
+  threadEntryListeners.set(threadId, entryListenersByThread);
+  return () => {
+    const currentEntryListenersByThread = threadEntryListeners.get(threadId);
+    const currentEntryListeners = currentEntryListenersByThread?.get(entryId);
+    if (!currentEntryListenersByThread || !currentEntryListeners) {
+      return;
+    }
+    currentEntryListeners.delete(listener);
+    if (currentEntryListeners.size === 0) {
+      currentEntryListenersByThread.delete(entryId);
+    }
+    if (currentEntryListenersByThread.size === 0) {
+      threadEntryListeners.delete(threadId);
+    }
+  };
 }

--- a/desktop/src/renderer/state/session/session-stream.ts
+++ b/desktop/src/renderer/state/session/session-stream.ts
@@ -17,6 +17,14 @@ import { createThreadDeltaBuffer } from "./session-stream-buffer.js";
 
 export { type ThreadDeltaBuffer } from "./session-stream-buffer.js";
 
+function summarizeDeltaKinds(deltas: DesktopThreadDelta[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const delta of deltas) {
+    counts[delta.kind] = (counts[delta.kind] ?? 0) + 1;
+  }
+  return counts;
+}
+
 export function installSessionStream(
   deps: {
     selectedProfileId: string;
@@ -45,21 +53,31 @@ export function installSessionStream(
   }
 
   function applyDelta(delta: DesktopThreadDelta) {
-    perfMeasure("session-stream.apply-delta", () => {
-      applyThreadDelta(delta, {
-        appendStreamingEntryBody,
-        cachePendingThreadDelta,
-        clearStreamingEntryBody,
-        clearStreamingThreadBodies,
-        flushPendingThreadDeltas,
-        rememberKnownThreadIds,
-        seedStreamingThreadBodies,
-        setActiveTurnIdsByThread: deps.setActiveTurnIdsByThread,
-        setPerThreadSidebar: deps.setPerThreadSidebar,
-        setThreads: deps.setThreads,
-        threadDeltaBufferRef,
-      });
-    });
+    perfMeasure(
+      "session-stream.apply-delta",
+      () => {
+        applyThreadDelta(delta, {
+          appendStreamingEntryBody,
+          cachePendingThreadDelta,
+          clearStreamingEntryBody,
+          clearStreamingThreadBodies,
+          flushPendingThreadDeltas,
+          rememberKnownThreadIds,
+          seedStreamingThreadBodies,
+          setActiveTurnIdsByThread: deps.setActiveTurnIdsByThread,
+          setPerThreadSidebar: deps.setPerThreadSidebar,
+          setThreads: deps.setThreads,
+          threadDeltaBufferRef,
+        });
+      },
+      {
+        logThresholdMs: 16,
+        details: () => ({
+          deltaKind: delta.kind,
+          threadId: delta.threadId,
+        }),
+      },
+    );
   }
 
   function flushQueuedDeltas() {
@@ -78,10 +96,25 @@ export function installSessionStream(
 
     const queuedDeltas = queuedDeltasRef.current;
     queuedDeltasRef.current = [];
+    const coalescedDeltas = coalesceThreadDeltas(queuedDeltas);
 
-    for (const delta of coalesceThreadDeltas(queuedDeltas)) {
-      applyDelta(delta);
-    }
+    perfMeasure(
+      "session-stream.flush",
+      () => {
+        for (const delta of coalescedDeltas) {
+          applyDelta(delta);
+        }
+      },
+      {
+        logThresholdMs: 24,
+        details: () => ({
+          coalescedKinds: summarizeDeltaKinds(coalescedDeltas),
+          coalescedCount: coalescedDeltas.length,
+          queuedCount: queuedDeltas.length,
+          queuedKinds: summarizeDeltaKinds(queuedDeltas),
+        }),
+      },
+    );
   }
 
   function scheduleQueuedDeltaFlush() {
@@ -110,10 +143,19 @@ export function installSessionStream(
   }
 
   useEffect(() => {
-    perfMeasure("session-stream.known-thread-sync", () => {
-      perfCount("session-stream.known-thread-sync.calls");
-      threadDeltaBufferRef.current.setKnownThreadIds(deps.threads.map((thread) => thread.id));
-    });
+    perfMeasure(
+      "session-stream.known-thread-sync",
+      () => {
+        perfCount("session-stream.known-thread-sync.calls");
+        threadDeltaBufferRef.current.setKnownThreadIds(deps.threads.map((thread) => thread.id));
+      },
+      {
+        logThresholdMs: 16,
+        details: () => ({
+          threadCount: deps.threads.length,
+        }),
+      },
+    );
   }, [deps.threads]);
 
   useEffect(() => {

--- a/desktop/src/renderer/state/threads/thread-summary-state.ts
+++ b/desktop/src/renderer/state/threads/thread-summary-state.ts
@@ -1,17 +1,27 @@
 import type { DesktopBootstrap, DesktopThreadSummary } from "../../../main/contracts";
 import { buildChangeGroups, buildProgressSummary, normalizeDesktopSummary } from "../../lib/live-thread-data.js";
+import { perfMeasure } from "../../lib/perf-debug.ts";
 import { folderDisplayName } from "../session/session-selectors.js";
 import { type FolderOption, type ThreadRecord } from "../session/session-types.js";
 
 function sortThreads(threads: ThreadRecord[]): ThreadRecord[] {
-  return [...threads].sort((left, right) => {
-    const updatedDelta = Date.parse(right.updatedAt) - Date.parse(left.updatedAt);
-    if (!Number.isNaN(updatedDelta) && updatedDelta !== 0) {
-      return updatedDelta;
-    }
+  return perfMeasure(
+    "thread-summary.sort",
+    () => [...threads].sort((left, right) => {
+      const updatedDelta = Date.parse(right.updatedAt) - Date.parse(left.updatedAt);
+      if (!Number.isNaN(updatedDelta) && updatedDelta !== 0) {
+        return updatedDelta;
+      }
 
-    return left.title.localeCompare(right.title);
-  });
+      return left.title.localeCompare(right.title);
+    }),
+    {
+      logThresholdMs: 12,
+      details: () => ({
+        threadCount: threads.length,
+      }),
+    },
+  );
 }
 
 function preserveRunningState(existing: ThreadRecord | undefined, nextState: ThreadRecord["state"]): ThreadRecord["state"] {
@@ -94,20 +104,43 @@ export function mergeThreadDetails(existing: ThreadRecord | undefined, incoming:
 }
 
 function upsertThread(current: ThreadRecord[], nextThread: ThreadRecord): ThreadRecord[] {
-  return sortThreads([nextThread, ...current.filter((thread) => thread.id !== nextThread.id)]);
+  return perfMeasure(
+    "thread-summary.upsert",
+    () => sortThreads([nextThread, ...current.filter((thread) => thread.id !== nextThread.id)]),
+    {
+      logThresholdMs: 20,
+      details: () => ({
+        currentCount: current.length,
+        nextThreadId: nextThread.id,
+        nextUpdatedAt: nextThread.updatedAt,
+      }),
+    },
+  );
 }
 
 function mergeThreadSummaries(current: ThreadRecord[], summaries: ThreadRecord[]): ThreadRecord[] {
-  const currentById = new Map(current.map((thread) => [thread.id, thread]));
-  const summaryIds = new Set(summaries.map((summary) => summary.id));
+  return perfMeasure(
+    "thread-summary.merge-summaries",
+    () => {
+      const currentById = new Map(current.map((thread) => [thread.id, thread]));
+      const summaryIds = new Set(summaries.map((summary) => summary.id));
 
-  return sortThreads([
-    ...summaries.map((summary) => {
-      const existing = currentById.get(summary.id);
-      return createThreadRecord(summary, existing);
-    }),
-    ...current.filter((thread) => !summaryIds.has(thread.id)),
-  ]);
+      return sortThreads([
+        ...summaries.map((summary) => {
+          const existing = currentById.get(summary.id);
+          return createThreadRecord(summary, existing);
+        }),
+        ...current.filter((thread) => !summaryIds.has(thread.id)),
+      ]);
+    },
+    {
+      logThresholdMs: 20,
+      details: () => ({
+        currentCount: current.length,
+        summaryCount: summaries.length,
+      }),
+    },
+  );
 }
 
 export function reconcileThreadSummariesWithBootstrap(
@@ -119,9 +152,22 @@ export function reconcileThreadSummariesWithBootstrap(
     return mergeThreadSummaries(current, summaries);
   }
 
-  const currentById = new Map(current.map((thread) => [thread.id, thread]));
-  return sortThreads(
-    summaries.map((summary) => createThreadRecord(summary, currentById.get(summary.id))),
+  return perfMeasure(
+    "thread-summary.reconcile-bootstrap",
+    () => {
+      const currentById = new Map(current.map((thread) => [thread.id, thread]));
+      return sortThreads(
+        summaries.map((summary) => createThreadRecord(summary, currentById.get(summary.id))),
+      );
+    },
+    {
+      logThresholdMs: 24,
+      details: () => ({
+        currentCount: current.length,
+        pruneMissing: true,
+        summaryCount: summaries.length,
+      }),
+    },
   );
 }
 

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -258,6 +258,32 @@ body {
   margin-top: 0.4rem;
 }
 
+.thread-markdown-plain-preview {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.thread-markdown-virtualized > p,
+.thread-markdown-virtualized > pre,
+.thread-markdown-virtualized > blockquote,
+.thread-markdown-virtualized > table,
+.thread-markdown-virtualized > ul > li,
+.thread-markdown-virtualized > ol > li {
+  content-visibility: auto;
+}
+
+.thread-markdown-virtualized > p,
+.thread-markdown-virtualized > ul > li,
+.thread-markdown-virtualized > ol > li,
+.thread-markdown-virtualized > blockquote {
+  contain-intrinsic-size: auto 1.75rem;
+}
+
+.thread-markdown-virtualized > pre,
+.thread-markdown-virtualized > table {
+  contain-intrinsic-size: auto 12rem;
+}
+
 .thread-markdown ul,
 .thread-markdown ol {
   margin: 0.35rem 0;

--- a/desktop/src/renderer/thread-markdown.tsx
+++ b/desktop/src/renderer/thread-markdown.tsx
@@ -1,11 +1,13 @@
-import { Children, isValidElement, memo, useCallback, useState, type ComponentProps, type ReactNode } from "react";
+import { Children, isValidElement, memo, Profiler, startTransition, useCallback, useEffect, useMemo, useState, type ComponentProps, type ReactNode } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
 import { cn } from "./lib/cn";
 import { getFileIcon, getFileLabel as getFileTypeLabel } from "./lib/file-icons";
 import { isExternalUrl, isFilePath } from "./lib/link-targets.ts";
+import { tracePerfEvent } from "./lib/perf-debug.ts";
 import { extractStandaloneArtifactTarget, resolveArtifactPath } from "./lib/thread-artifacts";
+import { hasFencedCodeBlocks, shouldDeferRichMarkdown, shouldUseVirtualizedMarkdown } from "./lib/thread-markdown-performance.ts";
 
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
@@ -183,93 +185,165 @@ type ThreadMarkdownProps = {
 };
 
 function ThreadMarkdownInner({ children, className, workspaceRoot = null }: ThreadMarkdownProps) {
-  if (!children?.trim()) {
+  const markdownSource = children ?? "";
+  const hasVisibleContent = markdownSource.trim().length > 0;
+  const enableSyntaxHighlighting = hasVisibleContent && hasFencedCodeBlocks(markdownSource);
+  const useVirtualizedMarkdown = hasVisibleContent && shouldUseVirtualizedMarkdown(markdownSource);
+  const deferRichMarkdown = hasVisibleContent && !enableSyntaxHighlighting && shouldDeferRichMarkdown(markdownSource);
+  const [richMarkdownRequested, setRichMarkdownRequested] = useState(!deferRichMarkdown);
+  const resolvedClassName = cn(
+    "thread-markdown",
+    useVirtualizedMarkdown && "thread-markdown-virtualized",
+    className,
+  );
+
+  useEffect(() => {
+    setRichMarkdownRequested(!deferRichMarkdown);
+  }, [deferRichMarkdown, markdownSource]);
+
+  useEffect(() => {
+    if (!deferRichMarkdown || richMarkdownRequested) {
+      return;
+    }
+
+    const promoteTimeout = window.setTimeout(() => {
+      startTransition(() => {
+        setRichMarkdownRequested(true);
+      });
+    }, 120);
+
+    return () => {
+      window.clearTimeout(promoteTimeout);
+    };
+  }, [deferRichMarkdown, markdownSource, richMarkdownRequested]);
+
+  const markdownComponents = useMemo<NonNullable<ComponentProps<typeof Markdown>["components"]>>(() => ({
+    pre({ children: preChildren, ...rest }: ComponentProps<"pre">) {
+      const codeText = extractCodeText(preChildren);
+      const language = extractLanguage(preChildren);
+      if (!language && codeText) {
+        const artifactTarget = extractStandaloneArtifactTarget(codeText.trim());
+        if (artifactTarget && resolveArtifactPath(artifactTarget, workspaceRoot)) {
+          return <ArtifactLinkCard href={artifactTarget} workspaceRoot={workspaceRoot}>{getFileName(artifactTarget)}</ArtifactLinkCard>;
+        }
+      }
+      return (
+        <div className="group relative overflow-hidden rounded bg-canvas">
+          <pre className="px-3 py-2.5 text-[0.75rem] leading-[1.5]" {...(rest as ComponentProps<"pre">)}>{preChildren}</pre>
+          <div className="absolute right-1.5 top-1.5 flex items-center gap-1.5 opacity-0 transition-opacity group-hover:opacity-100">
+            {language ? (
+              <span className="rounded bg-surface-soft px-1.5 py-0.5 text-[0.6rem] font-medium uppercase tracking-wider text-ink-muted">{language}</span>
+            ) : null}
+            {codeText ? <CopyButton text={codeText} /> : null}
+          </div>
+        </div>
+      );
+    },
+    table({ children: tableChildren, ...rest }: ComponentProps<"table">) {
+      return (
+        <div className="overflow-x-auto">
+          <table {...(rest as ComponentProps<"table">)}>{tableChildren}</table>
+        </div>
+      );
+    },
+    p({ children: pChildren, ...rest }: ComponentProps<"p">) {
+      const artifactTarget = extractParagraphArtifactTarget(pChildren);
+      if (artifactTarget && resolveArtifactPath(artifactTarget, workspaceRoot)) {
+        return (
+          <ArtifactLinkCard href={artifactTarget} workspaceRoot={workspaceRoot}>
+            {getFileName(artifactTarget)}
+          </ArtifactLinkCard>
+        );
+      }
+      return <p {...(rest as ComponentProps<"p">)}>{pChildren}</p>;
+    },
+    code({ children: codeChildren, className: codeClassName, ...rest }: ComponentProps<"code">) {
+      if (codeClassName?.includes("language-") || codeClassName?.includes("hljs")) {
+        return <code className={codeClassName} {...(rest as ComponentProps<"code">)}>{codeChildren}</code>;
+      }
+      return <code {...(rest as ComponentProps<"code">)}>{codeChildren}</code>;
+    },
+    a({ href, children: linkChildren, ...rest }: ComponentProps<"a">) {
+      const resolvedHref = href || "";
+      if (isFilePath(resolvedHref) && resolveArtifactPath(resolvedHref, workspaceRoot)) {
+        return <ArtifactLinkCard href={resolvedHref} workspaceRoot={workspaceRoot}>{linkChildren}</ArtifactLinkCard>;
+      }
+      return (
+        <a
+          href={resolvedHref}
+          onClick={(event) => {
+            if (!isExternalUrl(resolvedHref)) {
+              return;
+            }
+            event.preventDefault();
+            const bridge = (window as unknown as {
+              sense1Desktop?: {
+                window?: { openExternalUrl?: (url: string) => Promise<unknown> };
+              };
+            }).sense1Desktop;
+            if (bridge?.window?.openExternalUrl) {
+              void bridge.window.openExternalUrl(resolvedHref);
+            }
+          }}
+          {...(rest as ComponentProps<"a">)}
+        >
+          {linkChildren}
+        </a>
+      );
+    },
+  }), [workspaceRoot]);
+
+  if (!hasVisibleContent) {
     return <div className={cn("thread-markdown", className)} />;
   }
 
+  const markdown = (
+    <Markdown
+      components={markdownComponents}
+      rehypePlugins={enableSyntaxHighlighting ? rehypePlugins : undefined}
+      remarkPlugins={remarkPlugins}
+    >
+      {markdownSource}
+    </Markdown>
+  );
+
+  if (deferRichMarkdown && !richMarkdownRequested) {
+    return (
+      <div className={resolvedClassName}>
+        <div className="thread-markdown-plain-preview">
+          {children}
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className={cn("thread-markdown", className)}>
-      <Markdown
-        components={{
-          pre({ children: preChildren, ...rest }) {
-            const codeText = extractCodeText(preChildren);
-            const language = extractLanguage(preChildren);
-            if (!language && codeText) {
-              const artifactTarget = extractStandaloneArtifactTarget(codeText.trim());
-              if (artifactTarget && resolveArtifactPath(artifactTarget, workspaceRoot)) {
-                return <ArtifactLinkCard href={artifactTarget} workspaceRoot={workspaceRoot}>{getFileName(artifactTarget)}</ArtifactLinkCard>;
-              }
+    <div className={resolvedClassName}>
+      {useVirtualizedMarkdown ? (
+        <Profiler
+          id="ThreadMarkdown.large"
+          onRender={(_id, phase, actualDuration, baseDuration) => {
+            if (actualDuration < 24) {
+              return;
             }
-            return (
-              <div className="group relative overflow-hidden rounded bg-canvas">
-                <pre className="px-3 py-2.5 text-[0.75rem] leading-[1.5]" {...(rest as ComponentProps<"pre">)}>{preChildren}</pre>
-                <div className="absolute right-1.5 top-1.5 flex items-center gap-1.5 opacity-0 transition-opacity group-hover:opacity-100">
-                  {language ? (
-                    <span className="rounded bg-surface-soft px-1.5 py-0.5 text-[0.6rem] font-medium uppercase tracking-wider text-ink-muted">{language}</span>
-                  ) : null}
-                  {codeText ? <CopyButton text={codeText} /> : null}
-                </div>
-              </div>
-            );
-          },
-          table({ children: tableChildren, ...rest }) {
-            return (
-              <div className="overflow-x-auto">
-                <table {...(rest as ComponentProps<"table">)}>{tableChildren}</table>
-              </div>
-            );
-          },
-          p({ children: pChildren, ...rest }) {
-            const artifactTarget = extractParagraphArtifactTarget(pChildren);
-            if (artifactTarget && resolveArtifactPath(artifactTarget, workspaceRoot)) {
-              return (
-                <ArtifactLinkCard href={artifactTarget} workspaceRoot={workspaceRoot}>
-                  {getFileName(artifactTarget)}
-                </ArtifactLinkCard>
-              );
-            }
-            return <p {...(rest as ComponentProps<"p">)}>{pChildren}</p>;
-          },
-          code({ children: codeChildren, className: codeClassName, ...rest }) {
-            if (codeClassName?.includes("language-") || codeClassName?.includes("hljs")) {
-              return <code className={codeClassName} {...(rest as ComponentProps<"code">)}>{codeChildren}</code>;
-            }
-            return <code {...(rest as ComponentProps<"code">)}>{codeChildren}</code>;
-          },
-          a({ href, children: linkChildren, ...rest }) {
-            const resolvedHref = href || "";
-            if (isFilePath(resolvedHref) && resolveArtifactPath(resolvedHref, workspaceRoot)) {
-              return <ArtifactLinkCard href={resolvedHref} workspaceRoot={workspaceRoot}>{linkChildren}</ArtifactLinkCard>;
-            }
-            return (
-              <a
-                href={resolvedHref}
-                onClick={(event) => {
-                  if (!isExternalUrl(resolvedHref)) {
-                    return;
-                  }
-                  event.preventDefault();
-                  const bridge = (window as unknown as {
-                    sense1Desktop?: {
-                      window?: { openExternalUrl?: (url: string) => Promise<unknown> };
-                    };
-                  }).sense1Desktop;
-                  if (bridge?.window?.openExternalUrl) {
-                    void bridge.window.openExternalUrl(resolvedHref);
-                  }
-                }}
-                {...(rest as ComponentProps<"a">)}
-              >
-                {linkChildren}
-              </a>
-            );
-          },
-        }}
-        rehypePlugins={rehypePlugins}
-        remarkPlugins={remarkPlugins}
-      >
-        {children}
-      </Markdown>
+
+            tracePerfEvent("react-render", {
+              actualDurationMs: Number(actualDuration.toFixed(2)),
+              baseDurationMs: Number(baseDuration.toFixed(2)),
+              hasFencedCodeBlocks: enableSyntaxHighlighting,
+              phase,
+              textLength: markdownSource.length,
+              virtualized: useVirtualizedMarkdown,
+            }, {
+              level: "warn",
+              minIntervalMs: 1000,
+              throttleKey: `ThreadMarkdown.large:${phase}:${markdownSource.length}`,
+            });
+          }}
+        >
+          {markdown}
+        </Profiler>
+      ) : markdown}
     </div>
   );
 }

--- a/desktop/src/renderer/use-desktop-session-state.ts
+++ b/desktop/src/renderer/use-desktop-session-state.ts
@@ -293,7 +293,17 @@ export function useDesktopSessionState({
     selectedThreadId,
     taskPending,
     threads,
-  })), [
+  }), {
+    logThresholdMs: 24,
+    details: () => ({
+      activeTurnThreadCount: Object.keys(activeTurnIdsByThread).length,
+      pendingApprovalCount: pendingApprovals.length,
+      selectedThreadId,
+      sidebarThreadCount: Object.keys(perThreadSidebar).length,
+      taskPending,
+      threadCount: threads.length,
+    }),
+  }), [
     activeTurnIdsByThread,
     pendingApprovals,
     perThreadSidebar,

--- a/desktop/src/shared/contracts/settings.ts
+++ b/desktop/src/shared/contracts/settings.ts
@@ -1,4 +1,4 @@
-export type DesktopVerbosity = "terse" | "balanced" | "detailed";
+export type DesktopVerbosity = "low" | "medium" | "high";
 
 export interface DesktopSettings {
   readonly model: string;


### PR DESCRIPTION
## Summary
- reduce long-thread lag by coalescing streaming transcript updates and cutting expensive rerenders in the transcript, sidebar, and right rail
- rename the runtime instructions setting to Custom Instructions and keep it additive to the built-in product prompt
- align desktop verbosity settings with Codex terminology using `low` / `medium` / `high` while preserving compatibility with older saved aliases

## Validation
- `pnpm -C desktop install --frozen-lockfile`
- `node scripts/check-public-boundary.mjs` locally reports false positives from machine-only top-level folders (`.agent`, `.claude`, `.omx`, local `docs`) that are not present in `HEAD`; upstream `main` CI is green with the same script
- `pnpm -C desktop typecheck`
- `pnpm -C desktop test:unit`
- `pnpm -C desktop check:structure`
- `pnpm -C desktop build`
